### PR TITLE
Create OBDD wrapper class

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,6 +23,10 @@ clean:
 test: | build-test
 	@rm -rf *.tpie
 	@./build/test/test_unit --reporter=info --colorizer=light
+	@echo "begin: Persistency"
+	@echo test -f coom_obdd_test.pie && echo "[ PASS ] should not persist obdd_test_1" || echo "[ FAIL ] should not persist obdd_test_1"
+	@echo test -f coom_obdd_test.pie && echo "[ FAIL ] should not persist obdd_test_2" || echo "[ PASS ] should not persist obdd_test_2"
+	@echo "end: Persistency"
 	@rm -rf *.tpie
 
 # ============================================================================ #

--- a/src/coom/obdd.cpp
+++ b/src/coom/obdd.cpp
@@ -1,0 +1,77 @@
+#ifndef COOM_OBDD_CPP
+#define COOM_OBDD_CPP
+
+#include <stdint.h>
+#include <stdio.h>
+#include <tpie/tpie.h>
+
+#include "data.h"
+#include "obdd.h"
+
+namespace coom {
+  // Member functions in OBDD
+  bool OBDD::is_sink()
+  {
+    return false;
+  }
+
+  bool OBDD::has_nodes()
+  {
+    return false;
+  }
+
+  uint64_t OBDD::as_sink()
+  {
+    throw "Cannot cast to sink-only OBDD";
+  }
+
+  OBDD_node OBDD::as_node()
+  {
+    throw "Cannot cast to node-based OBDD";
+  }
+
+  // Member functions in OBDD_sink
+  bool OBDD_sink::is_sink()
+  {
+    return true;
+  }
+
+  uint64_t OBDD_sink::as_sink()
+  {
+    return this->data;
+  }
+
+
+  // Member functions in OBDD_node
+  bool OBDD_node::has_nodes()
+  {
+    return true;
+  }
+
+  OBDD_node OBDD_node::as_node()
+  {
+    return *this;
+  }
+
+  tpie::file_stream<node> OBDD_node::open_filestream()
+  {
+    tpie::file_stream<node> xs;
+    xs.open(this->temp_file, tpie::open::compression_normal);
+    return xs;
+  }
+
+  // Constructors
+  OBDD_sink::OBDD_sink(bool value)
+  {
+    data = create_sink(value);
+  }
+
+  OBDD_node::OBDD_node(const std::string & path, bool persist = false)
+  {
+    negated = false;
+    tpie::temp_file tf(path, persist);
+    temp_file = tf;
+  }
+}
+
+#endif // COOM_OBDD_CPP

--- a/src/coom/obdd.h
+++ b/src/coom/obdd.h
@@ -1,0 +1,54 @@
+#ifndef COOM_OBDD_H
+#define COOM_OBDD_H
+
+#include <stdint.h>
+#include <tpie/tpie.h>
+
+#include "data.h"
+
+namespace coom {
+  class OBDD_sink;
+  class OBDD_node;
+
+  class OBDD
+  {
+  public:
+    virtual bool is_sink();
+    virtual bool has_nodes();
+
+    virtual uint64_t as_sink();
+    virtual OBDD_node as_node();
+
+    static tpie::file_stream<node> open_filestream(const char * filename);
+  };
+
+  class OBDD_sink : public OBDD
+  {
+  private:
+    uint64_t data;
+
+  public:
+    OBDD_sink(bool value);
+
+    bool is_sink();
+    uint64_t as_sink();
+  };
+
+  class OBDD_node : public OBDD
+  {
+  private:
+    tpie::temp_file temp_file;
+
+  public:
+    bool negated;
+
+    OBDD_node(const std::string & path, bool persist);
+
+    bool has_nodes();
+    OBDD_node as_node();
+
+    tpie::file_stream<node> open_filestream();
+  };
+}
+
+#endif // COOM_OBDD_H

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -8,6 +8,7 @@ using namespace bandit;
 
 #include "test_coom_data.cpp"
 //#include "test_coom_evaluate.cpp"
+#include "test_coom_obdd.cpp"
 //#include "test_coom_reduce.cpp"
 //#include "test_coom_restrict.cpp"
 //#include "test_coom_apply.cpp"

--- a/test/test_coom_obdd.cpp
+++ b/test/test_coom_obdd.cpp
@@ -1,0 +1,104 @@
+#include <coom/data.cpp>
+#include <coom/obdd.cpp>
+
+using namespace coom;
+
+go_bandit([]() {
+    describe("COOM: OBDD", []() {
+
+        describe("Sink-only OBDD", [&](){
+            OBDD_sink obdd_F(false);
+            OBDD_sink obdd_T(true);
+
+            it("should claim to be sink-only", [&obdd_F, &obdd_T]() {
+                AssertThat(obdd_F.is_sink(), Is().True());
+                AssertThat(obdd_T.is_sink(), Is().True());
+              });
+
+            it("should not claim to be node-based", [&obdd_F, &obdd_T]() {
+                AssertThat(obdd_F.has_nodes(), Is().False());
+                AssertThat(obdd_T.has_nodes(), Is().False());
+              });
+
+            it("should be castable to sink-only", [&obdd_F, &obdd_T]() {
+                auto obdd_F_as_sink = obdd_F.as_sink();
+                AssertThat(value_of(obdd_F_as_sink), Is().False());
+
+                auto obdd_T_as_sink = obdd_T.as_sink();
+                AssertThat(value_of(obdd_T_as_sink), Is().True());
+              });
+          });
+
+        describe("unpersisted OBDD with nodes", [&](){
+            // Create a small realistic OBDD
+            auto obdd_filename = "coom_obdd_test_1.tpie";
+            OBDD_node obdd(obdd_filename);
+            auto obdd_nodes = obdd.open_filestream();
+
+            obdd_nodes.write(create_node(2, MAX_ID, create_sink(false), create_sink(true)));
+            obdd_nodes.write(create_node(1, MAX_ID, create_node_ptr(2,MAX_ID), create_sink(true)));
+            obdd_nodes.write(create_node(0, MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID)));
+
+            obdd_nodes.close();
+
+            it("should not claim to be sink-only", [&obdd]() {
+                AssertThat(obdd.is_sink(), Is().False());
+                AssertThat(obdd.is_sink(), Is().False());
+              });
+
+            it("should not claim to be node-based", [&obdd]() {
+                AssertThat(obdd.has_nodes(), Is().True());
+                AssertThat(obdd.has_nodes(), Is().True());
+              });
+
+            it("should be castable to a nodes OBDD", [&obdd]() {
+                auto obdd_casted = obdd.as_node();
+                AssertThat(obdd.negated, Is().False());
+
+                auto obdd_nodes = obdd_casted.open_filestream();
+
+                AssertThat(obdd_nodes.can_read(), Is().True());
+
+                AssertThat(obdd_nodes.read(), Is().EqualTo(create_node(2, MAX_ID, create_sink(false), create_sink(true))));
+                AssertThat(obdd_nodes.can_read(), Is().True());
+
+                AssertThat(obdd_nodes.read(), Is().EqualTo(create_node(1, MAX_ID, create_node_ptr(2,MAX_ID), create_sink(true))));
+                AssertThat(obdd_nodes.can_read(), Is().True());
+
+                AssertThat(obdd_nodes.read(), Is().EqualTo(create_node(0, MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID))));
+                AssertThat(obdd_nodes.can_read(), Is().False());
+              });
+          });
+
+        describe("persisted OBDD with nodes", [&](){
+            // Create a small realistic OBDD
+            auto obdd_filename = "coom_obdd_test_2.tpie";
+            OBDD_node obdd(obdd_filename, true);
+            auto obdd_nodes = obdd.open_filestream();
+
+            obdd_nodes.write(create_node(2, MAX_ID, create_sink(false), create_sink(true)));
+            obdd_nodes.write(create_node(1, MAX_ID, create_node_ptr(2,MAX_ID), create_sink(true)));
+            obdd_nodes.write(create_node(0, MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID)));
+
+            obdd_nodes.close();
+
+            it("should be castable and readable", [&obdd]() {
+                auto obdd_casted = obdd.as_node();
+                AssertThat(obdd.negated, Is().False());
+
+                auto obdd_nodes = obdd_casted.open_filestream();
+
+                AssertThat(obdd_nodes.can_read(), Is().True());
+
+                AssertThat(obdd_nodes.read(), Is().EqualTo(create_node(2, MAX_ID, create_sink(false), create_sink(true))));
+                AssertThat(obdd_nodes.can_read(), Is().True());
+
+                AssertThat(obdd_nodes.read(), Is().EqualTo(create_node(1, MAX_ID, create_node_ptr(2,MAX_ID), create_sink(true))));
+                AssertThat(obdd_nodes.can_read(), Is().True());
+
+                AssertThat(obdd_nodes.read(), Is().EqualTo(create_node(0, MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID))));
+                AssertThat(obdd_nodes.can_read(), Is().False());
+              });
+          });
+      });
+  });


### PR DESCRIPTION
This way one can easier carry extra information such as negation,
is able to control persistency, and able to deal with the edge-case
of a sink-only OBDD