### PR TITLE
Fix edge styling is swapped compared to litterature (closes #22)

### DIFF
--- a/src/coom/dot.cpp
+++ b/src/coom/dot.cpp
@@ -63,11 +63,11 @@ namespace coom {
             out << "\tn" << node.node_ptr
                 << " -> "
                 << "n" << node.low
-                << " [style=solid];" << std::endl;
+                << " [style=dashed];" << std::endl;
             out << "\tn" << node.node_ptr
                 << " -> "
                 << "n" << node.high
-                << "[style=dashed];"  << std::endl;
+                << "[style=solid];"  << std::endl;
           }
       }
     out << "}" << std::endl;
@@ -95,7 +95,7 @@ namespace coom {
             << "n" << label_of(a.target) << "_" << id_of(a.target)
             << " -> "
             << "n" << label_of(a.source) << "_" << id_of(a.source)
-            << " [style=" << (a.is_high ? "dashed" : "solid") << ", color=blue];"
+            << " [style=" << (a.is_high ? "solid" : "dashed") << ", color=blue];"
             << std::endl;
       }
 
@@ -112,7 +112,7 @@ namespace coom {
             << "n" << label_of(a.source) << "_" << id_of(a.source)
             << " -> "
             << "s" << value_of(a.target)
-            << " [style=" << (a.is_high ? "dashed" : "solid") << ", color=red];"
+            << " [style=" << (a.is_high ? "solid" : "dashed") << ", color=red];"
             << std::endl;
           }
 


### PR DESCRIPTION
DOT output of `filestream<node>` fixed from #12 

![dot_test tpie](https://user-images.githubusercontent.com/14313096/88033657-ea26a200-cb3f-11ea-9dee-ea2db3ed94ff.png)

DOT output of `filestream<arc>` fixed from #18 

![dot_test_arcs](https://user-images.githubusercontent.com/14313096/88033756-06c2da00-cb40-11ea-8564-48722c697b60.png)

