### PR TITLE
Add Tic-Tac-Toe example from Kunkle

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -48,3 +48,24 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: ./example/n_queens 8
 
+  tic_tac_toe:
+    name: 'Tic-Tac-Toe'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Apt | install boost aptitude
+      run: sudo apt install libboost-all-dev aptitude
+    - name: CMake | build
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build
+        cd ${{runner.workspace}}/build
+        cmake $GITHUB_WORKSPACE && cmake --build . --target tic_tac_toe
+    - name: Makefile | Tic-Tac-Toe (18)
+      working-directory: ${{runner.workspace}}/build
+      run: ./example/tic_tac_toe 18
+    - name: Makefile | Tic-Tac-Toe (20)
+      working-directory: ${{runner.workspace}}/build
+      run: ./example/tic_tac_toe 20

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![MIT License](https://img.shields.io/badge/license-MIT%20License-blue.svg)](LICENSE.md)
 [![Built with TPIE](https://img.shields.io/badge/built%20with-TPIE-blue)](https://users-cs.au.dk/~rav/tpie/)
 [![test](https://github.com/SSoelvsten/cache-oblivious-obdd/workflows/test/badge.svg?branch=master)](/actions?query=workflow%3Atest)
-[![docs](https://github.com/SSoelvsten/cache-oblivious-obdd/workflows/docs/badge.svg?branch=master)](/actions?query=workflow%3Adocst)
+[![examples](https://github.com/SSoelvsten/cache-oblivious-obdd/workflows/examples/badge.svg?branch=master)](/actions?query=workflow%3Aexamples)
+[![docs](https://github.com/SSoelvsten/cache-oblivious-obdd/workflows/docs/badge.svg?branch=master)](/actions?query=workflow%3Adocs)
 
 Following up on the work of [[Arge96](#references)], this project investigates
 the use of _Time-Forward Processing_ to improve the I/O complexity and
@@ -117,11 +118,14 @@ For development and more we also provide the following targets
 
 ### Examples and benchmarks
 The _/examples_ folder contains examples for using the data structure to solve
-various verification and satisfaction problems.
+various verification and satisfaction problems. The `main` function also also
+includes timing how long it takes to solve and computing other interesting
+statistics.
 
-| target                   | Example                                                     |
-|--------------------------|-------------------------------------------------------------|
-| `example-n-queens N=<?>` | N-Queens board creation, counting and enumerating solutions |
+| target                      | Example                                                           |
+|-----------------------------|-------------------------------------------------------------------|
+| `example-n-queens N=<?>`    | N-Queens board creation, counting and enumerating solutions       |
+| `example-tic-tac-toe N=<?>` | Counting the number of ties on a 3D 4✕4✕4 with _N_ crosses placed |
 
 
 ### In your own project
@@ -216,6 +220,11 @@ The software and documentation files in this repository are provided under the
   Timothy Kam, Tiziano Villa, Robert K. Brayton, and L. Sangiovanni-vincentelli
   Alberto. “_Multi-valued decision diagrams: Theory and applications_”. In:
   _Multiple- Valued Logic 4.1_ 1998
+
+- [[Kunkle10](https://dl.acm.org/doi/abs/10.1145/1837210.1837222)] Daniel
+  Kunkle, Vlad Slavici, Gene Cooperman. “_Parallel Disk-Based Computation for
+  Large, Monolithic Binary Decision Diagrams_”. In: _ PASCO '10: Proceedings of
+  the 4th International Workshop on Parallel and Symbolic Computation_. 2010
 
 - [Meinel94]
   J. Gergov and C. Meinel. “_Efficient analysis and manipulation of OBDDs can

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,3 +4,10 @@ add_executable (n_queens n_queens.cpp)
 
 target_link_libraries(n_queens coom)
 target_link_libraries(n_queens tpie)
+
+# ============================================================================ #
+# Tic-Tac-Toe example
+add_executable (tic_tac_toe tic_tac_toe.cpp)
+
+target_link_libraries(tic_tac_toe coom)
+target_link_libraries(tic_tac_toe tpie)

--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,6 @@
-# Examples ![examples](https://github.com/SSoelvsten/cache-oblivious-obdd/workflows/examples/badge.svg?branch=master)
+# Examples
+![examples](https://github.com/SSoelvsten/cache-oblivious-obdd/workflows/examples/badge.svg?branch=master)
+
 To benchmark the implementation and also to provide examples of how to use
 _COOM_ in your project, we provide multiple examples.
 
@@ -10,6 +12,8 @@ TPIE managing all the files underneath.
 
 - [Examples](#examples)
     - [N-Queens](#n-queens)
+    - [Tic-Tac-Toe](#tic-tac-toe)
+    - [References](#references)
 
 <!-- markdown-toc end -->
 
@@ -20,18 +24,39 @@ TPIE managing all the files underneath.
 **Target:** `make example-n-queens N=<?>`
 
 Solve the N-Queens problem for _N = `?`_ (default: `8`). This is done by
-constructing an OBDD row-by-row that represents whether the row is a legal
-state: is at least one queen placed on each row and it is also in no conflicts
+constructing an OBDD row-by-row that represents whether the row is in a legal
+state: is at least one queen placed on each row and is it also in no conflicts
 with any other? On this OBDD we then counts the number of satisfying
-assignments.
+assignments [[kunkle10](#references)].
 
-To list the solutions, we take the same OBDD, but instead of count the number of
-assignments within, we use it to prune a recursive enumeration of all possible
-queen placements. For up to _N = 8_ we run both the solution counting procedure
-and the enumeration procedure.
+To list the solutions, we take the same OBDD, but instead of counting the number
+of assignments within, we use it to prune a recursive enumeration of all
+possible queen placements. For up to _N = 8_ we run both the solution counting
+procedure and the enumeration procedure.
 
 **Notice**: This is a pretty simple example and has all of the normal
 shortcomings for OBDDs trying to solve the N-Queens problem. At around _N_ = 14
 the intermediate sizes explodes a lot. One can with about 100 GB of disk space
-or memory compute it, but for a better solution, consult the ideas of issue #42 .
-.
+or memory compute it, but for a better solution, consult the ideas of issue
+[#42](https://github.com/SSoelvsten/cache-oblivious-obdd/issues/42).
+
+
+## Tic-Tac-Toe
+
+**Files:** `tic_tac_toe.cpp`
+
+**Target:** `make example-tic-tac-toe N=<?>`
+
+Counts the number of possible ties in a 3D 4x4x4 Tic-Tac-Toe game where Player 1
+has placed _N = `?`_ (default: `20`) crosses and Player 2 has placed noughts on
+the remaining cells. Starting from an OBDD that is only true, if exactly N
+crosses are placed, the constraints of at least one cross and one nought for all
+rows, columns, and diagonals are added to it. On this OBDD we then counts the
+number of satisfying assignments [[Kunkle10](#references)].
+
+## References
+
+- [[Kunkle10](https://dl.acm.org/doi/abs/10.1145/1837210.1837222)] Daniel
+  Kunkle, Vlad Slavici, Gene Cooperman. “_Parallel Disk-Based Computation for
+  Large, Monolithic Binary Decision Diagrams_”. In: _ PASCO '10: Proceedings of
+  the 4th International Workshop on Parallel and Symbolic Computation_. 2010

--- a/example/tic_tac_toe.cpp
+++ b/example/tic_tac_toe.cpp
@@ -1,0 +1,399 @@
+#include <vector>
+#include <chrono>
+
+// TPIE Imports
+#include <tpie/tpie.h>
+#include <tpie/tpie_log.h>
+
+// COOM Imports
+#include <coom/data.cpp>
+#include <coom/assignment.cpp>
+
+#include <coom/debug_data.cpp>
+#include <coom/debug_assignment.cpp>
+#include <coom/debug.cpp>
+#include <coom/dot.cpp>
+
+#include <coom/assert.cpp>
+
+#include <coom/build.cpp>
+
+#include <coom/apply.cpp>
+#include <coom/pred.cpp>
+#include <coom/count.cpp>
+#include <coom/reduce.cpp>
+
+/*******************************************************************************
+ * We base our example for 3D 4x4x4 Tic-Tac-Toe on the procedure as described in
+ * the paper "Parallel Disk-Based Computation for Large, Monolithic Binary
+ * Decision Diagrams" by Daniel Kunkle, Vlad Slavici, and Gene Cooperman.
+ *
+ * The question to be answered is as follows: When Player X marks N spaces and
+ * Player O marks the remaining 4^3 - N = 64 - N spaces, how many of these
+ * placements are ties?
+ *
+ * We'd find it interesting to output the size of the largest OBDD, so we create
+ * the following global variables. Also it would be of interest to see the best
+ * and worst ratio between sink and node arcs in the unreduced OBDDs
+ */
+size_t largest_unreduced = 0;
+
+float best_sink_ratio = 0.0;
+float acc_sink_ratio = 0.0;
+float worst_sink_ratio = 1.0;
+
+inline void stats_unreduced(size_t node_arcs, size_t sink_arcs)
+{
+  size_t total_arcs = node_arcs + sink_arcs;
+  largest_unreduced = std::max(largest_unreduced, total_arcs / 2);
+
+  float sink_ratio = float(sink_arcs) / float(total_arcs);
+  best_sink_ratio = std::max(best_sink_ratio, sink_ratio);
+  acc_sink_ratio += sink_ratio;
+  worst_sink_ratio = std::min(worst_sink_ratio, sink_ratio);
+}
+
+size_t largest_reduced = 0;
+
+float best_reduction_ratio = 1.0;
+float acc_reduction_ratio = 0.0;
+float worst_reduction_ratio = 0.0;
+
+inline void stats_reduced(size_t unreduced_size, size_t reduced_size)
+{
+  largest_reduced = std::max(largest_reduced, reduced_size);
+
+  float reduction_ratio = float(reduced_size) / float(unreduced_size);
+  best_reduction_ratio = std::min(best_reduction_ratio, reduction_ratio);
+  acc_reduction_ratio += reduction_ratio;
+  worst_reduction_ratio = std::max(worst_reduction_ratio, reduction_ratio);
+}
+
+
+/*******************************************************************************
+ *                             Variable ordering
+ *
+ * We again go dimension by dimension in the variable ordering, assuming that
+ *
+ *                            0 <= i, j, k <= 4
+ *
+ * We interpret x_ijk as true, if an X is placed on (i,j,k).
+ */
+inline coom::label_t label_of_position(uint64_t i, uint64_t j, uint64_t k)
+{
+  return (4 * 4 * i) + (4 * j) + k;
+}
+
+
+/*******************************************************************************
+ * We need to encapsulate two restrictions for all rows, columns, and diagonals
+ * for it to be a tie:
+ *
+ * - Not all four spaces are marked by X?
+ * - At least one space has an X.
+ *
+ * This again is very well structured and can be easily constructed explicitly.
+ */
+void construct_is_not_winning(std::array<coom::label_t, 4>& line,
+                              tpie::file_stream<coom::node_t>& out_nodes)
+{
+  out_nodes.open();
+  uint64_t idx = 4 - 1;
+
+  coom::ptr_t no_Xs_false = coom::create_sink_ptr(false);
+  coom::ptr_t no_Xs_true = coom::create_sink_ptr(true);
+
+  coom::ptr_t some_Xs_true = coom::create_sink_ptr(false);
+
+  do {
+    coom::node_t no_Xs = coom::create_node(line[idx], 0,
+                                           no_Xs_false,
+                                           no_Xs_true);
+
+    coom::node_t some_Xs = coom::create_node(line[idx], 1,
+                                             coom::create_sink_ptr(true),
+                                             some_Xs_true);
+
+    /* Notice, we have to write bottom-up. That is actually more precisely in
+     * reverse topological order which also includes the id's. */
+    if (idx != 0) {
+      out_nodes.write(some_Xs);
+    }
+    out_nodes.write(no_Xs);
+
+    no_Xs_false = no_Xs.uid;
+    if (idx == 1) { // The next is the root?
+      no_Xs_true = some_Xs.uid;
+    }
+
+    some_Xs_true = some_Xs.uid;
+  } while (idx-- > 0);
+}
+
+/*******************************************************************************
+ * Then we need to combine it for all rows, columns and the 4 diagonals to
+ * ensure that no rows actually are winning and the game ends in a tie.
+ *
+ * We'll place these constraints one by one onto an OBDD that is only true if
+ * exactly N X's are placed. This OBDD is also easy to create. In fact, it is so
+ * simple and universal, that COOM already has a builder that creates it in
+ * linear time and linear I/O with regards to the output size.
+ *
+ * The order in which one picks applies something together is very important. An
+ * Apply technically just constructs the product of both OBDDs; each state
+ * reflects the states of both input OBDDs. From experiments it seems, that one
+ * achieves the smallest intermediate size by starting with the ones, where the
+ * difference between the label-value for the first cell and the fourth cell is
+ * as small as possible.
+ */
+size_t construct_is_tie(uint64_t N, tpie::file_stream<coom::node_t>& out_nodes)
+{
+  // Compute all rows, columns, and diagonals. Most likely the optimiser already
+  // precomputes this one.
+  std::vector<std::array<coom::label_t,4>> lines { };
+
+  // 4 planes and the rows in these
+  for (uint64_t i = 0; i < 4; i++) { // (dist: 4)
+    for (uint64_t j = 0; j < 4; j++) {
+      lines.push_back({ label_of_position(i,j,0), label_of_position(i,j,1), label_of_position(i,j,2), label_of_position(i,j,3) });
+    }
+  }
+  // 4 planes and a diagonal within
+  for (uint64_t i = 0; i < 4; i++) { // (dist: 10)
+    lines.push_back({ label_of_position(i,0,3), label_of_position(i,1,2), label_of_position(i,2,1), label_of_position(i,3,0) });
+  }
+  // 4 planes... again, now the columns
+  for (uint64_t i = 0; i < 4; i++) { // (dist: 13)
+    for (uint64_t k = 0; k < 4; k++) {
+      lines.push_back({ label_of_position(i,0,k), label_of_position(i,1,k), label_of_position(i,2,k), label_of_position(i,3,k) });
+    }
+  }
+  // 4 planes and the other diagonal within
+  for (uint64_t i = 0; i < 4; i++) { // (dist: 16)
+    lines.push_back({ label_of_position(i,0,0), label_of_position(i,1,1), label_of_position(i,2,2), label_of_position(i,3,3) });
+  }
+
+  // Diagonal of the entire cube (dist: 22)
+  lines.push_back({ label_of_position(0,3,3), label_of_position(1,2,2), label_of_position(2,1,1), label_of_position(3,0,0) });
+
+  // Diagonal of the entire cube (dist: 40)
+  lines.push_back({ label_of_position(0,3,0), label_of_position(1,2,1), label_of_position(2,1,2), label_of_position(3,0,3) });
+
+  // Diagonals in the vertical planes
+  for (uint64_t j = 0; j < 4; j++) { // (dist: 46)
+    lines.push_back({ label_of_position(0,j,3), label_of_position(1,j,2), label_of_position(2,j,1), label_of_position(3,j,0) });
+  }
+
+  // 16 vertical lines (dist: 48)
+  for (uint64_t j = 0; j < 4; j++) {
+    for (uint64_t k = 0; k < 4; k++) {
+      lines.push_back({ label_of_position(0,j,k), label_of_position(1,j,k), label_of_position(2,j,k), label_of_position(3,j,k) });
+    }
+  }
+
+  // Diagonals in the vertical planes
+  for (uint64_t j = 0; j < 4; j++) { // (dist: 49)
+    lines.push_back({ label_of_position(0,j,0), label_of_position(1,j,1), label_of_position(2,j,2), label_of_position(3,j,3) });
+  }
+
+  for (uint64_t k = 0; k < 4; k++) { // (dist: 36)
+    lines.push_back({ label_of_position(0,3,k), label_of_position(1,2,k), label_of_position(2,1,k), label_of_position(3,0,k) });
+  }
+  for (uint64_t k = 0; k < 4; k++) { // (dist: 60)
+    lines.push_back({ label_of_position(0,0,k), label_of_position(1,1,k), label_of_position(2,2,k), label_of_position(3,3,k) });
+  }
+
+  // The 4 diagonals of the entire cube (dist: 61)
+  lines.push_back({ label_of_position(0,0,3), label_of_position(1,1,2), label_of_position(2,2,1), label_of_position(3,3,0) });
+
+  // The 4 diagonals of the entire cube (dist: 64)
+  lines.push_back({ label_of_position(0,0,0), label_of_position(1,1,1), label_of_position(2,2,2), label_of_position(3,3,3) });
+
+  tpie::file_stream<coom::arc_t> reduce_node_arcs;
+  tpie::file_stream<coom::arc_t> reduce_sink_arcs;
+
+  tpie::file_stream<coom::node_t> next_not_winning;
+
+  out_nodes.open();
+  coom::build_counter(0, 63, N, out_nodes);
+
+  unsigned int idx = 0;
+  for (auto &line : lines) {
+    next_not_winning.open();
+    construct_is_not_winning(line, next_not_winning);
+
+    reduce_node_arcs.open();
+    reduce_sink_arcs.open();
+
+    coom::apply(out_nodes, next_not_winning, coom::and_op, reduce_node_arcs, reduce_sink_arcs);
+
+    // close (and clean up) prior result
+    out_nodes.close();
+    next_not_winning.close();
+
+    stats_unreduced(reduce_node_arcs.size(), reduce_sink_arcs.size());
+
+    // open for next result
+    out_nodes.open();
+
+    coom::reduce(reduce_node_arcs, reduce_sink_arcs, out_nodes);
+
+    stats_reduced((reduce_node_arcs.size() + reduce_sink_arcs.size()) / 2, out_nodes.size());
+
+    reduce_node_arcs.close();
+    reduce_sink_arcs.close();
+
+    idx++;
+  }
+
+  return lines.size();
+}
+
+/* A few chrono wrappers to improve readability of the code below */
+inline auto get_timestamp() {
+  return std::chrono::high_resolution_clock::now();
+}
+
+inline auto duration_of(std::chrono::high_resolution_clock::time_point &before,
+                        std::chrono::high_resolution_clock::time_point &after) {
+  return std::chrono::duration_cast<std::chrono::seconds>(after - before).count();
+}
+
+/* Expected numbers taken from "Parallel Disk-Based Computation for Large,
+ * Monolithic Binary Decision Diagrams" by Daniel Kunkle, Vlad Slavici, and Gene
+ * Cooperman. */
+uint64_t expected[25] = {
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  304,
+  136288,
+  9734400,
+  296106640,
+  5000129244,
+};
+
+/* TODO: File size calculations should be available from COOM. */
+inline auto MB_of_size(tpie::stream_size_type size) {
+  return size * sizeof(coom::node) /* bytes */ / (1024 * 1024) /* in MB */;
+}
+int main(int argc, char* argv[])
+{
+  // ===== Parse argument =====
+  int N = -1;
+  size_t M = 1;
+
+  try {
+    if (argc == 1) {
+      tpie::log_info() << "Missing argument for N and M" << std::endl;
+    } else {
+      N = std::stoi(argv[1]);
+      if (N < 0 || N > 32) {
+        tpie::log_info() << "N should be in interval [0;32]: " << argv[1] << std::endl;
+        N = -1;
+      }
+      if (argc == 3) {
+        M = std::stoi(argv[2]);
+        if (M <= 0) {
+          tpie::log_info() << "M should at least be 1: " << argv[2] << std::endl;
+        }
+      }
+    }
+  } catch (std::invalid_argument const &ex) {
+    tpie::log_info() << "Invalid number: " << argv[1] << std::endl;
+  } catch (std::out_of_range const &ex) {
+    tpie::log_info() << "Number out of range: " << argv[1] << std::endl;
+  }
+
+  if (N == -1 || M <= 0) {
+    exit(1);
+  }
+
+  // ===== TPIE =====
+  // Initialize
+  tpie::tpie_init();
+
+  tpie::get_memory_manager().set_limit(M * 1024 * 1024 * 1024);
+
+  tpie::log_info() << "| Initialized TPIE with " << M << " GB of memory"  << std::endl;
+
+  // ===== Tic-Tac-Toe =====
+
+  tpie::log_info() << "| Tic-Tac-Toe (" << N << ") : Is-tie construction"  << std::endl;
+  tpie::file_stream<coom::node> is_tie;
+
+  auto before_tie = get_timestamp();
+  size_t constraints = construct_is_tie(N, is_tie);
+  auto after_tie = get_timestamp();
+
+  tpie::log_info() << "|  | constraints: " << constraints << " lines" << std::endl;
+  tpie::log_info() << "|  | time: " << duration_of(before_tie, after_tie) << " s" << std::endl;
+
+  auto init_size = (N+1)*64-(N*N); // See coom::build_counter implementation
+  auto init_MB = MB_of_size(init_size);
+  tpie::log_info() << "|  | initial size: " << init_size << " nodes" << std::endl;
+  tpie::log_info() << "|  |               " << (init_MB > 0 ? std::to_string(init_MB) : "< 1") << " MB"<< std::endl;
+  tpie::log_info() << "|  |" << std::endl;
+
+  auto largest_unreduced_MB = (MB_of_size(largest_unreduced) * 3) / 2;
+  tpie::log_info() << "|  | largest OBDD (unreduced): " << largest_unreduced << " nodes" << std::endl;
+  tpie::log_info() << "|  |                           " << (largest_unreduced_MB > 0 ? std::to_string(largest_unreduced_MB) : "< 1")
+                                                        << " MB"<< std::endl;
+  tpie::log_info() << "|  |" << std::endl;
+
+  tpie::log_info() << "|  | sink ratio: " << std::endl;
+  tpie::log_info() << "|  |  | best:  " << best_sink_ratio << std::endl;
+  tpie::log_info() << "|  |  | avg:   " << acc_sink_ratio / constraints << std::endl;
+  tpie::log_info() << "|  |  | worst: " << worst_sink_ratio << std::endl;
+  tpie::log_info() << "|  |" << std::endl;
+
+  auto largest_reduced_MB = MB_of_size(largest_reduced);
+  tpie::log_info() << "|  | largest OBDD (reduced)  : " << largest_reduced << " nodes" << std::endl;
+  tpie::log_info() << "|  |                           " << (largest_reduced_MB > 0 ? std::to_string(largest_reduced_MB) : "< 1")
+                                                        << " MB"<< std::endl;
+  tpie::log_info() << "|  |" << std::endl;
+
+  tpie::log_info() << "|  | reduction ratio: " << std::endl;
+  tpie::log_info() << "|  |  | best:  " << best_reduction_ratio << std::endl;
+  tpie::log_info() << "|  |  | avg:   " << acc_reduction_ratio / constraints << std::endl;
+  tpie::log_info() << "|  |  | worst: " << worst_reduction_ratio << std::endl;
+  tpie::log_info() << "|  |" << std::endl;
+
+  auto final_MB = MB_of_size(is_tie.size());
+  tpie::log_info() << "|  | final size: " << is_tie.size() << " nodes"<< std::endl;
+  tpie::log_info() << "|  |             " << (final_MB > 0 ? std::to_string(final_MB) : "< 1") << " MB"<< std::endl;
+  tpie::log_info() << "|  |" << std::endl;
+
+  tpie::log_info() << "| Tic-Tac-Toe (" << N << ") : Counting ties"  << std::endl;
+  auto before_count = get_timestamp();
+  uint64_t solutions = coom::count_assignments(is_tie, coom::is_true);
+  auto after_count = get_timestamp();
+
+  tpie::log_info() << "|  | number of ties: " << solutions << std::endl;
+  tpie::log_info() << "|  | time: " << duration_of(before_count, after_count) << " s" << std::endl;
+
+  // ===== TPIE =====
+  // Close all of TPIE down again
+  tpie::tpie_finish();
+
+  // Return 'all good'
+  exit(N >= 25 || solutions == expected[N] ? 0 : 1);
+}
+

--- a/makefile
+++ b/makefile
@@ -53,8 +53,8 @@ main:
 #  EXAMPLES
 # ============================================================================ #
 M = 1
-N = 8
 
+example-n-queens: N := 8
 example-n-queens:
   # Build
 	@mkdir -p build/
@@ -65,4 +65,17 @@ example-n-queens:
   # Run
 	@echo ""
 	@./build/example/n_queens ${N} ${M}
+	@echo ""
+
+example-tic-tac-toe: N := 20
+example-tic-tac-toe:
+  # Build
+	@mkdir -p build/
+	@cd build/ && cmake -DCOOM_DEBUG=OFF -DCOOM_ASSERT=OFF ..
+
+	@cd build/ && make tic_tac_toe
+
+  # Run
+	@echo ""
+	@./build/example/tic_tac_toe ${N} ${M}
 	@echo ""


### PR DESCRIPTION
Surprisingly, it seems like the very first constraint construction order I had is almost optimal for the current variable ordering? Sorting them in any other way or changing the construction order seems only to worsen it for _N_ > 18. My guess is, that this sorting starts with the shallowest OBDDs in terms of the label ordering. This then widens the fewest layers of the resulting OBDD at the same time?

So, I changed the order to be exactly minimising this distance as much as possible, which seems to shave off quite a bit more on the largest OBDD.