### PR TITLE
Add more binary operators for sinks

### DIFF
--- a/test/coom/test_apply.cpp
+++ b/test/coom/test_apply.cpp
@@ -5,6 +5,118 @@ using namespace coom;
 
 go_bandit([]() {
     describe("COOM: Apply", [&]() {
+        describe("Operators", [&]() {
+            it("AND", [&]() {
+                AssertThat(and_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(and_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(and_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(and_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+              });
+
+            it("NAND", [&]() {
+                AssertThat(nand_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(nand_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(nand_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(nand_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+              });
+
+            it("OR", [&]() {
+                AssertThat(or_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(or_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(or_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(or_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+              });
+
+            it("NOR", [&]() {
+                AssertThat(nor_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(nor_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(nor_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(nor_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+              });
+
+            it("XOR", [&]() {
+                AssertThat(xor_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(xor_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(xor_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(xor_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+              });
+
+            it("IMPLIES", [&]() {
+                AssertThat(implies_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(implies_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(implies_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(implies_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+              });
+
+            it("IMPLIED BY", [&]() {
+                AssertThat(impliedby_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(impliedby_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(impliedby_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(impliedby_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+              });
+
+            it("EQUIV", [&]() {
+                AssertThat(equiv_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(equiv_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(equiv_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(equiv_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+              });
+
+            it("DIFF", [&]() {
+                AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(diff_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(diff_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+              });
+
+            it("LESS", [&]() {
+                AssertThat(less_op(create_sink_ptr(true), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(less_op(create_sink_ptr(true), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+                AssertThat(less_op(create_sink_ptr(false), create_sink_ptr(true)),
+                           Is().EqualTo(create_sink_ptr(true)));
+                AssertThat(less_op(create_sink_ptr(false), create_sink_ptr(false)),
+                           Is().EqualTo(create_sink_ptr(false)));
+              });
+          });
+
         // == CREATE SINK-ONLY OBDD FOR UNIT TESTS ==
         //                  START
         tpie::file_stream<node_t> obdd_F_1;


### PR DESCRIPTION
Also ensures, that the sink operators never provide a flag on the pointer. This is not included in the unit tests though.