### PR TITLE
Implement If-Then-Else algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 # TPIE files
 *.tpie
 *.coom*
+*.adiar*
 
 # ---------------------
 # DOT files

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -38,40 +38,6 @@ like the rest.
 The features are sorted based on the difficulty deriving their design and their
 implementation.
 
-### If-Then-Else
-The _ITE_ operator takes three OBDDs _f_, _g_, and _h_ and constructs an OBDD
-which resembles the _(f ∧ g) ∨ (¬f ∧ h)_ formula. That is, if _f_ is true,
-then output the value of _g_; otherwise output the value of _h_. one should be
-able to reproduce the ideas in _Apply_ to do a simultaneous sweep over all three
-OBDDs simultaneously in one go and gain a major performance gain over
-constructing the above formula with `adiar::apply` and `adiar:negate`.
-
-Yet, there are multiple edge-cases, in which one can do much, much better than
-the above.
-
-- If _f_ is a sink, it is trivial
-
-- If _g_ and _h_ are sinks, it's also either _f_, _~f_, or a collapse to a sink.
-
-- The labels of _f_ are 'above' _g_ and _h_. At this point, one can change the
-  pointers of _f_ to point to the root of _g_ and _h_, where the ids of _h_ are
-  decreased to not conflict with _g_.
-  
-  - If _g_ or _h_ also is separate from the other, then one can do it all
-    without reduction by merely copying the nodes of _g_ and _h_.
-
-There may be many more interesting and common cases, that may run much faster.
-
-One can also encode many other interesting operators within the ITE operator,
-where it might be worth investigating the performance difference between the use
-of _ITE_ rather than the other implementation of the algorithm
-
-| Operator    | Operator (formula) | ITE form                         |
-|-------------|--------------------|----------------------------------|
-| Composition | f(x, g(y), z)      | ITE(g(x), f(x, 1, z), f(x, 0, z) |
-| Existence   | ∃y : f(x, y, z)    | ITE(f(x, 1, z), 1, f(x, 0, z))   |
-| Forall      | ∀y : f(x, y, z)    | ITE(f(x, 1, z), f(x, 0, z), 0)   |
-
 ### Function composition
 The _Composition_ of two OBDDs _f_ and _g_ for some label _i ∊ [n]_ is
 _f ∘<sub>i</sub> g (x)_ and is to be interpreted as _f(x<sub>1</sub>, ...,

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -101,6 +101,12 @@ copy-constructed from the `node_file`.
     
     Same as `bdd_apply(f, g, less_op)` and computes `~f /\ g`.
 
+- `bdd bdd_ite(bdd f, bdd g, bdd h)`
+
+  Return the BDD representing `f ? g : h`. In other BDD packages such a function
+  is good for manually constructing a BDD bottom-up, but for those purposes one
+  should here instead use the [`node_writer`](/core.md#files) class.
+
 - `bdd bdd_not(bdd f)` (operator: `~`)
 
   Return the BDD representing `~f`.

--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HEADERS
   bdd/build.h
   bdd/count.h
   bdd/evaluate.h
+  bdd/if_then_else.h
   bdd/negate.h
   bdd/quantify.h
   bdd/restrict.h
@@ -50,6 +51,7 @@ set(SOURCES
   bdd/build.cpp
   bdd/count.cpp
   bdd/evaluate.cpp
+  bdd/if_then_else.cpp
   bdd/negate.cpp
   bdd/quantify.cpp
   bdd/restrict.cpp

--- a/src/adiar/adiar.h
+++ b/src/adiar/adiar.h
@@ -22,6 +22,7 @@
 #include <adiar/bdd/assignment.h>
 #include <adiar/bdd/count.h>
 #include <adiar/bdd/evaluate.h>
+#include <adiar/bdd/if_then_else.h>
 #include <adiar/bdd/negate.h>
 #include <adiar/bdd/restrict.h>
 #include <adiar/bdd/quantify.h>

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -355,6 +355,11 @@ namespace adiar
     return bdd_apply(bdd_1, bdd_2, xor_op);
   }
 
+  __bdd bdd_xnor(const bdd &bdd_1, const bdd &bdd_2)
+  {
+    return bdd_apply(bdd_1, bdd_2, xnor_op);
+  }
+
   __bdd bdd_imp(const bdd &bdd_1, const bdd &bdd_2)
   {
     return bdd_apply(bdd_1, bdd_2, imp_op);

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -26,7 +26,6 @@ namespace adiar
   struct apply_tuple_data : tuple_data
   {
     ptr_t source;
-    bool from_1;
   };
 
   typedef node_priority_queue<apply_tuple, tuple_label, tuple_fst_lt, std::less<>, 2> apply_priority_queue_t;
@@ -190,7 +189,7 @@ namespace adiar
       }
 
       ptr_t source, t1, t2;
-      bool with_data = false, from_1 = false;
+      bool with_data = false;
       ptr_t data_low = NIL, data_high = NIL;
 
       // Merge requests from  appD or appD_data
@@ -208,7 +207,6 @@ namespace adiar
         t2 = appD_data.top().t2;
 
         with_data = true;
-        from_1 = appD_data.top().from_1;
         data_low = appD_data.top().data_low;
         data_high = appD_data.top().data_high;
 
@@ -230,17 +228,18 @@ namespace adiar
       }
 
       // Forward information across the level
+      bool from_1 = fst(t1,t2) == t1;
+
       if (!with_data
           && !is_sink_ptr(t1) && !is_sink_ptr(t2) && label_of(t1) == label_of(t2)
           && (v1.uid != t1 || v2.uid != t2)) {
-        bool from_1 = v1.uid == t1;
         node_t v0 = from_1 ? v1 : v2;
 
-        appD_data.push({ t1, t2, v0.low, v0.high, source, from_1 });
+        appD_data.push({ t1, t2, v0.low, v0.high, source });
 
         while (appD.can_pull() && (appD.top().t1 == t1 && appD.top().t2 == t2)) {
           source = appD.pull().source;
-          appD_data.push({ t1, t2, v0.low, v0.high, source, from_1 });
+          appD_data.push({ t1, t2, v0.low, v0.high, source });
         }
         continue;
       }

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -6,7 +6,6 @@
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
 #include <adiar/priority_queue.h>
-#include <adiar/reduce.h>
 #include <adiar/tuple.h>
 
 #include <adiar/bdd/build.h>

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -194,6 +194,9 @@ namespace adiar
       }
 
       // Forward information across the level
+
+      // TODO: We don't need to forward something, if there are no more nodes to
+      // pull from that stream.
       if (is_node_ptr(t1) && is_node_ptr(t2) && label_of(t1) == label_of(t2)
           && !with_data && (v1.uid != t1 || v2.uid != t2)) {
         node_t v0 = v1.uid == t1 ? v1 : v2;

--- a/src/adiar/bdd/apply.h
+++ b/src/adiar/bdd/apply.h
@@ -27,6 +27,7 @@ namespace adiar
   __bdd bdd_or(const bdd &bdd_1, const bdd &bdd_2);
   __bdd bdd_nor(const bdd &bdd_1, const bdd &bdd_2);
   __bdd bdd_xor(const bdd &bdd_1, const bdd &bdd_2);
+  __bdd bdd_xnor(const bdd &bdd_1, const bdd &bdd_2);
   __bdd bdd_imp(const bdd &bdd_1, const bdd &bdd_2);
   __bdd bdd_invimp(const bdd &bdd_1, const bdd &bdd_2);
   __bdd bdd_equiv(const bdd &bdd_1, const bdd &bdd_2);

--- a/src/adiar/bdd/apply.h
+++ b/src/adiar/bdd/apply.h
@@ -7,9 +7,9 @@
 namespace adiar
 {
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Given two OBDDs creates one as per an operator.
+  /// \brief Given two BDDs creates one as per an operator.
   ///
-  /// Creates the product construction of the two given OBDDs.
+  /// Creates the product construction of the two given BDDs.
   ///
   /// \param bdd_i     BDD to apply with the other.
   ///

--- a/src/adiar/bdd/bdd.h
+++ b/src/adiar/bdd/bdd.h
@@ -79,10 +79,11 @@ namespace adiar {
     friend bdd operator~ (const bdd& bdd);
     friend bdd operator~ (bdd&& bdd);
 
-    friend __bdd bdd_apply(const bdd &in_1, const bdd &in_2, const bool_op &op);
-    friend __bdd operator& (const bdd& lhs, const bdd& rhs);
-    friend __bdd operator| (const bdd& lhs, const bdd& rhs);
-    friend __bdd operator^ (const bdd& lhs, const bdd& rhs);
+    friend __bdd bdd_apply(const bdd &bdd_1, const bdd &bdd_2, const bool_op &op);
+    friend __bdd bdd_ite(const bdd &bdd_if, const bdd &bdd_then, const bdd &bdd_else);
+    friend __bdd operator& (const bdd &lhs, const bdd &rhs);
+    friend __bdd operator| (const bdd &lhs, const bdd &rhs);
+    friend __bdd operator^ (const bdd &lhs, const bdd &rhs);
 
     ////////////////////////////////////////////////////////////////////////////
     // Internal state

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -1,0 +1,399 @@
+#ifndef ADIAR_IF_THEN_ELSE_CPP
+#define ADIAR_IF_THEN_ELSE_CPP
+
+#include "if_then_else.h"
+
+#include <adiar/file_stream.h>
+#include <adiar/file_writer.h>
+#include <adiar/priority_queue.h>
+#include <adiar/tuple.h>
+
+#include <adiar/bdd/build.h>
+#include <adiar/bdd/apply.h>
+#include <adiar/bdd/negate.h>
+
+#include <adiar/assert.h>
+
+namespace adiar
+{
+  //////////////////////////////////////////////////////////////////////////////
+  // Data structures
+  //
+  // To make the merge simpler we will make sure that 'data_1_x' and 'data_2_x'
+  // are ordered based on the order of the BDDs are given, i.e. the elements of
+  // the if-BDD would only every be forwarded in 'data_1_x'. The then-elements
+  // are forwarded only in 'data_2_x' if the if-BDD is also forwarded. Finally,
+  // the placement of the else-BDD on whether any element from the if-BDD or
+  // then-BDD has been forwarded.
+
+  struct ite_triple : triple
+  {
+    ptr_t source;
+  };
+
+  struct ite_triple_data_1 : ite_triple
+  {
+    ptr_t data_1_low;
+    ptr_t data_1_high;
+  };
+
+  struct ite_triple_data_2 : ite_triple_data_1
+  {
+    ptr_t data_2_low;
+    ptr_t data_2_high;
+  };
+
+
+  typedef node_priority_queue<ite_triple, triple_label, triple_fst_lt, std::less<>, 3> ite_priority_queue_1_t;
+  typedef tpie::priority_queue<ite_triple_data_1, triple_snd_lt> ite_priority_queue_2_t;
+  typedef tpie::priority_queue<ite_triple_data_2, triple_trd_lt> ite_priority_queue_3_t;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Helper functions
+  inline bool ite_must_forward(node_t v, ptr_t t, label_t out_label, ptr_t t_seek)
+  {
+    return
+      // is it a node at this level?
+      is_node_ptr(t) && label_of(t) == out_label
+      // and we should be seeing it later
+      && t_seek < t
+      // and we haven't by accident just run into it anyway
+      && v.uid != t;
+  }
+
+  inline void ite_init_request(node_stream<> &in_nodes, node_t &v, label_t out_label,
+                               ptr_t &low, ptr_t &high)
+  {
+    if (label_of(v) == out_label) {
+      low = v.low;
+      high = v.high;
+
+      if (in_nodes.can_pull()) { v = in_nodes.pull(); }
+    } else {
+      low = high = v.uid;
+    }
+  }
+
+  inline void ite_resolve_request(ite_priority_queue_1_t &ite_pq,
+                                  arc_writer &aw,
+                                  ptr_t source, ptr_t r_if, ptr_t r_then, ptr_t r_else)
+  {
+    // Early shortcut an ite, if the sinks of both cases have collapsed to the
+    // same anyway
+    if (is_sink_ptr(r_then) && is_sink_ptr(r_else) &&
+        value_of(r_then) == value_of(r_else)) {
+
+      aw.unsafe_push_sink(arc_t { source, r_then });
+      return;
+    }
+    // Remove irrelevant parts of a request to prune requests similar to
+    // shortcutting the operator in bdd_apply.
+    r_then = is_sink_ptr(r_if) && !value_of(r_if) ? NIL : r_then;
+    r_else = is_sink_ptr(r_if) && value_of(r_if) ? NIL : r_else;
+
+    if (is_sink_ptr(r_if) && is_sink_ptr(r_then)) {
+      // => ~NIL => r_if is a sink with the 'true' value
+      aw.unsafe_push_sink(arc_t { source, r_then });
+    } else if (is_sink_ptr(r_if) && is_sink_ptr(r_else)) {
+      // => ~NIL => r_if is a sink with the 'false' value
+      aw.unsafe_push_sink(arc_t { source, r_else });
+    } else {
+      ite_pq.push({ r_if, r_then, r_else, source });
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  __bdd bdd_ite(const bdd &bdd_if, const bdd &bdd_then, const bdd &bdd_else)
+  {
+    // There are multiple cases, where this boils down to an Apply rather than
+    // an If-Then-Else. The bdd_apply uses tuples rather than triples and only
+    // two priority queues, so it will run considerably faster.
+    //
+    // The translations into Apply can be found in Figure 1 of "Efficient
+    // Implementation of a BDD Package" of Karl S. Brace, Richard L. Rudell, and
+    // Randal E. Bryant.
+
+    // Resolve being given the same underlying file in both cases
+    if (bdd_then.file._file_ptr == bdd_else.file._file_ptr) {
+      return bdd_then.negate == bdd_else.negate
+        ? __bdd(bdd_then)
+        : bdd_xnor(bdd_if, bdd_then);
+    }
+
+    // Resolve being given the same underlying file for conditional and a case
+    if (bdd_if.file._file_ptr == bdd_then.file._file_ptr) {
+      return bdd_if.negate == bdd_then.negate
+        ? bdd_or(bdd_if, bdd_else)
+        : bdd_and(bdd_not(bdd_if), bdd_else);
+    } else if (bdd_if.file._file_ptr == bdd_else.file._file_ptr) {
+      return bdd_if.negate == bdd_else.negate
+        ? bdd_and(bdd_if, bdd_then)
+        : bdd_imp(bdd_if, bdd_then);
+    }
+
+    // Resolve being given a sink in one of the cases
+    if      (is_sink(bdd_then, is_true))  { return bdd_or (bdd_if,          bdd_else); }
+    else if (is_sink(bdd_then, is_false)) { return bdd_and(bdd_not(bdd_if), bdd_else); }
+    else if (is_sink(bdd_else, is_true))  { return bdd_imp(bdd_if,          bdd_then); }
+    else if (is_sink(bdd_else, is_false)) { return bdd_and(bdd_if,          bdd_then); }
+
+    // Now, at this point we will not defer to using the Apply, so we can take
+    // up memory by opening the input streams and evaluating trivial
+    // conditionals.
+    node_stream<> in_nodes_if(bdd_if);
+    node_t v_if = in_nodes_if.pull();
+
+    if (is_sink(v_if)) {
+      return value_of(v_if) ? bdd_then : bdd_else;
+    }
+
+    // TODO: If the levels of 'then' and 'else' are disjunct and the 'if' BDD is
+    // above the two others, then we can merely zip the 'then' and 'else' BDDs.
+    // This is only O((N1+N2+N3)/B) I/Os!
+
+    node_stream<> in_nodes_then(bdd_then);
+    node_t v_then = in_nodes_then.pull();
+
+    node_stream<> in_nodes_else(bdd_else);
+    node_t v_else = in_nodes_else.pull();
+
+    arc_file out_arcs;
+    arc_writer aw(out_arcs);
+
+    // TODO: Do statistics on size of the 3 priority queues
+    tpie::memory_size_type available_memory = tpie::get_memory_manager().available();
+
+    ite_priority_queue_1_t ite_pq_1({bdd_if, bdd_then, bdd_else}, available_memory / 3);
+    ite_priority_queue_2_t ite_pq_2(calc_tpie_pq_factor(available_memory / 3));
+    ite_priority_queue_3_t ite_pq_3(calc_tpie_pq_factor(available_memory / 3));
+
+    // Process root and create initial recursion requests
+    label_t out_label = label_of(fst(v_if.uid, v_then.uid, v_else.uid));
+    id_t out_id = 0;
+
+    aw.unsafe_push(meta_t { out_label });
+
+    ptr_t low_if, low_then, low_else, high_if, high_then, high_else;
+    ite_init_request(in_nodes_if, v_if, out_label, low_if, high_if);
+    ite_init_request(in_nodes_then, v_then, out_label, low_then, high_then);
+    ite_init_request(in_nodes_else, v_else, out_label, low_else, high_else);
+
+    uid_t out_uid = create_node_uid(out_label, out_id);
+    ite_resolve_request(ite_pq_1, aw, out_uid, low_if, low_then, low_else);
+    ite_resolve_request(ite_pq_1, aw, flag(out_uid), high_if, high_then, high_else);
+
+    // Process all nodes in topological order of both BDDs
+    while (ite_pq_1.can_pull() || ite_pq_1.has_next_layer() || !ite_pq_2.empty() || !ite_pq_3.empty()) {
+      if (!ite_pq_1.can_pull() && ite_pq_2.empty() && ite_pq_3.empty()) {
+        ite_pq_1.setup_next_layer();
+        out_label = ite_pq_1.current_layer();
+        aw.unsafe_push(meta_t { out_label });
+        out_id = 0;
+      }
+
+      ptr_t source, t_if, t_then, t_else;
+      bool with_data_1 = false, with_data_2 = false;
+      ptr_t data_1_low = NIL, data_1_high = NIL, data_2_low = NIL, data_2_high = NIL;
+
+      // Merge requests from priority queues
+      if (ite_pq_1.can_pull()
+          && (ite_pq_2.empty() || fst(ite_pq_1.top()) < snd(ite_pq_2.top()))
+          && (ite_pq_3.empty() || fst(ite_pq_1.top()) < trd(ite_pq_3.top()))) {
+        ite_triple r = ite_pq_1.top();
+        ite_pq_1.pop();
+
+        source = r.source;
+        t_if = r.t1;
+        t_then = r.t2;
+        t_else = r.t3;
+      } else if (!ite_pq_2.empty()
+                 && (ite_pq_3.empty() || snd(ite_pq_2.top()) < trd(ite_pq_3.top()))) {
+        ite_triple_data_1 r = ite_pq_2.top();
+        ite_pq_2.pop();
+
+        source = r.source;
+        t_if = r.t1;
+        t_then = r.t2;
+        t_else = r.t3;
+
+        with_data_1 = true;
+        data_1_low = r.data_1_low;
+        data_1_high = r.data_1_high;
+      } else {
+        ite_triple_data_2 r = ite_pq_3.top();
+        ite_pq_3.pop();
+
+        source = r.source;
+        t_if = r.t1;
+        t_then = r.t2;
+        t_else = r.t3;
+
+        with_data_1 = true;
+        data_1_low = r.data_1_low;
+        data_1_high = r.data_1_high;
+
+        with_data_2 = true;
+        data_2_low = r.data_2_low;
+        data_2_high = r.data_2_high;
+      }
+
+      // Seek request partially in stream
+      ptr_t t_fst = fst(t_if,t_then,t_else);
+      ptr_t t_snd = snd(t_if,t_then,t_else);
+      ptr_t t_trd = trd(t_if,t_then,t_else);
+
+      ptr_t t_seek = with_data_2 ? t_trd
+                   : with_data_1 ? t_snd
+                                 : t_fst;
+
+      while (v_if.uid < t_seek && in_nodes_if.can_pull()) {
+        v_if = in_nodes_if.pull();
+      }
+      while (v_then.uid < t_seek && in_nodes_then.can_pull()) {
+        v_then = in_nodes_then.pull();
+      }
+      while (v_else.uid < t_seek && in_nodes_else.can_pull()) {
+        v_else = in_nodes_else.pull();
+      }
+
+      // Forward information across the level
+      if (ite_must_forward(v_if, t_if, out_label, t_seek) ||
+          ite_must_forward(v_then, t_then, out_label, t_seek) ||
+          ite_must_forward(v_else, t_else, out_label, t_seek)) {
+        // An element should be forwarded, if it was not already forwarded
+        // (t_seek <= t_x), if it isn't the last one to seek (t_x < t_trd), and
+        // if we actually are holding it.
+        bool forward_if   = t_seek <= t_if   && t_if < t_trd   && v_if.uid == t_if;
+        bool forward_then = t_seek == t_then && t_then < t_trd && v_then.uid == t_then;
+        bool forward_else = t_seek == t_else && t_else < t_trd && v_else.uid == t_else;
+
+        int number_of_elements_to_forward = ((int) forward_if)
+                                          + ((int) forward_then)
+                                          + ((int) forward_else);
+
+        if (with_data_1 || number_of_elements_to_forward == 2) {
+          adiar_debug(!with_data_1 || t_seek != t_fst,
+                      "cannot have data and still seek the first element");
+          adiar_debug(!(with_data_1 && (number_of_elements_to_forward == 2)),
+                      "cannot have forwarded an element, hold two unforwarded items, and still need to forward for something");
+
+          if (with_data_1) {
+            if (t_if < t_seek || forward_else) {
+              node_t v2 = forward_else ? v_else : v_then;
+              data_2_low = v2.low;
+              data_2_high = v2.high;
+            } else { // if (forward_if || t_else < t_seek)
+              data_2_low = data_1_low;
+              data_2_high = data_1_high;
+
+              node_t v1 = forward_if ? v_if : v_then;
+              data_1_low = v1.low;
+              data_1_high = v1.high;
+            }
+          } else {
+            node_t v1 = forward_if   ? v_if   : v_then;
+            node_t v2 = forward_else ? v_else : v_then;
+
+            data_1_low = v1.low;
+            data_1_high = v1.high;
+            data_2_low = v2.low;
+            data_2_high = v2.high;
+          }
+
+          ite_pq_3.push({ t_if, t_then, t_else, source, data_1_low, data_1_high, data_2_low, data_2_high });
+
+          while (ite_pq_1.can_pull() && ite_pq_1.top().t1 == t_if
+                                     && ite_pq_1.top().t2 == t_then
+                                     && ite_pq_1.top().t3 == t_else) {
+            source = ite_pq_1.pull().source;
+            ite_pq_3.push({ t_if, t_then, t_else, source, data_1_low, data_1_high, data_2_low, data_2_high });
+          }
+        } else {
+          // got no data and the stream only gave us a single item to forward.
+          node_t v1 = forward_if   ? v_if
+                    : forward_then ? v_then
+                                   : v_else;
+
+          ite_pq_2.push({ t_if, t_then, t_else, source, v1.low, v1.high });
+
+          while (ite_pq_1.can_pull() && ite_pq_1.top().t1 == t_if
+                                     && ite_pq_1.top().t2 == t_then
+                                     && ite_pq_1.top().t3 == t_else) {
+            source = ite_pq_1.pull().source;
+            ite_pq_2.push({ t_if, t_then, t_else, source, v1.low, v1.high });
+          }
+        }
+        continue;
+      }
+
+      // Resolve current node and recurse
+      if (is_sink_ptr(t_if) || out_label < label_of(t_if)) {
+        low_if = high_if = t_if;
+      } else {
+        low_if = t_if == v_if.uid ? v_if.low : data_1_low;
+        high_if = t_if == v_if.uid ? v_if.high : data_1_high;
+      }
+
+      if (is_nil(t_then) || is_sink_ptr(t_then) || out_label < label_of(t_then)) {
+        low_then = high_then = t_then;
+      } else if (t_then == v_then.uid) {
+        low_then = v_then.low;
+        high_then = v_then.high;
+      } else if (t_seek <= t_if) {
+        low_then = data_1_low;
+        high_then = data_1_high;
+      } else {
+        low_then = data_2_low;
+        high_then = data_2_high;
+      }
+
+      if (is_nil(t_else) || is_sink_ptr(t_else) || out_label < label_of(t_else)) {
+        low_else = high_else = t_else;
+      } else if (t_else == v_else.uid) {
+        low_else = v_else.low;
+        high_else = v_else.high;
+      } else if (t_seek <= t_if && t_seek <= t_then) {
+        low_else = data_1_low;
+        high_else = data_1_high;
+      } else {
+        low_else = data_2_low;
+        high_else = data_2_high;
+      }
+
+      // Resolve request
+      adiar_debug(out_id < MAX_ID, "Has run out of ids");
+      out_uid = create_node_uid(out_label, out_id++);
+
+      ite_resolve_request(ite_pq_1, aw, out_uid, low_if, low_then, low_else);
+      ite_resolve_request(ite_pq_1, aw, flag(out_uid), high_if, high_then, high_else);
+
+      // Output ingoing arcs
+      while (true) {
+        arc_t out_arc = { source, out_uid };
+        aw.unsafe_push_node(out_arc);
+
+        if (ite_pq_1.can_pull() && ite_pq_1.top().t1 == t_if
+                                && ite_pq_1.top().t2 == t_then
+                                && ite_pq_1.top().t3 == t_else) {
+          source = ite_pq_1.pull().source;
+        } else if (!ite_pq_2.empty() && ite_pq_2.top().t1 == t_if
+                                     && ite_pq_2.top().t2 == t_then
+                                     && ite_pq_2.top().t3 == t_else) {
+          source = ite_pq_2.top().source;
+          ite_pq_2.pop();
+        } else if (!ite_pq_3.empty() && ite_pq_3.top().t1 == t_if
+                                     && ite_pq_3.top().t2 == t_then
+                                     && ite_pq_3.top().t3 == t_else) {
+          source = ite_pq_3.top().source;
+          ite_pq_3.pop();
+        } else {
+          break;
+        }
+      }
+    }
+
+    return out_arcs;
+  }
+}
+
+#endif // ADIAR_IF_THEN_ELSE_CPP

--- a/src/adiar/bdd/if_then_else.h
+++ b/src/adiar/bdd/if_then_else.h
@@ -1,0 +1,25 @@
+#ifndef ADIAR_IF_THEN_ELSE_H
+#define ADIAR_IF_THEN_ELSE_H
+
+#include <adiar/data.h>
+#include <adiar/bdd/bdd.h>
+
+namespace adiar
+{
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Given two BDDs creates one as per an operator.
+  ///
+  /// Creates the product construction of the three given BDDs to resemble their
+  /// if-then-else. That is, if the first BDD evaluates to true, then the output
+  /// will evaluate to the value of the second. If not, then it evaluates to the
+  /// value of the third.
+  ///
+  /// This is faster than using bdd_apply to compute
+  ///
+  ///               (bdd_if => bdd_then) && (~bdd_if => bdd_else)
+  ///
+  //////////////////////////////////////////////////////////////////////////////
+  __bdd bdd_ite(const bdd &bdd_if, const bdd &bdd_then, const bdd &bdd_else);
+}
+
+#endif // ADIAR_IF_THEN_ELSE_H

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -161,7 +161,7 @@ namespace adiar
     id_t out_id = 0;
 
     if (label_of(v.uid) == label) {
-      // Precondition: The input is reduced and will not collapse to a sink-only OBDD
+      // Precondition: The input is reduced and will not collapse to a sink-only BDD
       quantD.push({ fst(v.low, v.high), snd(v.low, v.high), NIL });
     } else {
       aw.unsafe_push(meta_t { out_label });
@@ -263,10 +263,8 @@ namespace adiar
       } else {
         // The variable should stay: proceed as in Apply by simulating both
         // possibilities in parallel.
-        uid_t out_uid = create_node_uid(out_label, out_id);
-
         adiar_debug(out_id < MAX_ID, "Has run out of ids");
-        out_id++;
+        uid_t out_uid = create_node_uid(out_label, out_id++);
 
         quantify_resolve_request(quantD, aw, op,
                                  out_uid, low1, low2);

--- a/src/adiar/bdd/restrict.cpp
+++ b/src/adiar/bdd/restrict.cpp
@@ -48,6 +48,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   __bdd bdd_restrict(const bdd &bdd, const assignment_file &assignment)
   {
+    // TODO: Assert whether no assignment actually is present in the bdd.
     if (assignment.size() == 0 || is_sink(bdd, is_any)) {
       return bdd;
     }

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -136,7 +136,7 @@ namespace adiar {
 
   const bool_op nand_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
   {
-    return negate(unflag(sink1 & sink2));
+    return negate(and_op(sink1, sink2));
   };
 
   const bool_op or_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
@@ -146,7 +146,7 @@ namespace adiar {
 
   const bool_op nor_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
   {
-    return negate(unflag(sink1 | sink2));
+    return negate(or_op(sink1, sink2));
   };
 
   const bool_op xor_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -166,7 +166,7 @@ namespace adiar {
 
   const bool_op equiv_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
   {
-    return create_sink_ptr(sink1 == sink2);
+    return create_sink_ptr(unflag(sink1) == unflag(sink2));
   };
 
   const bool_op diff_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -154,6 +154,11 @@ namespace adiar {
     return SINK_BIT | unflag(sink1 ^ sink2);
   };
 
+  const bool_op xnor_op  = [](ptr_t sink1, ptr_t sink2) -> ptr_t
+  {
+    return negate(xor_op(sink1, sink2));
+  };
+
   const bool_op imp_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
   {
     return create_sink_ptr(!value_of(sink1) || value_of(sink2));

--- a/src/adiar/data.h
+++ b/src/adiar/data.h
@@ -131,6 +131,7 @@ namespace adiar {
   extern const bool_op or_op;
   extern const bool_op nor_op;
   extern const bool_op xor_op;
+  extern const bool_op xnor_op;
   extern const bool_op imp_op;
   extern const bool_op invimp_op;
   extern const bool_op equiv_op;

--- a/src/adiar/homomorphism.cpp
+++ b/src/adiar/homomorphism.cpp
@@ -11,13 +11,8 @@ namespace adiar
 {
   //////////////////////////////////////////////////////////////////////////////
   // Data structures
-  struct homomorphism_tuple_data : tuple_data
-  {
-    bool from_1;
-  };
-
   typedef node_priority_queue<tuple, tuple_label, tuple_fst_lt, std::less<>, 2> homomorphism_priority_queue_t;
-  typedef tpie::priority_queue<homomorphism_tuple_data, tuple_snd_lt> homomorphism_data_priority_queue_t;
+  typedef tpie::priority_queue<tuple_data, tuple_snd_lt> homomorphism_data_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions
@@ -106,7 +101,7 @@ namespace adiar
       }
 
       ptr_t t1, t2;
-      bool with_data, from_1 = false;
+      bool with_data;
       ptr_t data_low = NIL, data_high = NIL;
 
       // Merge requests from pq or pq_data
@@ -123,7 +118,6 @@ namespace adiar
         t1 = pq_data.top().t1;
         t2 = pq_data.top().t2;
 
-        from_1 = pq_data.top().from_1;
         data_low = pq_data.top().data_low;
         data_high = pq_data.top().data_high;
 
@@ -140,13 +134,14 @@ namespace adiar
       }
 
       // Forward information across the layer
+      bool from_1 = fst(t1,t2) == t1;
+
       if (!with_data
           && !is_sink_ptr(t1) && !is_sink_ptr(t2) && label_of(t1) == label_of(t2)
           && (v1.uid != t1 || v2.uid != t2)) {
-        bool from_1 = v1.uid == t1;
         node_t v0 = from_1 ? v1 : v2;
 
-        pq_data.push({ t1, t2, v0.low, v0.high, from_1 });
+        pq_data.push({ t1, t2, v0.low, v0.high });
 
         // Skip all requests to the same node
         while (pq.can_pull() && (pq.top().t1 == t1 && pq.top().t2 == t2)) {

--- a/src/adiar/homomorphism.cpp
+++ b/src/adiar/homomorphism.cpp
@@ -16,8 +16,8 @@ namespace adiar
     bool from_1;
   };
 
-  typedef node_priority_queue<tuple, tuple_queue_label, tuple_queue_1_lt, std::less<>, 2> homomorphism_priority_queue_t;
-  typedef tpie::priority_queue<homomorphism_tuple_data, tuple_queue_2_lt> homomorphism_data_priority_queue_t;
+  typedef node_priority_queue<tuple, tuple_label, tuple_fst_lt, std::less<>, 2> homomorphism_priority_queue_t;
+  typedef tpie::priority_queue<homomorphism_tuple_data, tuple_snd_lt> homomorphism_data_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions
@@ -111,8 +111,8 @@ namespace adiar
 
       // Merge requests from pq or pq_data
       if (pq.can_pull() && (pq_data.empty() ||
-                              std::min(pq.top().t1, pq.top().t2) <
-                              std::max(pq_data.top().t1, pq_data.top().t2))) {
+                              fst(pq.top().t1, pq.top().t2) <
+                              snd(pq_data.top().t1, pq_data.top().t2))) {
         with_data = false;
         t1 = pq.top().t1;
         t2 = pq.top().t2;
@@ -131,33 +131,12 @@ namespace adiar
       }
 
       // Seek request partially in stream
-      if (with_data) {
-        if (from_1) {
-          while (v2.uid < t2) {
-            v2 = in_nodes_2.pull();
-          }
-        } else {
-          while (v1.uid < t1) {
-            v1 = in_nodes_1.pull();
-          }
-        }
-      } else {
-        if (t1 == t2) {
-          while (v1.uid < t1) {
-            v1 = in_nodes_1.pull();
-          }
-          while (v2.uid < t2) {
-            v2 = in_nodes_2.pull();
-          }
-        } else if (t1 < t2) {
-          while (v1.uid < t1) {
-            v1 = in_nodes_1.pull();
-          }
-        } else {
-          while (v2.uid < t2) {
-            v2 = in_nodes_2.pull();
-          }
-        }
+      ptr_t t_seek = with_data ? snd(t1,t2) : fst(t1,t2);
+      while (v1.uid < t_seek && in_nodes_1.can_pull()) {
+        v1 = in_nodes_1.pull();
+      }
+      while (v2.uid < t_seek && in_nodes_2.can_pull()) {
+        v2 = in_nodes_2.pull();
       }
 
       // Forward information across the layer

--- a/src/adiar/tuple.h
+++ b/src/adiar/tuple.h
@@ -16,9 +16,49 @@ namespace adiar {
     ptr_t data_high;
   };
 
+  struct triple : tuple
+  {
+    ptr_t t3;
+  };
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Ordered access
+  inline ptr_t fst(const ptr_t t1, const ptr_t t2)
+  {
+    return std::min(t1, t2);
+  }
+
+  inline ptr_t fst(const ptr_t t1, const ptr_t t2, const ptr_t t3)
+  {
+    return std::min({t1, t2, t3});
+  }
+
+  inline ptr_t fst(const tuple &t) { return fst(t.t1, t.t2); }
+  inline ptr_t fst(const triple &t) { return fst(t.t1, t.t2, t.t3); }
+
+  inline ptr_t snd(const ptr_t t1, const ptr_t t2)
+  {
+    return std::max(t1, t2);
+  }
+
+  inline ptr_t snd(const ptr_t t1, const ptr_t t2, const ptr_t t3)
+  {
+    return std::max(std::min(t1, t2), std::min(std::max(t1,t2),t3));
+  }
+
+  inline ptr_t snd(const tuple &t) { return snd(t.t1, t.t2); }
+  inline ptr_t snd(const triple &t) { return snd(t.t1, t.t2, t.t3); }
+
+  inline ptr_t trd(const ptr_t t1, const ptr_t t2, const ptr_t t3)
+  {
+    return std::max({t1, t2, t3});
+  }
+
+  inline ptr_t trd(const triple &t) { return trd(t.t1, t.t2, t.t3); }
+
   //////////////////////////////////////////////////////////////////////////////
   // Priority queue functions
-  struct tuple_queue_label
+  struct tuple_label
   {
     label_t label_of(const tuple &t)
     {
@@ -26,21 +66,73 @@ namespace adiar {
     }
   };
 
-  struct tuple_queue_1_lt
+  struct tuple_fst_lt
   {
     bool operator()(const tuple &a, const tuple &b)
     {
-      return std::min(a.t1, a.t2) < std::min(b.t1, b.t2) ||
-        (std::min(a.t1, a.t2) == std::min(b.t1, b.t2) && std::max(a.t1, a.t2) < std::max(b.t1, b.t2));
+      // Sort primarily by the element to be encountered first
+      return fst(a) < fst(b) ||
+        // Group requests to the same tuple together by sorting on the second
+        (fst(a) == fst(b) && snd(a) < snd(b));
     }
   };
 
-  struct tuple_queue_2_lt
+  struct tuple_snd_lt
   {
     bool operator()(const tuple &a, const tuple &b)
     {
-      return std::max(a.t1, a.t2) < std::max(b.t1, b.t2) ||
-            (std::max(a.t1, a.t2) == std::max(b.t1, b.t2) && std::min(a.t1, a.t2) < std::min(b.t1, b.t2));
+      // Sort primarily by the element to be encountered second
+      return snd(a) < snd(b) ||
+         // Group requests to the same tuple together by sorting on the first
+         (snd(a) == snd(b) && fst(a) < fst(b));
+    }
+  };
+
+  struct triple_label
+  {
+    label_t label_of(const triple &t)
+    {
+      return adiar::label_of(fst(t));
+    }
+  };
+
+  struct triple_lt
+  {
+    bool operator()(const triple &a, const triple &b)
+    {
+      return a.t1 < b.t1
+        || (a.t1 == b.t1 && a.t2 < b.t2)
+        || (a.t1 == b.t1 && a.t2 == b.t2 && a.t3 < b.t3);
+    }
+  };
+
+  struct triple_fst_lt
+  {
+    bool operator()(const triple &a, const triple &b)
+    {
+      return fst(a) < fst(b)
+         // If they are tied, sort them coordinate-wise
+         || (fst(a) == fst(b) && triple_lt()(a,b));
+    }
+  };
+
+  struct triple_snd_lt
+  {
+    bool operator()(const triple &a, const triple &b)
+    {
+      return snd(a) < snd(b)
+         // If they are tied, sort them coordinate-wise
+         || (snd(a) == snd(b) && triple_lt()(a,b));
+    }
+  };
+
+  struct triple_trd_lt
+  {
+    bool operator()(const triple &a, const triple &b)
+    {
+      return trd(a) < trd(b)
+         // If they are tied, sort them coordinate-wise
+         || (trd(a) == trd(b) && triple_lt()(a,b));
     }
   };
 }

--- a/test/adiar/bdd/test_if_then_else.cpp
+++ b/test/adiar/bdd/test_if_then_else.cpp
@@ -1,0 +1,1431 @@
+go_bandit([]() {
+    describe("BDD: If-Then-Else", [&]() {
+        // == CREATE BDDs FOR UNIT TESTS ==
+        //             START
+        ptr_t sink_T = create_sink_ptr(true);
+        ptr_t sink_F = create_sink_ptr(false);
+
+        node_file bdd_F;
+        node_file bdd_T;
+        node_file bdd_x0;
+        node_file bdd_not_x0;
+        node_file bdd_x1;
+        node_file bdd_not_x1;
+        node_file bdd_x2;
+        node_file bdd_x0_xor_x1;
+        node_file bdd_x0_xor_x2;
+
+        { // Garbage collect writers to free write-lock
+          node_writer nw_F(bdd_F);
+          nw_F << create_sink(false);
+
+          node_writer nw_T(bdd_T);
+          nw_T << create_sink(true);
+
+          node_writer nw_x0(bdd_x0);
+          nw_x0 << create_node(0,0,sink_F,sink_T);
+
+          node_writer nw_not_x0(bdd_not_x0);
+          nw_not_x0 << create_node(0,0,sink_T,sink_F);
+
+          node_writer nw_x1(bdd_x1);
+          nw_x1 << create_node(1,0,sink_F,sink_T);
+
+          node_writer nw_not_x1(bdd_not_x1);
+          nw_not_x1 << create_node(1,0,sink_T,sink_F);
+
+          node_writer nw_x2(bdd_x2);
+          nw_x2 << create_node(2,0,sink_F,sink_T);
+
+          node_writer nw_x0_xor_x1(bdd_x0_xor_x1);
+          nw_x0_xor_x1 << create_node(1,1,sink_T,sink_F)
+                       << create_node(1,0,sink_F,sink_T)
+                       << create_node(0,0,create_node_uid(1,0),create_node_uid(1,1));
+
+          node_writer nw_x0_xor_x2(bdd_x0_xor_x2);
+          nw_x0_xor_x2 << create_node(2,1,sink_T,sink_F)
+                       << create_node(2,0,sink_F,sink_T)
+                       << create_node(0,0,create_node_uid(2,0),create_node_uid(2,1));
+        }
+
+        //              END
+        // == CREATE BDD FOR UNIT TESTS ==
+
+        // Trivial evaluation by given a sink
+        it("should give back first file on if-true (true ? x0 : x1)", [&]() {
+            __bdd out = bdd_ite(bdd_T, bdd_x0, bdd_x1);
+
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+            AssertThat(out.negate, Is().False());
+          });
+
+        it("should give back first file with negation flag on if-true (true ? ~x0 : (~x0))", [&]() {
+            // Notice, they are equivalent then-and-else cases, but in two
+            // different files.
+            __bdd out = bdd_ite(bdd_T, bdd_not(bdd_x0), bdd_not_x0);
+
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+            AssertThat(out.negate, Is().True());
+          });
+
+        it("should give back second file on if-false (false ? x0 : x1)", [&]() {
+            __bdd out = bdd_ite(bdd_F, bdd_x0, bdd_x1);
+
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+            AssertThat(out.negate, Is().False());
+          });
+
+        it("should give back second file on if-false (false ? (~x1) : ~x1)", [&]() {
+            // Notice, they are equivalent then-and-else cases, but in two
+            // different files.
+            __bdd out = bdd_ite(bdd_F, bdd_not_x1, bdd_not(bdd_x1));
+
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+            AssertThat(out.negate, Is().True());
+          });
+
+        // Trivial inputs with duplicate file inputs
+        it("should return 'then' file if 'else' file is the same [1]", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_x1);
+
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+            AssertThat(out.negate, Is().False());
+          });
+
+        it("should return 'then' file if 'else' file is the same [2]", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x1), bdd_not(bdd_x1));
+
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+            AssertThat(out.negate, Is().True());
+          });
+
+        // Inputs boiling down to an apply
+        it("should create XNOR of x0 and x1 (x0 ? x1 : ~x1) due to same file", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_not(bdd_x1));
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create XNOR of x0 and ~x1 (x0 ? ~x1 : x1) due to same file", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x1), bdd_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create OR of x0 and x1 (x0 ? x0 : x1) due to same file", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x0, bdd_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create AND of x0 (negated) and x1 (x0 ? ~x0 : x1) due to same file", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x0), bdd_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create AND of x0 and x1 (x0 ? x1 : x0) due to same file", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_x0);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create IMPLIES of x0 and x1 (x0 ? x1 : ~x0) due to same file", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_not(bdd_x0));
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create OR of x0 and x1 (x0 ? T : x1)", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_T, bdd_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create AND of x0 (negated) and x1 (x0 ? F : x1)", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_F, bdd_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+        });
+
+        it("should create IMPLIES of x0 and x1 (x0 ? x1 : T)", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_T);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should create AND of x0 and x1 (x0 ? x1 : F)", [&]() {
+            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_F);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        // Inputs that require the cross-product of all three BDDs
+        it("should compute x0 ? ~x1 : x1", [&]() {
+            /*
+                     (x0, ~x1, x1)             ---- x0
+                      /         \
+               (F, Nil, x1)  (T, ~x1, Nil)     ---- x1
+                /        \    /         \
+                F        T    T         F
+
+                The low arc is resolved first, since F < T
+             */
+            __bdd out = bdd_ite(bdd_x0, bdd_not_x1, bdd_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute x1 ? ~x0 : x0", [&]() {
+            /*
+                     (x1, ~x0, x0)          ---- x0
+                      /         \
+                (x1, T, F)  (x1, F, T)      ---- x1
+                 /      \    /      \
+                 F      T    T      F
+
+                The high arc is resolved first, since T > F on the second coordinate
+             */
+            __bdd out = bdd_ite(bdd_x1, bdd_not_x0, bdd_x0);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute x1 ? x0 : ~x0", [&]() {
+            /*
+                     (x1, x0, ~x0)         ---- x0
+                      /         \
+               (x1, F, T)  (x1, T, F)      ---- x1
+                /      \    /       \
+                T      F    F       T
+
+                The low arc is resolved first, since F < T on the second coordinate.
+             */
+            __bdd out = bdd_ite(bdd_x1, bdd_x0, bdd_not_x0);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute ~x2 ? (x0^x1) : ~(x0^x1)", [&]() {
+            // Create an XNOR input where one needs to forward data across the
+            // level once to resolve the request
+            node_file bdd_x0_xnor_x1;
+            {
+              node_writer nw_x0_xnor_x1(bdd_x0_xnor_x1);
+              nw_x0_xnor_x1 << create_node(1,1,sink_T,sink_F)
+                            << create_node(1,0,sink_F,sink_T)
+                            << create_node(0,0,create_node_uid(1,1),create_node_uid(1,0));
+            }
+
+            /*
+                                ((2,0),(0,0),(0,0))                 ---- x0
+                                 /               \
+                      ((2,0),(1,0),(1,1))  ((2,0),(1,1),(1,0))      ---- x1
+                             /   \              /      \
+                            /     \             \ _____/
+                            |      \ ____________X
+                            |       X________     \
+                            |      /         \     \
+                           ((2,0),F,T)      ((2,0),T,F)             ---- x2
+                              / \               / \
+                              F T               T F
+             */
+            __bdd out = bdd_ite(bdd_not(bdd_x2), bdd_x0_xor_x1, bdd_x0_xnor_x1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),(1,0),(1,1))
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),(1,1),(1,0))
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),F,T)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),T,F)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // ((2,0),F,T)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // ((2,0),T,F)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        // == CREATE BIG OBDDs FOR UNIT TESTS ==
+        //                START
+
+        node_file bdd_1;
+        /*                  _1_              ---- x0
+                           /   \
+                           2   3             ---- x1
+                          / \ / \
+                          6  5  4            ---- x2
+                         / \/ \/ \
+                         F T  7  T           ---- x3
+                             / \
+                             F T
+         */
+
+        { // Garbage collect writers to free write-lock
+          node_writer nw_1(bdd_1);
+          nw_1 << create_node(3,0,sink_F,sink_T)                             // 7
+               << create_node(2,2,sink_F,sink_T)                             // 6
+               << create_node(2,1,sink_T,create_node_ptr(3,0))               // 5
+               << create_node(2,0,create_node_ptr(3,0),sink_T)               // 4
+               << create_node(1,1,create_node_ptr(2,1),create_node_ptr(2,0)) // 3
+               << create_node(1,0,create_node_ptr(2,2),create_node_ptr(2,1)) // 2
+               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(1,1)) // 1
+            ;
+        }
+
+        node_file bdd_2;
+        /*                     __1__         ---- x0
+                              /     \
+                            _2_     _3_      ---- x1
+                           /   \   /   \
+                           4   5   6   7     ---- x2
+                          / \ / \ / \ / \
+                          F 8 F 9 T F F T    ---- x3
+                           / \ / \
+                           T F F T
+         */
+
+        { // Garbage collect writers to free write-lock
+          node_writer nw_2(bdd_2);
+          nw_2 << create_node(3,1,sink_F,sink_T)                              // 9
+               << create_node(3,0,sink_T,sink_F)                              // 8
+               << create_node(2,3,sink_F,sink_T)                              // 7
+               << create_node(2,2,sink_T,sink_F)                              // 6
+               << create_node(2,1,sink_F,create_node_ptr(3,1))                // 5
+               << create_node(2,0,sink_F,create_node_ptr(3,0))                // 4
+               << create_node(1,1,create_node_ptr(2,2),create_node_ptr(2,3))  // 3
+               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))  // 2
+               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(1,1))  // 1
+            ;
+        }
+
+        node_file bdd_3;
+       /*                     __1__         ---- x0
+                             /     \
+                           _2_      \       ---- x1
+                          /   \      \
+                          3   4      5      ---- x2
+                         / \ / \    / \
+                         T F F 6    F T     ---- x3
+                              / \
+                              F T
+        */
+
+        { // Garbage collect writers to free write-lock
+          node_writer nw_3(bdd_3);
+          nw_3 << create_node(3,0,sink_F,sink_T)                             // 6
+               << create_node(2,2,sink_F,sink_T)                             // 5
+               << create_node(2,1,sink_F,create_node_ptr(3,0))               // 4
+               << create_node(2,0,sink_T,sink_F)                             // 3
+               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1)) // 2
+               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,2)) // 1
+            ;
+        }
+
+        node_file bdd_4;
+        /*                     __1__         ---- x0
+                              /     \
+                            _2_      \       ---- x1
+                           /   \      \
+                           4   5      3      ---- x2
+                          / \ / \    / \
+                          6 T F 7    T F     ---- x3
+                         / \   / \
+                         T F   F T
+        */
+        { // Garbage collect writers to free write-lock
+          node_writer nw_4(bdd_4);
+          nw_4 << create_node(3,1,sink_F,sink_T)                             // 7
+               << create_node(3,0,sink_T,sink_F)                             // 6
+               << create_node(2,2,sink_F,create_node_ptr(3,1))               // 5
+               << create_node(2,1,create_node_ptr(3,0),sink_T)               // 4
+               << create_node(2,0,sink_T,sink_F)                             // 3
+               << create_node(1,0,create_node_ptr(2,1),create_node_ptr(2,2)) // 2
+               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,0)) // 1
+            ;
+        }
+
+        node_file bdd_5;
+        /*                     __1__         ---- x0
+                              /     \
+                            _2_      \       ---- x1
+                           /   \      \
+                           5   3      4      ---- x2
+                          / \ / \    / \
+                          F 6 T F    F T     ---- x3
+                           / \
+                           T F
+        */
+        { // Garbage collect writers to free write-lock
+          node_writer nw_5(bdd_5);
+          nw_5 << create_node(3,0,sink_T,sink_F)                             // 6
+               << create_node(2,2,sink_F,create_node_ptr(3,0))               // 5
+               << create_node(2,1,sink_F,sink_T)                             // 4
+               << create_node(2,0,sink_T,sink_F)                             // 3
+               << create_node(1,0,create_node_ptr(2,2),create_node_ptr(2,0)) // 2
+               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,1)) // 1
+            ;
+        }
+
+        node_file bdd_6;
+        /*                          1         ---- x0
+                                   / \
+                                   F _2_      ---- x1
+                                    /   \
+                                    3   4     ---- x2
+                                   / \ / \
+                                   F T T F
+
+        */
+        { // Garbage collect writers to free write-lock
+          node_writer nw_6(bdd_6);
+          nw_6 << create_node(2,1,sink_T,sink_F)
+               << create_node(2,0,sink_F,sink_T)
+               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))
+               << create_node(0,0,sink_F,create_node_ptr(1,0))
+            ;
+        }
+
+        node_file bdd_not_6;
+         /*                         1         ---- x0
+                                   / \
+                                   T _2_      ---- x1
+                                    /   \
+                                    3   4     ---- x2
+                                   / \ / \
+                                   T F F T
+
+        */
+        { // Garbage collect writers to free write-lock
+          node_writer nw_not_6(bdd_not_6);
+          nw_not_6 << create_node(2,1,sink_F,sink_T)
+                   << create_node(2,0,sink_T,sink_F)
+                   << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))
+                   << create_node(0,0,sink_T,create_node_ptr(1,0))
+            ;
+        }
+
+        //                 END
+        // == CREATE BIG OBDDs FOR UNIT TESTS ==
+
+        it("should compute x3 ? (x1 & x2) : bdd_1", [&]() {
+            node_file bdd_x3;
+            /*
+                     1     ---- x3
+                    / \
+                    F T
+             */
+            {
+              node_writer nw_x3(bdd_x3);
+              nw_x3 << create_node(3,0,sink_F,sink_T);
+            }
+
+            node_file bdd_x1_and_x2;
+            /*
+                     1     ---- x1
+                    / \
+                    F 2    ---- x2
+                     / \
+                     F T
+             */
+            {
+              node_writer nw_x1_and_x2(bdd_x1_and_x2);
+              nw_x1_and_x2 << create_node(2,1,sink_F,sink_T)
+                           << create_node(1,0,sink_F,create_node_ptr(2,1));
+            }
+
+            /*
+                                        (1,1,1)                          ---- x0
+                             ____________/   \___________
+                            /                            \
+                         (1,1,2)                      (1,1,3)            ---- x1
+                      ____/   \____                ____/   \____
+                     /             \              /             \
+                  (1,F,6)       (1,2,5)       (1,F,5)        (1,2,4)     ---- x2
+                   /   \         /   \         /   \          /   \
+                   F    \       /     \       /     \        /    T
+                         \     /       \     /       \_______\
+                          \___/________ \ __/                 \
+                           \             \                     \
+                         (1,F,T)       (1,T,7)              (1,F,7)      ---- x3
+                          /   \         /   \                /   \
+                          T   F         F   T                F   F
+
+              The drawing above is in-order for all but x2 and x3 where the
+              order actually is.
+
+                            (1,2,4), (1,2,5), (1,F,5), (1,F,6)   ---- x2
+
+                                 (1,F,7), (1,F,T), (1,T,7)       ---- x3
+
+              No forwarding across the level is needed due to the ids
+
+              Furthermore notice, the F sink of (1,F,6) is due to both the
+              'then' and the 'else' case agree, so we don't recurse to obtain
+              the value of the 'if' conditional. The same goes for T sink of
+              (1,2,4).
+             */
+            __bdd out = bdd_ite(bdd_x3, bdd_x1_and_x2, bdd_1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,1,2)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,1,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,4)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,5)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,5)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,2) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,6)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,3) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,7)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,T)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,1) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), create_node_ptr(3,1) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), create_node_ptr(3,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,T,7)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,2) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,2,4)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,6)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,7)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,T)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,T,7)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute bdd_3 ? bdd_4 : bdd_5", [&]() {
+            /*
+                                     (1,1,1)               ---- x0
+                                 ______/ \______
+                                /               \
+                            (2,2,2)              \         ---- x1
+                         ____/   \____            \
+                        /             \            \
+                     (3,4,5)        (4,5,3)     (5,3,4)    ---- x2
+                       \ /           /   \       /   \
+                        X            T   |       F   F
+                      _/ \_              |
+                     /     \             |
+                 (T,6,_) (F,_,6)      (6,7,F)              ---- x3
+                  /   \   /   \        /   \
+                  T   F   T   F        F   T
+
+                Forwarding for each node is needed for level x2 twice, but due
+                to the ids involved one will only obtain the nodes in question
+                one at a time.
+
+                The level for x3 equires to forward (6) in (6,7,F) once.
+             */
+
+            __bdd out = bdd_ite(bdd_3, bdd_4, bdd_5);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,5)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (4,5,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (5,3,4)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,2) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,6)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (T,6,_)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (6,7,F)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,2) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5,3)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (5,3,4)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,6)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (T,6,_)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (6,7,F)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute bdd_6 ? x0^x2 : bdd_not_6", [&]() {
+            /*                bdd_x0_xor_x2
+                    _1_       ---- x1
+                   /   \
+                   2   3      ---- x2
+                  / \ / \
+                  F T T F
+            */
+
+            /*
+                                 (1,1,1)               ---- x0
+                                  /   \
+                                  T  (2,2,3)           ---- x1
+                                      /   \
+                                 (3,3,3) (4,4,3)       ---- x2
+                                  /   \   /   \
+                                  T   F   T   T
+
+                 On level x2 forwarding happens for (3,3,3) with the two nodes
+                 3, 3 from the if-case and else-case. Both of these are
+                 encountered simultaneously, so they are in one-go forwarded.
+             */
+
+            __bdd out = bdd_ite(bdd_6, bdd_x0_xor_x2, bdd_not_6);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (4,4,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,1,1)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,3)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,4,3)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+
+        it("should compute bdd_not_6 ? bdd_6 : x0^x2", [&]() {
+            /*                bdd_x0_xor_x2
+                    _1_       ---- x1
+                   /   \
+                   2   3      ---- x2
+                  / \ / \
+                  F T T F
+            */
+
+            /*
+                                 (1,1,1)               ---- x0
+                                  /   \
+                                  F  (2,3,2)           ---- x1
+                                      /   \
+                                 (3,3,3) (4,3,4)       ---- x2
+                                  /   \   /   \
+                                  F   F   T   F
+
+                 On level x2 forwarding happens for (3,3,3) with the two nodes
+                 3, 3 from the if-case and then-case. Both of these are
+                 encountered simultaneously, so they are in one-go forwarded.
+             */
+
+            __bdd out = bdd_ite(bdd_not_6, bdd_6, bdd_x0_xor_x2);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,3,2)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (4,3,4)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,1,1)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,3)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,4,3)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute ~(x0^x2) ? ~x2 : bdd_1", [&]() {
+            node_file bdd_x0_xnor_x2;
+            /*
+                                _1_
+                               /   \
+                               3   2
+                              / \ / \
+                              T F F T
+             */
+            {
+              node_writer nw_x0_xnor_x2(bdd_x0_xnor_x2);
+              nw_x0_xnor_x2 << create_node(2,1,sink_T,sink_F)                              // 3
+                            << create_node(2,0,sink_F,sink_T)                              // 2
+                            << create_node(0,0,create_node_uid(2,1),create_node_uid(2,0)); // 1
+            }
+
+            /*
+                                 (1,1,1)                   ---- x0
+                           _______/   \________
+                          /                    \
+                      (3,1,2)                (2,1,3)       ---- x1
+                       /   \                  /   \
+                  (3,1,6) (3,1,5)        (2,1,5) (2,1,4)   ---- x2
+                   /   \   /   \          /   \   /   \
+                   T   T   T    \         T   F  /    F
+                                 \______   _____/
+                                        \ /
+                                      (F,_,7)              ---- x3
+                                       /   \
+                                       F   T
+
+               Where the order for x2 is:
+
+                      (2,1,4), (2,1,5), (3,1,5), (3,1,6)
+
+               and (2,1,4) is resolved without forwarding, (2,1,5) forwards two
+               elements (2 and 1) at once, and finally (3,1,5) and (3,1,6)
+               require forwarding two elements one at a time.
+             */
+
+            __bdd out = bdd_ite(bdd_x0_xnor_x2, bdd_not(bdd_x2), bdd_1);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,2)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,4)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,5)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,5)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,6)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,3) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,7)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,1,4)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,1,5)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,1,5)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,1,6)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,7)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+
+        it("should compute (x1^x2) ? bdd_1 : bdd_2", [&]() {
+            node_file bdd_x1_xor_x2_2;
+            /*
+                            _1_      ---- x1
+                           /   \
+                           3   2     ---- x2
+                          / \ / \
+                          F T T F
+             */
+
+            {
+              node_writer nw_x1_xor_x2(bdd_x1_xor_x2_2);
+              nw_x1_xor_x2 << create_node(2,1,sink_F,sink_T)                              // 3
+                           << create_node(2,0,sink_T,sink_F)                              // 2
+                           << create_node(1,0,create_node_uid(2,1),create_node_uid(2,0)); // 1
+            }
+
+            /*
+                                 (1,1,1)                   ---- x0
+                            ______/   \_____
+                           /                \
+                      (1,2,2)             (1,3,3)          ---- x1
+                       /   \               /   \
+                  (3,6,4) (2,5,5)     (3,5,6) (2,4,7)      ---- x2  Order of resolvement:
+                   /   \   /   \       /   \   /   \                    (2,5,5)**, (3,5,6)***, (3,6,4)*, (2,4,7)*
+                   F   T   T   |       T    \ /    T                        *   Forwarding two item once
+                               |             |                              **  Forwarding one item once
+                               |             |                              *** Forwarding one item twice
+                            (F,_,9)       (T,7,_)          ---- x3
+                             /   \         /   \                    (To reproduce: look at actual ids and sorting)
+                             F   T         F   T
+             */
+            __bdd out = bdd_ite(bdd_x1_xor_x2_2, bdd_1, bdd_2);
+
+            node_arc_test_stream node_arcs(out);
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,2)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (1,3,3)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,5,5)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,5,6)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (3,6,4)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,2) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (2,4,7)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,3) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (T,7,_)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
+            AssertThat(node_arcs.can_pull(), Is().True());
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), create_node_ptr(3,0) }));
+
+            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,9)
+            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
+
+            AssertThat(node_arcs.can_pull(), Is().False());
+
+            sink_arc_test_stream sink_arcs(out);
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,5,5)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,5,6)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,6,4)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,4,7)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (T,7,_)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,9)
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
+            AssertThat(sink_arcs.can_pull(), Is().True());
+            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
+
+            AssertThat(sink_arcs.can_pull(), Is().False());
+
+            meta_test_stream<arc_t, 2> meta(out);
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+
+            AssertThat(meta.can_pull(), Is().True());
+            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+
+            AssertThat(meta.can_pull(), Is().False());
+          });
+      });
+  });

--- a/test/adiar/test_data.cpp
+++ b/test/adiar/test_data.cpp
@@ -218,6 +218,17 @@ go_bandit([]() {
                                Is().EqualTo(create_sink_ptr(true)));
                   });
 
+                it("EQUIV (flags)", [&]() {
+                    AssertThat(equiv_op(flag(create_sink_ptr(true)), create_sink_ptr(true)),
+                               Is().EqualTo(create_sink_ptr(true)));
+                    AssertThat(equiv_op(create_sink_ptr(true), flag(create_sink_ptr(false))),
+                               Is().EqualTo(create_sink_ptr(false)));
+                    AssertThat(equiv_op(flag(create_sink_ptr(false)), create_sink_ptr(true)),
+                               Is().EqualTo(create_sink_ptr(false)));
+                    AssertThat(equiv_op(create_sink_ptr(false), flag(create_sink_ptr(false))),
+                               Is().EqualTo(create_sink_ptr(true)));
+                  });
+
                 it("DIFF", [&]() {
                     AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(true)),
                                Is().EqualTo(create_sink_ptr(false)));

--- a/test/adiar/test_data.cpp
+++ b/test/adiar/test_data.cpp
@@ -185,6 +185,17 @@ go_bandit([]() {
                                Is().EqualTo(create_sink_ptr(false)));
                   });
 
+                it("XNOR", [&]() {
+                    AssertThat(xnor_op(create_sink_ptr(true), create_sink_ptr(true)),
+                               Is().EqualTo(create_sink_ptr(true)));
+                    AssertThat(xnor_op(create_sink_ptr(true), create_sink_ptr(false)),
+                               Is().EqualTo(create_sink_ptr(false)));
+                    AssertThat(xnor_op(create_sink_ptr(false), create_sink_ptr(true)),
+                               Is().EqualTo(create_sink_ptr(false)));
+                    AssertThat(xnor_op(create_sink_ptr(false), create_sink_ptr(false)),
+                               Is().EqualTo(create_sink_ptr(true)));
+                  });
+
                 it("IMP", [&]() {
                     AssertThat(imp_op(create_sink_ptr(true), create_sink_ptr(true)),
                                Is().EqualTo(create_sink_ptr(true)));

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -62,6 +62,7 @@ public:
 #include "adiar/bdd/test_build.cpp"
 #include "adiar/bdd/test_count.cpp"
 #include "adiar/bdd/test_evaluate.cpp"
+#include "adiar/bdd/test_if_then_else.cpp"
 #include "adiar/bdd/test_negate.cpp"
 #include "adiar/bdd/test_quantify.cpp"
 #include "adiar/bdd/test_restrict.cpp"


### PR DESCRIPTION
Pull request includes

- [x] Implement O(sort(N₁ N₂ N₃ )) If-Then-Else algorithm
   - [x] O(1) I/Os used if conditional is a sink. 
   - [x] O(sort(N₁ N₂)) I/Os used for cases of only two files or a sink by delegating to `bdd_apply`, which is much faster.
   - [x] O((N₁ + N₂ + N₃ ) / B) I/Os for the simple case of 'if' above the disjunct levels of 'then' and 'else'. Then, merely the three BDDs are zipped together and reduction is skipped.
- [x] Major clean up in other product-construction algorithms: `homomorphism`, `apply`, `quantification`
- [x] XNOR operator
- [x] Equiv operator bugfix

This includes changes to the Apply algorithm, so of course, we should double-check the code cleanup has not resulted in a slowdown. The following numbers were obtained on _Alice_ with 4GiB of memory available to Adiar and the numbers obtained row-by-row left-to-right.

| `master` | `bdd/if-then-else` |
|------------|-------------------------|
| 708 s     | 686 s                   |
| 696 s     | 692 s                   |
| 702 s     | 686 s                   |
| 700 s     | 680 s                   |
| 696 s     | 681 s                   |
| 698 s     | 682 s                   |
|               |                             |
| 700        | 684,5 s                |

Which alludes to possibly even a 2% performance increase. Definitely, it isn't a performance decrease that is for sure.