### PR TITLE
Increase label size to 24 bits

### DIFF
--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -21,7 +21,7 @@ namespace adiar {
   //////////////////////////////////////////////////////////////////////////////
   ///  COMMON VARIABLES AND GENERAL PTR
   //////////////////////////////////////////////////////////////////////////////
-  const uint8_t  LABEL_BITS = 16;
+  const uint8_t  LABEL_BITS = 24;
   const uint64_t MAX_LABEL  = (1ull << LABEL_BITS) - 1;
 
   const uint8_t  ID_BITS = 64 - 2 - LABEL_BITS;


### PR DESCRIPTION
This does decrease the maximal size of each layer to 6 TiB of nodes. But, that does seem to be a realistic upper bound on the size of each layer anyway, since you already need 6 TiB above and 6 TiB below to make something so big.

This closes #64 .