### PR TITLE
Add settings to omit failure due to removal of covered code

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,13 @@
 fixes:
-  - "adiar/::"  # remove adiar/ in path
+  - "adiar/::" 
+
+coverage:
+  precision: 3
+  round: nearest
+  range: "80...95"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
The pull request #108 was failing due to moving _covered_ code into a macro, which was not counted anymore. Yet, the lines in all four expansion of the macro were not accounted for. So, since that is a net total decrease in the number of covered lines, that decreased the coverage by 0.03%. It seems wrong to me, that GitHub should outright make it into an error. If it drops by more than 1%, then something bad probably happened, but otherwise, I'd rather judge myself based on the posted report.