### PR TITLE
Clean up in documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 project (adiar
-  VERSION 0.2
+  VERSION 1.0
   DESCRIPTION "Adiar, an external memory decision diagram library"
   LANGUAGES CXX
 )

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -57,9 +57,9 @@ here.
 
 ### Coudert's and Madre's Restrict
 The current _Restrict_ algorithm is the basic algorithm of Bryant, but one has
-been proposed in [[Coudert90](README.md#references)] that is very different and
-may be used in Verification. They also proposed algorithms with the name
-_Constrain_ and _Expand_.
+been proposed in [[Coudert90](#references)] that is very different and may be
+used in Verification. They also proposed algorithms with the name _Constrain_
+and _Expand_.
 
 ### Variable reordering
 Currently, _Adiar_ only uses a static ordering of the variables, but since the
@@ -78,7 +78,7 @@ the original variable reordering algorithms.
 Currently, we do not support complement edges, though one can expect about a 7%
 factor decrease in the size of the OBDD from using said technique. In the
 recursive algorithms, one can even expect a factor two decrease in the
-algorithms execution time [[Brace90](README.md#references)].
+algorithms execution time [[Brace90](#references)].
 
 
 ## Extensions
@@ -87,14 +87,13 @@ algorithms execution time [[Brace90](README.md#references)].
 One can easily extend the proposed representation of sink nodes to encompass
 non-boolean values, such as integers or floats. Thereby, the algorithms
 immediately yield an I/O efficient implementation of the _Multi-Terminal Binary
-Decision Diagrams_ (MTBDD) of [[Fujita97](README.md#references)].
+Decision Diagrams_ (MTBDD) of [[Fujita97](#references)].
 
 ### Zero-suppressed Decision Diagrams
-A Zero-suppressed Decision Diagram
-([ZDD](https://en.wikipedia.org/wiki/Zero-suppressed_decision_diagram)) is a
-binary decision diagram, which is very compresed when representing sparse sets
-of bit vectors. This has been shown to be great for solving NP-Complete problems
-and symbolic model checking algorithms on sparse sets of states.
+A Zero-suppressed Decision Diagram [[Minato93](#references)] is a binary
+decision diagram, which is very compresed when representing sparse sets of bit
+vectors. This has been shown to be great for solving NP-Complete problems and
+symbolic model checking algorithms on sparse sets of states.
 
 To achieve this, ZDDs make use of a different reduction rule than BDDs to do so.
 So, to implement them we need to:
@@ -106,15 +105,15 @@ So, to implement them we need to:
 ### Multi-valued Decision Diagrams
 By solely using an edge-based representation of the data-structure one can also
 implement a _Multi-valued Decision Diagram_ (MDD) of
-[[Kam98](README.md#references)]. This allows one to succinctly encode a function
+[[Kam98](#references)]. This allows one to succinctly encode a function
 from a non-boolean domain. Switching to the edge-based representation will lead
 to rewriting almost all algorithms, but we may look into recreating the _List
-Decision Diagrams_ of [[Dijk16](README.md#references)] to circumvent this.
+Decision Diagrams_ of [[Dijk16](#references)] to circumvent this.
 
 ### Free Boolean Decision Diagrams
 One can remove the restriction of ordering the decision diagram to then
 potentially compress the data structure even more. These Free Binary Decision
-Diagrams (FBDD) of [[Meinel94](README.md#references)] may also be possible to
+Diagrams (FBDD) of [[Meinel94](#references)] may also be possible to
 implement in the setting of Time-forward processing used here.
 
 
@@ -131,12 +130,12 @@ possible to exploit this with a radix sort for an _O(N)_ time complexity, though
 maybe one will not gain too much due to the _O(sort(N))_ I/O lower bound.
 
 ### From _recursive_ algorithm to _time-forward processing_ and back again
-Most implementations, such as the ones in [[Brace90,
-Dijk16](README.md#references)], make use of a _unique node table_, which is a
-hash-table in which all BDDs exist. This has the benefit of allowing one to
-reuse common subtrees across BDDs (which saves space linear in the number of
-concurrent BDDs in use) and the recursive algorithms run _2_ or even _4_ times
-faster than the current algorithms (when they don't outgrow the main memory).
+Most implementations, such as the ones in [[Brace90, Dijk16](#references)], make
+use of a _unique node table_, which is a hash-table in which all BDDs exist.
+This has the benefit of allowing one to reuse common subtrees across BDDs (which
+saves space linear in the number of concurrent BDDs in use) and the recursive
+algorithms run _2_ or even _4_ times faster than the current algorithms (when
+they don't outgrow the main memory).
 
 _TPIE_ provides a hash table, so one can look into one of the following two
 
@@ -153,3 +152,39 @@ Based on the memory usage I've witnessed during benchmarking, I think the first
 option is the most promising.
 
 See also the discussion in issue [#98](https://github.com/SSoelvsten/adiar/issues/98)
+
+## References
+
+- [[Brace90](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=114826)]
+  Karl S. Brace, Richard L. Rudell, and Randal E. Bryant. “_Efficient
+  implementation of a BDD package_”. In: _27th ACM/IEEE Design Automation
+  Conference_. pp. 40 – 45 (1990)
+
+- [[Coudert90](http://www.ocoudert.com/papers/pdf/iccad90.pdf)]
+  Olivier Coudert and Jean Christophe Madre. “_A Unified Framework for the
+  Formal verification of sequential circuits_”. In: _Computer-Aided Design /
+  IEEE International Conference_. (1990)
+
+- [[Dijk16](https://link.springer.com/content/pdf/10.1007/s10009-016-0433-2.pdf)]
+  Tom van Dijk, Jaco van de Pol. “_Sylvan: multi-core framework for decision
+  diagrams_”. In: _International Journal on Software Tools for Technology
+  Transfer_. (2016)
+
+- [[Fujita97](https://link.springer.com/article/10.1023/A:1008647823331#citeas)]
+  M. Fujita, P.C. McGeer, J.C.-Y. Yang . “_Multi-Terminal Binary Decision
+  Diagrams: An Efficient Data Structure for Matrix Representation_”. In: _Formal
+  Methods in System Design_. (2012)
+
+- [Kam98]
+  Timothy Kam, Tiziano Villa, Robert K. Brayton, and L. Sangiovanni-vincentelli
+  Alberto. “_Multi-valued decision diagrams: Theory and applications_”. In:
+  _Multiple- Valued Logic 4.1_ (1998)
+
+- [Meinel94]
+  J. Gergov and C. Meinel. “_Efficient analysis and manipulation of OBDDs can
+  be extended to FBDDs_”. (1994)
+
+- [Minato93](https://dl.acm.org/doi/pdf/10.1145/157485.164890)
+  S. Minato. “_Zero-suppressed BDDs for set manipulation in combinatorial
+  problems_”. In: _DAC '93: Proceedings of the 30th international Design
+  Automation Conference_ (1993)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ repository recursively, then run the following command
 git submodule update --init --recursive
 ```
 
-One also needs a _C++_ compiler of ones choice. All development has currently
-been with the _gcc_ compiler, so we cannot guarantee other compilers will work
-out-of-the-box. The project is built with _CMake_ and has dependencies on the
-_Boost Library_. On Ubuntu 18+ you can obtain all these with the following
-commands.
+One also needs a _C++_ compiler that supports the _17_ standard. All development
+has currently been with the _gcc_ compiler, so we cannot guarantee other
+compilers will work out-of-the-box. The project is built with _CMake_ and has
+dependencies on the _Boost Library_. On Ubuntu 20+ you can obtain all these with
+the following commands.
 
 ```bash
 apt install g++ cmake libboost-all-dev

--- a/README.md
+++ b/README.md
@@ -12,34 +12,24 @@ far outgrow the memory limit of the given machine.
 
 **Table of Contents**
 
-- [Installation](#installation)
-    - [Dependencies](#dependencies)
 - [Documentation](#documentation)
+- [Dependencies](#dependencies)
 - [Usage](#usage)
+    - [Makefile targets](#makefile-targets)
     - [Examples and benchmarks](#examples-and-benchmarks)
 - [Future Work](#future-work)
 - [Credits](#credits)
 - [License](#license)
 - [References](#references)
 
-## Installation
 
-The _Adiar_ library is built with _CMake_. After having cloned this repository locally
-and installed its dependencies (cf. [Dependencies](#dependencies)), then include the
-project as a _subdirectory_ within your _CMakeLists.txt_
-```cmake
-add_subdirectory (<path/to/adiar> adiar)
-```
-Then you link up your executable.
-```cmake
-add_executable(<target> <source>)
-target_link_libraries(<target> adiar)
-set_target_properties(<target> PROPERTIES CXX_STANDARD 17)
-```
-The last line is only necessary if the `CXX_STANDARD` has not been set project-wide to
-_17_ or higher.
+## Documentation
+The documentation is provided as a collection of Markdown files in the
+[/docs](https://github.com/SSoelvsten/adiar/tree/master/docs) folder, which are also
+viewable on [Github Pages](https://ssoelvsten.github.io/adiar/).
 
-### Dependencies
+
+## Dependencies
 The implementation is dependant on the the following external libraries
 
 - [TPIE](https://github.com/thomasmoelhave/tpie):
@@ -78,11 +68,10 @@ apt install graphviz
 ```
 
 
-## Documentation
-We provide the documentation on the following [Github Pages](https://ssoelvsten.github.io/adiar/).
-
-
 ## Usage
+
+### Makefile targets
+
 The project is build with _CMake_, though for convenience I have simplified the
 _CMake_ interactions to a single _Makefile_ which works on a local machine. This
 has only been tested on _Ubuntu 18.04 LTS_ and _20.04 LTS_.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![codecov](https://codecov.io/gh/SSoelvsten/adiar/branch/master/graph/badge.svg?token=106RCIR4DJ)](https://codecov.io/gh/SSoelvsten/adiar)
 [![examples](https://github.com/SSoelvsten/adiar/workflows/examples/badge.svg?branch=master)](/actions?query=workflow%3Aexamples)
 
-Following up on the work of [[Arge96](#references)], this implementation of
-a BDD library makes use of _Time-Forward Processing_ to improve the I/O
-complexity of BDD Manipulation to achieve efficient manipulation of BDDs, that
-far outgrow the memory limit of the given machine.
+Following up on the work of [[Arge96](#references)], this implementation of a
+BDD [[Bryant86](#references)] library makes use of _Time-Forward Processing_ to
+improve the I/O complexity of BDD Manipulation to achieve efficient manipulation
+of BDDs, that far outgrow the memory limit of the given machine.
 
 **Table of Contents**
 
@@ -36,7 +36,7 @@ The implementation is dependant on the the following external libraries
   Framework for implementation of I/O efficient algorithms. It directly provides
   sorting algorithms and a priotity queue. Both are much faster than the
   algorithms in the _C++_ standard library
-  [[Mølhave12](#references)].
+  [[Vengroff94,Mølhave12](#references)].
 
 - [Bandit](https://github.com/banditcpp/bandit):
   Writing and running unit tests
@@ -158,68 +158,15 @@ The software and documentation files in this repository are provided under the
 - [[Arge96](https://tidsskrift.dk/brics/article/view/20010/17643)]
   Lars Arge. “_The I/O-complexity of Ordered Binary-Decision Diagram
   Manipulation_”. In: _Efficient External-Memory Data Structures and
-  Applications_. 1996
-
-- [[Arge05](https://imada.sdu.dk/~rolf/Edu/DM808/F08/Handouts/ionotes.pdf)]
-  Lars Arge. “_External Memory Geometric Data Structures_”. In: _External Memory
-  Geometric Data Structures_. 2005
-
-- [[Arge10](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=5470440)]
-  Lars Arge, Michael T. Goodrich, Nodari Sitchinava. “_Parallel external memory
-  graph algorithms_”. In: _2010 IEEE International Symposium on Parallel
-  Distributed Processing (IPDPS)_. 2010
-
-- [[Arge17](https://pure.au.dk/portal/files/119531804/paper_bigdata17_camera.pdf)]
-  Lars Arge, Mathias Rav, Svend C. Svendsen, Jakob Truelsen. “_External Memory
-  Pipelining Made Easy With TPIE_”. In: _2017 IEEE International Conference on
-  Big Data_. 2017
-
-- [[Brace90](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=114826)]
-  Karl S. Brace, Richard L. Rudell, and Randal E. Bryant. “_Efficient
-  implementation of a BDD package_”. In: _27th ACM/IEEE Design Automation
-  Conference_. 1990, pp. 40 – 45.
+  Applications_. (1996)
 
 - [[Bryant86](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1676819)]
   Randal E. Bryant. “_Graph-Based Algorithms for Boolean Function Manipulation_”.
   In: _IEEE Transactions on Computers_. (1986)
 
-- [[Coudert90](http://www.ocoudert.com/papers/pdf/iccad90.pdf)]
-  Olivier Coudert and Jean Christophe Madre. “_A Unified Framework for the
-  Formal verification of sequential circuits_”. In: _Computer-Aided Design /
-  IEEE International Conference_. (1990)
-
-- [[Dijk16](https://link.springer.com/content/pdf/10.1007/s10009-016-0433-2.pdf)]
-  Tom van Dijk, Jaco van de Pol. “_Sylvan: multi-core framework for decision
-  diagrams_”. In: _International Journal on Software Tools for Technology
-  Transfer_. 2016
-
-- [[Fujita97](https://link.springer.com/article/10.1023/A:1008647823331#citeas)]
-  M. Fujita, P.C. McGeer, J.C.-Y. Yang . “_Multi-Terminal Binary Decision
-  Diagrams: An Efficient Data Structure for Matrix Representation_”. In: _Formal
-  Methods in System Design_. 2012
-
-- [Kam98]
-  Timothy Kam, Tiziano Villa, Robert K. Brayton, and L. Sangiovanni-vincentelli
-  Alberto. “_Multi-valued decision diagrams: Theory and applications_”. In:
-  _Multiple- Valued Logic 4.1_ 1998
-
-- [[Kunkle10](https://dl.acm.org/doi/abs/10.1145/1837210.1837222)] Daniel
-  Kunkle, Vlad Slavici, Gene Cooperman. “_Parallel Disk-Based Computation for
-  Large, Monolithic Binary Decision Diagrams_”. In: _PASCO '10: Proceedings of
-  the 4th International Workshop on Parallel and Symbolic Computation_. 2010
-
-- [Meinel94]
-  J. Gergov and C. Meinel. “_Efficient analysis and manipulation of OBDDs can
-  be extended to FBDDs_”. 1994
-
 - [[Mølhave12](https://dl.acm.org/doi/pdf/10.1145/2367574.2367579)]
-  Thomas Mølhave. “_Using TPIE for Processing Massive Data Sets in C++_”. 2012
+  Thomas Mølhave. “_Using TPIE for Processing Massive Data Sets in C++_”. (2012)
 
-- [[Sanders01](https://dl.acm.org/doi/pdf/10.1145/351827.384249)]
-  Peter Sanders. “_Fast Priority Queues for Cached Memory_”. In: _J. Exp.
-  Algorithmics 5_. 2001
-
-- [[Sitchinava12](https://dl.acm.org/doi/pdf/10.1145/2312005.2312046)]
-  Nodari Sitchinava, Norbert Zeh. “_A Parallel Buffer Tree_”. In: _Proceedings
-  of the Twenty-Fourth Annual ACM Symposium on Parallelism in Algorithms and
-  Architectures_. 2012
+- [[Vengroff94](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.38.3030)]
+  D.E. Vengroff. “_A transparent parallel I/O environment_”. In: _In Proc. 1994
+  DAGS Symposium on Parallel Computation_. pp. 117–134 (1994)

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: 404
+permalink: /404.md
+nav_exclude: true
+search_exclude: true
+---
+
+# Page not found
+
+The page you requested could not be found. Try using the navigation on the left
+or the search bar at the top to find what you are looking for.
+{: .fs-6 .fw-300 }
+
+[Site's home page](/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,61 @@
+################################################################################
+#                                 Site settings
+################################################################################
 title: Adiar
-description: An External Memory Decision Diagram Library
+description: An External Memory Binary Decision Diagram Library
 
-theme: jekyll-theme-slate
+# Prior theme choice
+# theme: jekyll-theme-slate
+
+################################################################################
+#                                 Just-the-docs
+################################################################################
+remote_theme: pmarsceill/just-the-docs
+
+# Enable or disable the site search
+# Supports true (default) or false
+search_enabled: true
+search:
+  # Split pages into sections that can be searched individually
+  heading_level: 1
+  # Maximum amount of previews per search result
+  previews: 5
+  # Maximum amount of words to display before a matched word in the preview
+  preview_words_before: 3
+  # Maximum amount of words to display after a matched word in the preview
+  preview_words_after: 3
+  # Set the search token separator
+  tokenizer_separator: /[\s/]+/
+  # Display the relative url in search results
+  rel_url: true
+  # Enable or disable the search button that appears in the bottom right corner
+  # of every page Supports true or false
+  button: false
+
+# Enable or disable heading anchors
+heading_anchors: true
+
+# Aux links for the upper right navigation
+aux_links:
+  "Adiar on GitHub":
+    - "//github.com/ssoelvsten/adiar"
+
+# Makes Aux links open in a new tab. Default is false
+aux_links_new_tab: true
+
+# Sort order for navigation links
+nav_sort: case_insensitive
+
+
+# Back to top link
+back_to_top: true
+back_to_top_text: "Back to top"
+
+footer_content: "The source and the documentation is distributed under the <a href=\"https://github.com/ssoelvsten/adiar/tree/master/LICENSE.md\">MIT license.</a>"
+
+# Footer last edited timestamp
+last_edit_timestamp: true
+last_edit_time_format: "%b %e %Y at %I:%M %p"
+
+# Color scheme
+color_scheme: light

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -1,23 +1,29 @@
+---
+layout: default
+title: BDD
+nav_order: 2
+description: "The BDD data structure and the functions provided to manipulate it"
+permalink: /bdd
+---
+
 # BDD
+{: no_toc}
 
 A Binary Decision Diagram (BDD) represents a boolean function
-
 <p style="text-align: center;">
   {0,1}ⁿ → {0,1}
 </p>
-
 The `bdd` class takes care of reference counting and optimal garbage collection
 of the underlying files (c.f. [Files](/core.md#files)). To ensure the most
 disk-space is available, try to garbage collect the `bdd` objects as quickly as
 possible and/or minimise the number of lvalues of said type.
+{: .fs-6 .fw-300 }
 
-**Table of Contents**
+## Table of contents
+{: .no_toc .text-delta }
 
-- [Basic Constructors](#basic-constructors)
-- [Basic Manipulation](#basic-manipulation)
-- [Counting Operations](#counting-operations)
-- [Other Functions](#other-functions)
-- [DOT Output](#dot-output)
+1. TOC
+{:toc}
 
 ## Basic Constructors
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -1,21 +1,25 @@
+---
+layout: default
+title: Core
+nav_order: 3
+description: "The underlying data structures nodes and files"
+permalink: /core
+---
+
 # Core
 
 Most of the features of _Adiar_ can be used without knowing anything about how
-the underlying algorithms work. Yet, few BDD functions involve a `label_file` or
-`assignment_file` (c.f. [Assignment and Labels](#assignments-and-labels)), and
-especially an efficient manual construction of a well structured BDDs will
-require direct interaction with the underlying data types and files.
+the underlying algorithms work. Yet, a few BDD functions involve a `label_file`
+or `assignment_file`. Furthermore, an efficient manual construction of a well
+structured BDDs will require direct interaction with the underlying data types
+and files.
+{: .fs-6 .fw-300 }
 
-**Table of Contents**
+## Table of contents
+{: .no_toc .text-delta }
 
-- [Data types](#data-types)
-    - [Nodes and Pointers](#nodes-and-pointers)
-    - [Assignments](#assignments)
-- [Files](#files)
-    - [Nodes](#nodes)
-        - [Node Stream](#node-stream)
-        - [Node Writer](#node-writer)
-    - [Assignments and Labels](#assignments-and-labels)
+1. TOC
+{:toc}
 
 ## Data types
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Examples
+nav_order: 4
+description: "Complete examples that cover how to use Adiar"
+has_children: true
+---
+
+# Examples
+{: .no_toc }
+
+The following examples are provide an introduction to using all aspects of
+_Adiar_.
+{: .fs-6 .fw-300 }

--- a/docs/examples/queens.md
+++ b/docs/examples/queens.md
@@ -1,22 +1,28 @@
-# N-Queens Example
+---
+layout: default
+title: Queens
+nav_order: 1
+parent: Examples
+description: "N-Queens example"
+permalink: examples/queens
+---
+
+# N-Queens
+{: .no_toc }
 
 Remember that the N-Queens problem is as follows
-
 > Given N, then in how many ways can N queens be placed on an N x N chess board
 > without threatening each other?
+We will solve this problem using BDDs. The final program is available in
+[example/queens.cpp](//github.com/SSoelvsten/adiar/blob/master/example/queens.cpp).
 
-In the following we will solve this problem using BDDs. The final program is
-available in
-[example/n_queens.cpp](https://github.com/SSoelvsten/adiar/blob/master/example/n_queens.cpp).
+{: .fs-6 .fw-300 }
 
-**Table of Contents**
+## Table of contents
+{: .no_toc .text-delta }
 
-- [Computing the set of all solutions](#computing-the-set-of-all-solutions)
-    - [Explicitly constructing base cases](#explicitly-constructing-base-cases)
-    - [Constructing the entire board](#constructing-the-entire-board)
-    - [Counting the number of solutions](#counting-the-number-of-solutions)
-- [Printing each solution](#printing-each-solution)
-
+1. TOC
+{:toc}
 
 ## Computing the set of all solutions
 
@@ -360,3 +366,4 @@ void n_queens_print_solution(std::vector<uint64_t>& assignment)
   std::cout << "\n";
 }
 ```
+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,10 +1,18 @@
+---
+layout: default
+title: Getting Started
+nav_order: 2
+description: "The dependencies and installation of _Adiar_ and how to initialise it."
+---
+
 # Getting Started
+{: no_toc}
 
-**Table of Contents**
+## Table of contents
+{: .no_toc .text-delta }
 
-- [Dependencies](#dependencies)
-- [Building with CMake](#building-with-cmake)
-- [Usage](#usage)
+1. TOC
+{:toc}
 
 ## Dependencies
 One needs a C++ compiler of ones choice that supports the _17_ standard. All

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,10 +7,10 @@
 - [Usage](#usage)
 
 ## Dependencies
-One needs a C++ compiler of ones choice. All development has been done with the
-gcc compiler, so we recommend one to use the same. The project also has
-dependencies on the TPIE library, which itself has dependencies on the Boost
-Library.
+One needs a C++ compiler of ones choice that supports the _17_ standard. All
+development has been done with the gcc compiler, so we recommend one to use the
+same. The project also has dependencies on the TPIE library, which itself has
+dependencies on the Boost Library.
 
 On Ubuntu 18+ you can obtain these dependencies with the following command.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,37 +1,53 @@
-_Adiar_ is a library for manipulating Decision Diagrams even when these grow
-bigger than the memory one has available. To achieve this, all operations are
-not implemented recursively with a global memoization table, but instead they
-are created as streaming algorithms that exploit the sorting of the graph on
-disk to delay recursion with Time-Forward Processing.
+---
+layout: default
+title: Home
+nav_order: 1
+description: "An External Memory Binary Decision Diagram Library"
+permalink: /
+---
 
-**Maintainer:** [Steffan Sølvsten](mailto:soelvsten@cs.au.dk)
+# Adiar
 
-# Table of Content
+{: .fs-9 }
 
-- [**Getting Started**](/getting_started.md)
-  - [**Dependencies**](/getting_started.md#dependencies)
-  - [**Building with CMake**](/getting_started.md#building-with-cmake)
-  - [**Usage**](/getting_started.md#usage)
+_Adiar_ is a library for manipulating Binary Decision Diagrams even when these
+grow bigger than the memory one has available. To achieve this, all operations
+are not implemented recursively with a global memoization table, but instead
+they are created as streaming algorithms that exploit the sorting of the graph
+on disk to delay recursion with Time-Forward Processing.
+{: .fs-6 .fw-300 }
 
-- [**BDD**](/bdd.md)
-  - [**Basic Constructurs**](/bdd.md#basic-constructors)
-  - [**Basic Manipulation**](/bdd.md#basic-manipulation)
-  - [**Counting Operations**](/bdd.md#counting-operations)
-  - [**Other Functions**](/bdd.md#other-functions)
-  - [**DOT Output**](/bdd.md#dot-output)
+[View it on GitHub](https://github.com/ssoelvsten/adiar){: .btn .fs-5 .mb-4 .mb-md-0 }
 
-- [**Core**](/core.md)
-    - [**Data types**](/core.md#data-types)
-        - [**Nodes and Pointers**](/core.md#nodes-and-pointers)
-        - [**Assignments**](/core.md#assignments)
-    - [**Files**](/core.md#files)
-        - [**Nodes**](/core.md#nodes)
-        - [**Assignments and Labels**](/core.md#assignments-and-labels)
+---
 
-- [**N-Queens Example**](/example.md)
-  - [**Computing the set of all solutions**](/example.md#computing-the-set-of-all-solutions)
-  - [**Printing each solution**](/example.md#printing-each-solution)
+## Table of Content
 
-# License
-The software and documentation files in this repository are provided under the
+- [**Getting Started**](/getting_started)
+
+  Dependencies and installation of _Adiar_ and how to initialise it in your C++
+  program.
+
+- [**BDD**](/bdd)
+
+  The _BDD_ data structure and the functions provided to manipulate it.
+
+- [**Core**](/core)
+
+  The underlying data structures _nodes_ and _files_ that you would use to
+  quickly construct larger Decision Diagrams programmatically.
+
+- [**Examples**](/examples)
+
+  Examples that cover the functionalities of _Adiar_.
+
+  - [**N-Queens**](/examples/queens)
+
+
+## About the project
+
+**Current Maintainer:** [Steffan Sølvsten](mailto:soelvsten@cs.au.dk)
+
+### License
+The software and documentation files in this repository are distributed under the
 [MIT License](https://github.com/SSoelvsten/adiar/blob/master/LICENSE.md).

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -169,10 +169,7 @@ namespace adiar {
     return create_sink_ptr(!value_of(sink2) || value_of(sink1));
   };
 
-  const bool_op equiv_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
-  {
-    return create_sink_ptr(unflag(sink1) == unflag(sink2));
-  };
+  const bool_op equiv_op = xnor_op;
 
   const bool_op diff_op = [](ptr_t sink1, ptr_t sink2) -> ptr_t
   {


### PR DESCRIPTION
Covers
- Minor code optimisation by making `equiv_op` into an alias for `xnor_op` which uses fewer bit-operations
- Update `README.md` and remove anything covered in the documentaiton
- Set the _CMake_ version to the soon to-be version of 1.0
- Switch Github Pages theme to [just-the-docs](https://github.com/pmarsceill/just-the-docs)