### PR TITLE
Feature/level size

### DIFF
--- a/docs/core/files.md
+++ b/docs/core/files.md
@@ -55,7 +55,7 @@ functions
 ### Node Writer
 
 To follow the ordering in a `node_file` one has to write nodes bottom-up and in
-reverse for each layer with respect to the _id_. One can write nodes to the file
+reverse for each level with respect to the _id_. One can write nodes to the file
 by use of the `node_writer` object, that can be constructed in two ways.
 
 - `node_writer()`

--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -12,7 +12,7 @@ set(HEADERS
   file_stream.h
   file_writer.h
   homomorphism.h
-  priority_queue.h
+  levelized_priority_queue.h
   reduce.h
   tuple.h
   union.h
@@ -42,7 +42,7 @@ set(SOURCES
   file_stream.cpp
   file_writer.cpp
   homomorphism.cpp
-  priority_queue.cpp
+  levelized_priority_queue.cpp
   reduce.cpp
 
   # bdd files

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -146,10 +146,10 @@ namespace adiar
     apply_resolve_request(appD, aw, op, flag(out_uid), high1, high2);
 
     // Process nodes in topological order of both BDDs
-    while (appD.can_pull() || appD.has_next_layer() || !appD_data.empty()) {
+    while (appD.can_pull() || appD.has_next_level() || !appD_data.empty()) {
       if (!appD.can_pull() && appD_data.empty()) {
-        appD.setup_next_layer();
-        out_label = appD.current_layer();
+        appD.setup_next_level();
+        out_label = appD.current_level();
         aw.unsafe_push(meta_t { out_label });
         out_id = 0;
       }

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -5,7 +5,7 @@
 
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 #include <adiar/tuple.h>
 
 #include <adiar/bdd/build.h>
@@ -27,7 +27,7 @@ namespace adiar
     ptr_t source;
   };
 
-  typedef node_priority_queue<apply_tuple, tuple_label, tuple_fst_lt, std::less<>, 2> apply_priority_queue_t;
+  typedef levelized_node_priority_queue<apply_tuple, tuple_label, tuple_fst_lt, std::less<>, 2> apply_priority_queue_t;
   typedef tpie::priority_queue<apply_tuple_data, tuple_snd_lt> apply_data_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -134,23 +134,22 @@ namespace adiar
     label_t out_label = label_of(fst(v1.uid, v2.uid));
     id_t out_id = 0;
 
-    aw.unsafe_push(meta_t { out_label });
-
     ptr_t low1, low2, high1, high2;
     apply_init_request(in_nodes_1, v1, out_label, low1, high1);
     apply_init_request(in_nodes_2, v2, out_label, low2, high2);
 
     // Shortcut the root
-    uid_t out_uid = create_node_uid(out_label, out_id);
+    uid_t out_uid = create_node_uid(out_label, out_id++);
     apply_resolve_request(apply_pq_1, aw, op, out_uid, low1, low2);
     apply_resolve_request(apply_pq_1, aw, op, flag(out_uid), high1, high2);
 
     // Process nodes in topological order of both BDDs
     while (apply_pq_1.can_pull() || apply_pq_1.has_next_level() || !apply_pq_2.empty()) {
       if (!apply_pq_1.can_pull() && apply_pq_2.empty()) {
+        aw.unsafe_push(create_meta(out_label, out_id));
+
         apply_pq_1.setup_next_level();
         out_label = apply_pq_1.current_level();
-        aw.unsafe_push(meta_t { out_label });
         out_id = 0;
       }
 
@@ -253,6 +252,9 @@ namespace adiar
         }
       }
     }
+
+    // Push the level of the very last iteration
+    aw.unsafe_push(create_meta(out_label, out_id));
 
     return out_arcs;
   }

--- a/src/adiar/bdd/assignment.cpp
+++ b/src/adiar/bdd/assignment.cpp
@@ -26,7 +26,7 @@ namespace adiar
     meta_stream<node_t,1> in_meta(f);
 
     bool pick_high = pick_next(v_curr);
-    aw << create_assignment(in_meta.pull().label, pick_high);
+    aw << create_assignment(label_of(in_meta.pull()), pick_high);
 
     ptr_t v_next = pick_high ? v_curr.high : v_curr.low;
 
@@ -35,19 +35,19 @@ namespace adiar
       while (v_curr.uid < v_next) { v_curr = in_nodes.pull(); }
 
       // set default to all skipped levels
-      while (in_meta.peek().label < label_of(v_next)) {
-        aw << create_assignment(in_meta.pull().label, default_for_skipped_var);
+      while (label_of(in_meta.peek()) < label_of(v_next)) {
+        aw << create_assignment(label_of(in_meta.pull()), default_for_skipped_var);
       }
 
       pick_high = pick_next(v_curr);
-      aw << create_assignment(in_meta.pull().label, pick_high);
+      aw << create_assignment(label_of(in_meta.pull()), pick_high);
 
       v_next = pick_high ? v_curr.high : v_curr.low;
     }
 
     // Set the remaining levels to the default value
     while (in_meta.can_pull()) {
-      aw << create_assignment(in_meta.pull().label, default_for_skipped_var);
+      aw << create_assignment(label_of(in_meta.pull()), default_for_skipped_var);
     }
     return out;
   }

--- a/src/adiar/bdd/bdd.h
+++ b/src/adiar/bdd/bdd.h
@@ -75,7 +75,7 @@ namespace adiar {
               typename LabelExt,
               typename TComparator, typename LabelComparator,
               size_t MetaStreams, size_t Buckets>
-    friend class priority_queue;
+    friend class levelized_priority_queue;
 
     // |- functions
     friend bdd bdd_not(const bdd&);

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -38,7 +38,7 @@ namespace adiar {
     node_file nf;
     node_writer nw(nf);
     nw.unsafe_push(create_node(label, 0, create_sink_ptr(false), create_sink_ptr(true)));
-    nw.unsafe_push(meta_t {label});
+    nw.unsafe_push(create_meta(label,1u));
     return nf;
   }
 
@@ -73,7 +73,7 @@ namespace adiar {
       high = next_node.uid;
 
       nw.unsafe_push(next_node);
-      nw.unsafe_push(meta_t {next_label});
+      nw.unsafe_push(create_meta(next_label,1u));
     }
 
     return nf;
@@ -103,7 +103,7 @@ namespace adiar {
       low = next_node.uid;
 
       nw.unsafe_push(next_node);
-      nw.unsafe_push(meta_t {next_label});
+      nw.unsafe_push(create_meta(next_label,1u));
     }
 
     return nf;
@@ -137,7 +137,8 @@ namespace adiar {
     do {
       // Start with the maximal number the accumulated value can be at
       // up to this label.
-      id_t curr_id = std::min(curr_label - min_label, threshold);
+      id_t max_id = std::min(curr_label - min_label, threshold);
+      id_t curr_id = max_id;
 
       // How small has the accumulated sum up to this point to be, such
       // that it is still possible to reach threshold before max_label?
@@ -165,7 +166,7 @@ namespace adiar {
         nw.unsafe_push(adiar::create_node(curr_label, curr_id, low, high));
 
       } while (curr_id-- > min_id);
-      nw.unsafe_push(meta_t {curr_label});
+      nw.unsafe_push(create_meta(curr_label, (max_id - min_id) + 1));
     } while (curr_label-- > min_label);
 
     return nf;

--- a/src/adiar/bdd/count.cpp
+++ b/src/adiar/bdd/count.cpp
@@ -180,10 +180,10 @@ namespace adiar
     while (ns.can_pull()) {
       node_t n = ns.pull();
 
-      if (partial_sums.current_layer() != label_of(n)) {
-        partial_sums.setup_next_layer();
+      if (partial_sums.current_level() != label_of(n)) {
+        partial_sums.setup_next_level();
       }
-      adiar_debug(partial_sums.current_layer() == label_of(n),
+      adiar_debug(partial_sums.current_level() == label_of(n),
                   "Priority queue is out-of-sync with node stream");
       adiar_debug(partial_sums.can_pull() && partial_sums.top().uid == n.uid,
                   "Priority queue is out-of-sync with node stream");

--- a/src/adiar/bdd/count.cpp
+++ b/src/adiar/bdd/count.cpp
@@ -4,7 +4,7 @@
 #include "count.h"
 
 #include <adiar/file_stream.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 #include <adiar/reduce.h>
 
 #include <adiar/assert.h>
@@ -56,7 +56,7 @@ namespace adiar
   };
 
   template <typename T>
-  using count_priority_queue_t = node_priority_queue<T, count_queue_label, count_queue_lt<T>>;
+  using count_priority_queue_t = levelized_node_priority_queue<T, count_queue_label, count_queue_lt<T>>;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -5,7 +5,7 @@
 
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 #include <adiar/tuple.h>
 
 #include <adiar/bdd/build.h>
@@ -44,7 +44,7 @@ namespace adiar
   };
 
 
-  typedef node_priority_queue<ite_triple, triple_label, triple_fst_lt, std::less<>, 3> ite_priority_queue_1_t;
+  typedef levelized_node_priority_queue<ite_triple, triple_label, triple_fst_lt, std::less<>, 3> ite_priority_queue_1_t;
   typedef tpie::priority_queue<ite_triple_data_1, triple_snd_lt> ite_priority_queue_2_t;
   typedef tpie::priority_queue<ite_triple_data_2, triple_trd_lt> ite_priority_queue_3_t;
 

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -261,10 +261,10 @@ namespace adiar
     ite_resolve_request(ite_pq_1, aw, flag(out_uid), high_if, high_then, high_else);
 
     // Process all nodes in topological order of both BDDs
-    while (ite_pq_1.can_pull() || ite_pq_1.has_next_layer() || !ite_pq_2.empty() || !ite_pq_3.empty()) {
+    while (ite_pq_1.can_pull() || ite_pq_1.has_next_level() || !ite_pq_2.empty() || !ite_pq_3.empty()) {
       if (!ite_pq_1.can_pull() && ite_pq_2.empty() && ite_pq_3.empty()) {
-        ite_pq_1.setup_next_layer();
-        out_label = ite_pq_1.current_layer();
+        ite_pq_1.setup_next_level();
+        out_label = ite_pq_1.current_level();
         aw.unsafe_push(meta_t { out_label });
         out_id = 0;
       }

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -145,7 +145,7 @@ namespace adiar
     }
   }
 
-  inline void ite_resolve_request(ite_priority_queue_1_t &ite_pq,
+  inline void ite_resolve_request(ite_priority_queue_1_t &ite_pq_1,
                                   arc_writer &aw,
                                   ptr_t source, ptr_t r_if, ptr_t r_then, ptr_t r_else)
   {
@@ -169,7 +169,7 @@ namespace adiar
       // => ~NIL => r_if is a sink with the 'false' value
       aw.unsafe_push_sink(arc_t { source, r_else });
     } else {
-      ite_pq.push({ r_if, r_then, r_else, source });
+      ite_pq_1.push({ r_if, r_then, r_else, source });
     }
   }
 

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -188,10 +188,10 @@ namespace adiar
       }
     }
 
-    while(quantD.can_pull() || quantD.has_next_layer() || !quantD_data.empty()) {
+    while(quantD.can_pull() || quantD.has_next_level() || !quantD_data.empty()) {
       if (!quantD.can_pull() && quantD_data.empty()) {
-        quantD.setup_next_layer();
-        out_label = quantD.current_layer();
+        quantD.setup_next_level();
+        out_label = quantD.current_level();
         out_id = 0;
 
         if (out_label != label) {
@@ -230,7 +230,7 @@ namespace adiar
         v = in_nodes.pull();
       }
 
-      // Forward information of v.uid == t1 across the layer if needed
+      // Forward information of v.uid == t1 across the level if needed
       if (!with_data && !is_nil(t2) && !is_sink(t2) && label_of(t1) == label_of(t2)) {
         quantD_data.push({ t1, t2, v.low, v.high, source });
 

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -5,7 +5,7 @@
 
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 #include <adiar/tuple.h>
 #include <adiar/util.h>
 
@@ -52,7 +52,7 @@ namespace adiar
     }
   };
 
-  typedef node_priority_queue<quantify_tuple, tuple_label, quantify_1_lt> quantify_priority_queue_t;
+  typedef levelized_node_priority_queue<quantify_tuple, tuple_label, quantify_1_lt> quantify_priority_queue_t;
   typedef tpie::priority_queue<quantify_tuple_data, quantify_2_lt> quantify_data_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd/restrict.cpp
+++ b/src/adiar/bdd/restrict.cpp
@@ -8,7 +8,7 @@
 
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 #include <adiar/reduce.h>
 #include <adiar/util.h>
 
@@ -30,7 +30,7 @@ namespace adiar
     }
   };
 
-  typedef node_priority_queue<arc_t, restrict_queue_label, restrict_queue_lt> restrict_priority_queue_t;
+  typedef levelized_node_priority_queue<arc_t, restrict_queue_label, restrict_queue_lt> restrict_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions

--- a/src/adiar/bdd/restrict.cpp
+++ b/src/adiar/bdd/restrict.cpp
@@ -87,17 +87,17 @@ namespace adiar
 
     // process all to-be-visited nodes in topological order
     while(!resD.empty()) {
-      if (resD.empty_layer()) {
-        resD.setup_next_layer();
+      if (resD.empty_level()) {
+        resD.setup_next_level();
 
         // seek assignment
-        while(as.can_pull() && resD.current_layer() > a.label) {
+        while(as.can_pull() && resD.current_level() > a.label) {
           a = as.pull();
         }
 
-        // will any nodes in this layer be outputted?
-        if (a.label != resD.current_layer()) {
-          aw.unsafe_push(meta_t { resD.current_layer() });
+        // will any nodes in this level be outputted?
+        if (a.label != resD.current_level()) {
+          aw.unsafe_push(meta_t { resD.current_level() });
         }
       }
 

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -419,9 +419,26 @@ namespace adiar {
     return m;
   }
 
+  meta_t create_meta(label_t label, size_t level_size)
+  {
+    // we reuse the same logic above to store both values in 64 bits. This is
+    // only to save on memory, not actually to do anything else.
+    return { create_node_uid(label,level_size) };
+  }
+
+  label_t label_of(const meta_t& m)
+  {
+    return label_of(m.level_info);
+  }
+
+  size_t size_of(const meta_t& m)
+  {
+    return id_of(m.level_info);
+  }
+
   bool operator== (const meta& a, const meta& b)
   {
-    return a.label == b.label;
+    return a.level_info == b.level_info;
   }
 
   bool operator!= (const meta& a, const meta& b)

--- a/src/adiar/data.h
+++ b/src/adiar/data.h
@@ -59,7 +59,7 @@ namespace adiar {
   ///  - L : the variable label. For nodes n1 and n2 with n1.label < n2.label,
   ///        we guarantee that n1 comes before n2 in the stream reading order.
   ///
-  ///  - I : a unique identifier for the nodes on the same layer. For nodes n1
+  ///  - I : a unique identifier for the nodes on the same level. For nodes n1
   ///        and n2 with n1.label == n2.label but n1.id < n2.id, we guarantee
   ///        that n1 comes before n2 in the stream reading order.
   ///
@@ -68,7 +68,7 @@ namespace adiar {
   ///   | S | LLLLLLLLLLLLLLLLLLLL | IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII | F |
   ///
   /// That means that nodes are to be sorted first by their label, and then by
-  /// their layer-identifier.
+  /// their level-identifier.
   //////////////////////////////////////////////////////////////////////////////
   extern const uint64_t MAX_LABEL;
   extern const uint64_t MAX_ID;

--- a/src/adiar/data.h
+++ b/src/adiar/data.h
@@ -271,17 +271,22 @@ namespace adiar {
 
 
   //////////////////////////////////////////////////////////////////////////////
-  /// Our layer-aware priority queue needs to manage which bucket corresponds to
+  /// Our level-aware priority queue needs to manage which bucket corresponds to
   /// which label to place things correctly or in an internal priority queue for
   /// bucket overflows. To make things more efficient, we require the use of
   /// meta information about the input BDD streams.
   //////////////////////////////////////////////////////////////////////////////
   struct meta
   {
-    label_t label;
+    uint64_t level_info;
   };
 
   typedef meta meta_t;
+
+  meta_t create_meta(label_t label, size_t level_size);
+
+  label_t label_of(const meta_t &m);
+  size_t size_of(const meta_t &m);
 
   meta operator! (const meta& m);
 

--- a/src/adiar/homomorphism.cpp
+++ b/src/adiar/homomorphism.cpp
@@ -48,7 +48,7 @@ namespace adiar
     }
 
     // Are they trivially not the same thing, since they have different number
-    // of layers (in the _meta_file) or have different number of nodes (in
+    // of levels (in the _meta_file) or have different number of nodes (in
     // _files[0])
     if (f1._file_ptr -> _meta_file.size() != f2._file_ptr -> _meta_file.size()
         || f1._file_ptr -> _files[0].size() != f2._file_ptr -> _files[0].size()) {
@@ -95,9 +95,9 @@ namespace adiar
 
     homomorphism_data_priority_queue_t pq_data(calc_tpie_pq_factor(available_memory / 4));
 
-    while (pq.can_pull() || pq.has_next_layer() || !pq_data.empty()) {
+    while (pq.can_pull() || pq.has_next_level() || !pq_data.empty()) {
       if (!pq.can_pull() && pq_data.empty()) {
-        pq.setup_next_layer();
+        pq.setup_next_level();
       }
 
       ptr_t t1, t2;
@@ -133,7 +133,7 @@ namespace adiar
         v2 = in_nodes_2.pull();
       }
 
-      // Forward information across the layer
+      // Forward information across the level
       bool from_1 = fst(t1,t2) == t1;
 
       if (!with_data

--- a/src/adiar/homomorphism.cpp
+++ b/src/adiar/homomorphism.cpp
@@ -47,12 +47,30 @@ namespace adiar
       return negate1 == negate2;
     }
 
-    // Are they trivially not the same thing, since they have different number
-    // of levels (in the _meta_file) or have different number of nodes (in
-    // _files[0])
-    if (f1._file_ptr -> _meta_file.size() != f2._file_ptr -> _meta_file.size()
-        || f1._file_ptr -> _files[0].size() != f2._file_ptr -> _files[0].size()) {
+    // Are they trivially not the same, since they have different number of
+    // nodes (in _files[0])?
+    if (f1._file_ptr -> _files[0].size() != f2._file_ptr -> _files[0].size()) {
       return false;
+    }
+
+    // Are they trivially not the same, since they have different number of
+    // levels (in the _meta_file)?
+    if (f1._file_ptr -> _meta_file.size() != f2._file_ptr -> _meta_file.size()) {
+      return false;
+    }
+
+    // Are they trivially not the same, since the labels or the size of each
+    // level does not match?
+    { // Create new scope to garbage collect the two meta_streams early
+      meta_stream<node_t, 1> in_meta_1(f1);
+      meta_stream<node_t, 1> in_meta_2(f2);
+
+      while (in_meta_1.can_pull()) {
+        adiar_debug(in_meta_2.can_pull(), "meta files are same size");
+        if (in_meta_1.pull() != in_meta_2.pull()) {
+          return false;
+        }
+      }
     }
 
     node_stream<> in_nodes_1(f1, negate1);

--- a/src/adiar/homomorphism.cpp
+++ b/src/adiar/homomorphism.cpp
@@ -4,14 +4,14 @@
 #include "homomorphism.h"
 
 #include <adiar/file_stream.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 #include <adiar/tuple.h>
 
 namespace adiar
 {
   //////////////////////////////////////////////////////////////////////////////
   // Data structures
-  typedef node_priority_queue<tuple, tuple_label, tuple_fst_lt, std::less<>, 2> homomorphism_priority_queue_t;
+  typedef levelized_node_priority_queue<tuple, tuple_label, tuple_fst_lt, std::less<>, 2> homomorphism_priority_queue_t;
   typedef tpie::priority_queue<tuple_data, tuple_snd_lt> homomorphism_data_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/levelized_priority_queue.cpp
+++ b/src/adiar/levelized_priority_queue.cpp
@@ -3,7 +3,7 @@
 
 #include <tpie/priority_queue.h> // imports tpie::consecutive_memory_available
 
-#include "priority_queue.h"
+#include "levelized_priority_queue.h"
 
 namespace adiar {
   tpie::dummy_progress_indicator pq_tpie_progress_indicator { };

--- a/src/adiar/levelized_priority_queue.h
+++ b/src/adiar/levelized_priority_queue.h
@@ -202,7 +202,8 @@ namespace adiar {
             typename LabelExt,
             typename TComparator = std::less<T>, typename LabelComparator = std::less<label_t>,
             size_t MetaStreams = 1u, size_t Buckets = ADIAR_PQ_BUCKETS>
-  class priority_queue : private LabelExt, private pq_label_mgr<File_T, Files, LabelComparator, MetaStreams>
+  class levelized_priority_queue
+    : private LabelExt, private pq_label_mgr<File_T, Files, LabelComparator, MetaStreams>
   {
     static_assert(0 < MetaStreams, "At least one meta stream should be provided");
 
@@ -236,7 +237,7 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     // Constructors
   private:
-    priority_queue(tpie::memory_size_type memory_given)
+    levelized_priority_queue(tpie::memory_size_type memory_given)
       : _overflow_queue(calc_tpie_pq_factor(m_overflow_queue<T, Buckets>(memory_given)))
     {
       _memory_occupied_by_meta = tpie::get_memory_manager().available();
@@ -253,9 +254,9 @@ namespace adiar {
     /// \param memory_given    Total amount of memory the priority queue should
     ///                        take.
     ////////////////////////////////////////////////////////////////////////////
-    priority_queue(const meta_file<File_T, Files> (& files) [MetaStreams],
+    levelized_priority_queue(const meta_file<File_T, Files> (& files) [MetaStreams],
                    tpie::memory_size_type memory_given)
-      : priority_queue(memory_given)
+      : levelized_priority_queue(memory_given)
     {
       for (const meta_file<File_T, Files> &f : files) {
         label_mgr::hook_meta_stream(f);
@@ -263,20 +264,20 @@ namespace adiar {
       setup_buckets();
     }
 
-    priority_queue(const bdd (& bdds) [MetaStreams],
+    levelized_priority_queue(const bdd (& bdds) [MetaStreams],
                    tpie::memory_size_type memory_given)
-      : priority_queue(memory_given) {
+      : levelized_priority_queue(memory_given) {
       for (const bdd& b : bdds) {
         label_mgr::hook_meta_stream(b.file);
       }
       setup_buckets();
     }
 
-    priority_queue(const meta_file<File_T, Files> (& files) [MetaStreams])
-    : priority_queue(files, tpie::get_memory_manager().available()) { }
+    levelized_priority_queue(const meta_file<File_T, Files> (& files) [MetaStreams])
+    : levelized_priority_queue(files, tpie::get_memory_manager().available()) { }
 
-    priority_queue(const bdd (& bdds) [MetaStreams])
-    : priority_queue(bdds, tpie::get_memory_manager().available()) { }
+    levelized_priority_queue(const bdd (& bdds) [MetaStreams])
+    : levelized_priority_queue(bdds, tpie::get_memory_manager().available()) { }
 
     ////////////////////////////////////////////////////////////////////////////
     // Private constructor methods
@@ -648,12 +649,12 @@ namespace adiar {
   template <typename T, typename LabelExt,
             typename TComparator = std::less<T>, typename LabelComparator = std::less<label_t>,
             size_t MetaStreams = 1u, size_t Buckets = ADIAR_PQ_BUCKETS>
-  using node_priority_queue = priority_queue<node_t, 1u, T, LabelExt, TComparator, LabelComparator, MetaStreams, Buckets>;
+  using levelized_node_priority_queue = levelized_priority_queue<node_t, 1u, T, LabelExt, TComparator, LabelComparator, MetaStreams, Buckets>;
 
   template <typename T, typename LabelExt,
             typename TComparator = std::less<T>, typename LabelComparator = std::less<label_t>,
             size_t MetaStreams = 1u, size_t Buckets = ADIAR_PQ_BUCKETS>
-  using arc_priority_queue = priority_queue<arc_t, 2u, T, LabelExt, TComparator, LabelComparator, MetaStreams, Buckets>;
+  using levelized_arc_priority_queue = levelized_priority_queue<arc_t, 2u, T, LabelExt, TComparator, LabelComparator, MetaStreams, Buckets>;
 }
 
 #endif // ADIAR_PRIORITY_QUEUE_H

--- a/src/adiar/levelized_priority_queue.h
+++ b/src/adiar/levelized_priority_queue.h
@@ -131,9 +131,9 @@ namespace adiar {
       label_t min_label = 0u;
       for (size_t idx = 0u; idx < MetaStreams; idx++) {
         if (_meta_streams[idx] -> can_pull()
-            && (!has_min_label || _comparator(_meta_streams[idx] -> peek().label, min_label))) {
+            && (!has_min_label || _comparator(label_of(_meta_streams[idx] -> peek()), min_label))) {
           has_min_label = true;
-          min_label = _meta_streams[idx] -> peek().label;
+          min_label = label_of(_meta_streams[idx] -> peek());
         }
       }
 
@@ -151,7 +151,7 @@ namespace adiar {
 
       // pull from all with min_label
       for (const std::unique_ptr<meta_stream<File_T, Files>> &meta_stream : _meta_streams) {
-        if (meta_stream -> can_pull() && meta_stream -> peek().label == min_label) {
+        if (meta_stream -> can_pull() && label_of(meta_stream -> peek()) == min_label) {
           meta_stream -> pull();
         }
       }

--- a/src/adiar/priority_queue.h
+++ b/src/adiar/priority_queue.h
@@ -170,8 +170,8 @@ namespace adiar {
 
   //////////////////////////////////////////////////////////////////////////////
   /// A levelized priority queue for BDDs capable of improving performance by
-  /// placing all pushed queue elements in buckets for the specific layer and
-  /// then sorting it when one finally arrives at said layer. If no bucket
+  /// placing all pushed queue elements in buckets for the specific level and
+  /// then sorting it when one finally arrives at said level. If no bucket
   /// exists for said request, then they will be placed in a priority queue to
   /// then be merged with the current bucket.
   ///
@@ -333,9 +333,9 @@ namespace adiar {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief The label of the current layer
+    /// \brief The label of the current level
     ////////////////////////////////////////////////////////////////////////////
-    label_t current_layer() const
+    label_t current_level() const
     {
       if constexpr (Buckets == 0) {
         return _buckets_label[0];
@@ -345,12 +345,12 @@ namespace adiar {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Is there any non-empty layer?
+    /// \brief Is there any non-empty level?
     ////////////////////////////////////////////////////////////////////////////
-    bool has_next_layer()
+    bool has_next_level()
     {
       if constexpr (Buckets == 0) {
-        adiar_debug (!can_pull(), "Cannot check on next layer on empty queue");
+        adiar_debug (!can_pull(), "Cannot check on next level on empty queue");
 
         return !_overflow_queue.empty();
       }
@@ -371,7 +371,7 @@ namespace adiar {
     /// and the queue forwards to the first non-empty level. This is the default
     /// behaviour.
     ////////////////////////////////////////////////////////////////////////////
-    void setup_next_layer(label_t stop_label = MAX_LABEL+1)
+    void setup_next_level(label_t stop_label = MAX_LABEL+1)
     {
       bool has_stop_label = stop_label <= MAX_LABEL;
 
@@ -379,10 +379,10 @@ namespace adiar {
                  "Stop label is prior to the current front bucket");
 
       adiar_debug(!can_pull(),
-                 "Layer is non-empty");
+                 "Level is non-empty");
 
-      adiar_debug(has_next_layer(),
-                 "Has no next layer to go to");
+      adiar_debug(has_next_level(),
+                 "Has no next level to go to");
 
       if constexpr (Buckets == 0) {
         while (LabelExt::label_of(_overflow_queue.top()) != _buckets_label[0]
@@ -423,7 +423,7 @@ namespace adiar {
         adiar_debug(!has_stop_label || _label_comparator(front_bucket_label(), stop_label),
                     "stop label should be strictly ahead of current level");
         adiar_debug(!_overflow_queue.empty(),
-                    "'has_next_layer()' implied non-empty queue, all buckets turned out to be empty, yet overflow queue is also.");
+                    "'has_next_level()' implied non-empty queue, all buckets turned out to be empty, yet overflow queue is also.");
 
         label_t pq_label = LabelExt::label_of(_overflow_queue.top());
         stop_label = has_stop_label && _label_comparator(stop_label, pq_label)
@@ -451,7 +451,7 @@ namespace adiar {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Are there more elements on the current layer?
+    /// \brief Are there more elements on the current level?
     ////////////////////////////////////////////////////////////////////////////
     bool can_pull()
     {
@@ -471,19 +471,19 @@ namespace adiar {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Is the current layer of elements empty?
+    /// \brief Is the current level of elements empty?
     ////////////////////////////////////////////////////////////////////////////
-    bool empty_layer()
+    bool empty_level()
     {
       return !can_pull();
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Peek the next element on the current layer
+    /// \brief Peek the next element on the current level
     ////////////////////////////////////////////////////////////////////////////
     T peek()
     {
-      adiar_debug (can_pull(), "Cannot peek on empty layer/queue");
+      adiar_debug (can_pull(), "Cannot peek on empty level/queue");
 
       if constexpr (Buckets == 0) {
         return _overflow_queue.top();
@@ -510,11 +510,11 @@ namespace adiar {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Pull the next element on the current layer
+    /// \brief Pull the next element on the current level
     ////////////////////////////////////////////////////////////////////////////
     T pull()
     {
-      adiar_debug (can_pull(), "Cannot pull on empty layer/queue");
+      adiar_debug (can_pull(), "Cannot pull on empty level/queue");
 
       _size--;
       if constexpr (Buckets == 0) {
@@ -557,7 +557,7 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Is the stream empty.
     ///
-    /// If you only want to know if it is empty for the current layer, then use
+    /// If you only want to know if it is empty for the current level, then use
     /// can_pull instead.
     ////////////////////////////////////////////////////////////////////////////
     bool empty() const

--- a/src/adiar/reduce.cpp
+++ b/src/adiar/reduce.cpp
@@ -130,9 +130,9 @@ namespace adiar
     // Find the first label
     label_t label = label_of(sink_arcs.peek().source);
 
-    // Process bottom-up each layer
+    // Process bottom-up each level
     while (sink_arcs.can_pull() || redD.can_pull()) {
-      adiar_invariant(label == redD.current_layer(), "label and priority queue are in sync");
+      adiar_invariant(label == redD.current_level(), "label and priority queue are in sync");
 
       // Temporary file for Reduction Rule 1 mappings (opened later if need be)
       tpie::file_stream<mapping> red1_mapping;
@@ -142,7 +142,7 @@ namespace adiar
       child_grouping.set_available_memory(sorter_phase_1, sorter_phase_2, sorter_phase_1);
       child_grouping.begin();
 
-      // Pull out all nodes from redD and sink_arcs for this layer
+      // Pull out all nodes from redD and sink_arcs for this level
       while ((sink_arcs.can_pull() && label_of(sink_arcs.peek().source) == label) || redD.can_pull()) {
         arc_t e_high = reduce_get_next(redD, sink_arcs);
         arc_t e_low = reduce_get_next(redD, sink_arcs);
@@ -250,16 +250,16 @@ namespace adiar
         }
       }
 
-      // Move on to the next layer
+      // Move on to the next level
       red1_mapping.close();
 
-      if (redD.has_next_layer()) {
+      if (redD.has_next_level()) {
         if (sink_arcs.can_pull()) {
-          redD.setup_next_layer(label_of(sink_arcs.peek().source));
+          redD.setup_next_level(label_of(sink_arcs.peek().source));
         } else {
-          redD.setup_next_layer();
+          redD.setup_next_level();
         }
-        label = redD.current_layer();
+        label = redD.current_level();
       } else if (!out_writer.has_pushed()) {
         adiar_debug(!node_arcs.can_pull() && !sink_arcs.can_pull(),
                    "Nodes are still left to be processed");

--- a/src/adiar/reduce.cpp
+++ b/src/adiar/reduce.cpp
@@ -121,7 +121,7 @@ namespace adiar
                                             e_low.target,
                                             e_high.target));
 
-        out_writer.unsafe_push(meta_t { label });
+        out_writer.unsafe_push(create_meta(label,1u));
       }
 
       return out_file;
@@ -173,13 +173,10 @@ namespace adiar
         id_t out_id = MAX_ID;
         node_t current_node = child_grouping.pull();
 
-        out_writer.unsafe_push(meta_t { label });
-
-        node_t out_node = create_node(label, out_id, current_node.low, current_node.high);
-        out_writer.unsafe_push(out_node);
-
         adiar_debug(out_id > 0, "Has run out of ids");
-        out_id--;
+
+        node_t out_node = create_node(label, out_id--, current_node.low, current_node.high);
+        out_writer.unsafe_push(out_node);
 
         red2_mapping.push({ current_node.uid, out_node.uid });
 
@@ -199,6 +196,8 @@ namespace adiar
             red2_mapping.push({current_node.uid, out_node.uid});
           }
         }
+
+        out_writer.unsafe_push(create_meta(label, MAX_ID - out_id));
       }
 
       // Sort mappings for Reduction rule 2 back in order of node_arcs

--- a/src/adiar/reduce.cpp
+++ b/src/adiar/reduce.cpp
@@ -7,7 +7,7 @@
 
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 
 #include <adiar/assert.h>
 
@@ -54,7 +54,7 @@ namespace adiar
     return a.old_uid > b.old_uid;
   };
 
-  typedef arc_priority_queue<arc_t, reduce_queue_label, reduce_queue_lt, std::greater<label_t>> reduce_priority_queue_t;
+  typedef levelized_arc_priority_queue<arc_t, reduce_queue_label, reduce_queue_lt, std::greater<label_t>> reduce_priority_queue_t;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions

--- a/test/adiar/bdd/test_apply.cpp
+++ b/test/adiar/bdd/test_apply.cpp
@@ -249,10 +249,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -293,10 +293,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -337,10 +337,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -371,7 +371,7 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -583,13 +583,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -671,16 +671,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -757,16 +757,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -842,16 +842,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,3u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -950,16 +950,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,4u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1120,31 +1120,31 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {3}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {4}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(4,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {5}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(5,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {6}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(6,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {7}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(7,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {8}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(8,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1331,31 +1331,31 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {3}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {4}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(4,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {5}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(5,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {6}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(6,4u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {7}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(7,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t {8}));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(8,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });

--- a/test/adiar/bdd/test_apply.cpp
+++ b/test/adiar/bdd/test_apply.cpp
@@ -857,7 +857,7 @@ go_bandit([]() {
           });
 
         it("should XOR BDD 3 and 1", [&]() {
-            /* The queue appD_data is used to forward data across the layer. When
+            /* The queue appD_data is used to forward data across the level. When
                BDD 1 and 3 are combined, this is needed
 
                   The product between the BDD 3 and BDD 1 then is

--- a/test/adiar/bdd/test_bdd.cpp
+++ b/test/adiar/bdd/test_bdd.cpp
@@ -95,8 +95,8 @@ go_bandit([]() {
               aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(true)});
               aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
 
-              aw.unsafe_push(meta {0});
-              aw.unsafe_push(meta {1});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
             }
 
             it("should copy-construct values from arc_file", [&]() {

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -65,7 +65,7 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 0 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -80,7 +80,7 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 42 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(42,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -97,7 +97,7 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 1 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -112,7 +112,7 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 3 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -149,13 +149,13 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 5 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 1 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -207,13 +207,13 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 5 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 1 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -280,19 +280,19 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 5 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 4 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 3 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 1 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -343,16 +343,16 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 5 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 4 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,3u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 3 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -501,31 +501,31 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 8 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 7 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(7,3u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 6 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 5 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 4 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 3 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,3u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 1 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 0 }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });

--- a/test/adiar/bdd/test_evaluate.cpp
+++ b/test/adiar/bdd/test_evaluate.cpp
@@ -184,7 +184,7 @@ go_bandit([]() {
         //              END
         // == CREATE 'SKIPPING' BDD ==
 
-        it("should be able to evaluate BDD that skips layers [1]", [&skip_bdd]() {
+        it("should be able to evaluate BDD that skips level [1]", [&skip_bdd]() {
             assignment_file assignment;
 
             { // Garbage collect writer to free write-lock
@@ -200,7 +200,7 @@ go_bandit([]() {
             AssertThat(bdd_eval(skip_bdd, assignment), Is().False());
           });
 
-        it("should be able to evaluate BDD that skips layers [2]", [&skip_bdd]() {
+        it("should be able to evaluate BDD that skips level [2]", [&skip_bdd]() {
             assignment_file assignment;
 
             { // Garbage collect writer to free write-lock

--- a/test/adiar/bdd/test_if_then_else.cpp
+++ b/test/adiar/bdd/test_if_then_else.cpp
@@ -132,10 +132,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -172,10 +172,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -206,10 +206,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -240,10 +240,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -274,10 +274,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -308,10 +308,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -342,10 +342,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -376,10 +376,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
         });
@@ -410,10 +410,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -444,10 +444,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -494,10 +494,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -543,10 +543,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -592,10 +592,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -663,13 +663,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1004,16 +1004,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,4u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,3u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1099,16 +1099,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,3u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1171,13 +1171,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1241,13 +1241,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1349,16 +1349,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,4u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1458,16 +1458,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,4u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1564,16 +1564,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,3u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,3u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1655,16 +1655,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1744,16 +1744,16 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,4u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1803,16 +1803,16 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });
@@ -1927,28 +1927,28 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> meta(out);
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 8 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(8,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 6 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(6,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 5 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(5,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 4 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(4,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta.can_pull(), Is().True());
-            AssertThat(meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta.can_pull(), Is().False());
           });

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -469,7 +469,7 @@ go_bandit([]() {
                 AssertThat(meta.can_pull(), Is().False());
               });
 
-            it("should keep nodes as is when skipping quantified layer [BDD 3]", [&]() {
+            it("should keep nodes as is when skipping quantified level [BDD 3]", [&]() {
                 __bdd out = bdd_exists(bdd_3, 1);
 
                 node_arc_test_stream node_arcs(out);

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -296,10 +296,10 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 1 }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 0 }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -326,7 +326,7 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -369,10 +369,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,2u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -415,10 +415,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,2u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -461,10 +461,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,2u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -509,10 +509,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,2u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -549,10 +549,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -589,10 +589,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -638,10 +638,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -697,13 +697,13 @@ go_bandit([]() {
                  meta_test_stream<arc_t, 2> meta(out);
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,2u)));
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 3u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(3u,2u)));
 
                  AssertThat(meta.can_pull(), Is().False());
               });
@@ -737,10 +737,10 @@ go_bandit([]() {
                  meta_test_stream<arc_t, 2> meta(out);
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                  AssertThat(meta.can_pull(), Is().False());
               });
@@ -782,13 +782,13 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -830,13 +830,13 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -909,10 +909,10 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 3 }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 0 }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -944,10 +944,10 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 3 }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 0 }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -984,13 +984,13 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1022,10 +1022,10 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1057,10 +1057,10 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1093,10 +1093,10 @@ go_bandit([]() {
                 meta_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1211,7 +1211,7 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -1254,10 +1254,10 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,2u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -1300,13 +1300,13 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 1u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(1u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -1362,13 +1362,13 @@ go_bandit([]() {
                  meta_test_stream<arc_t, 2> meta(out);
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,2u)));
 
                  AssertThat(meta.can_pull(), Is().True());
-                 AssertThat(meta.pull(), Is().EqualTo(meta_t { 3u }));
+                 AssertThat(meta.pull(), Is().EqualTo(create_meta(3u,2u)));
 
                  AssertThat(meta.can_pull(), Is().False());
               });
@@ -1410,13 +1410,13 @@ go_bandit([]() {
                 meta_test_stream<arc_t, 2> meta(out);
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 0u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(0u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(meta.can_pull(), Is().True());
-                AssertThat(meta.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(meta.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(meta.can_pull(), Is().False());
               });
@@ -1493,10 +1493,10 @@ go_bandit([]() {
 
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -1533,10 +1533,10 @@ go_bandit([]() {
 
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 3u }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(3u,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(meta_t { 2u }));
+                AssertThat(ms.pull(), Is().EqualTo(create_meta(2u,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });

--- a/test/adiar/bdd/test_restrict.cpp
+++ b/test/adiar/bdd/test_restrict.cpp
@@ -34,7 +34,7 @@ go_bandit([]() {
         //                END
         // == CREATE BDD FOR UNIT TESTS ==
 
-        it("should bridge layers [1]. Assignment: (_,_,T,_)", [&]() {
+        it("should bridge level [1]. Assignment: (_,_,T,_)", [&]() {
             /*
                  1      ---- x0
                 / \
@@ -94,7 +94,7 @@ go_bandit([]() {
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
 
-        it("should bridge layers. [2]. Assignment: (_,F,_,_)", [&]() {
+        it("should bridge levels. [2]. Assignment: (_,F,_,_)", [&]() {
             /*
                  1      ---- x0
                 / \
@@ -143,7 +143,7 @@ go_bandit([]() {
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
 
-        it("should bridge layers [3]. Assignment: (_,T,_,_)", [&]() {
+        it("should bridge levels [3]. Assignment: (_,T,_,_)", [&]() {
             /*
                   1         ---- x0
                  / \

--- a/test/adiar/bdd/test_restrict.cpp
+++ b/test/adiar/bdd/test_restrict.cpp
@@ -83,13 +83,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -135,10 +135,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -198,13 +198,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -256,10 +256,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 1 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -297,7 +297,7 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -394,42 +394,10 @@ go_bandit([]() {
         it("should return input unchanged when given an empty assignment", [&]() {
             assignment_file assignment;
 
-            __bdd output = bdd_restrict(bdd, assignment);
+            __bdd out = bdd_restrict(bdd, assignment);
 
-            node_test_stream out_nodes(output);
-
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(n5));
-
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(n4));
-
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(n3));
-
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(n2));
-
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(n1));
-
-            AssertThat(out_nodes.can_pull(), Is().False());
-
-            meta_test_stream<node_t, 1> out_meta(output);
-
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {3}));
-
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
-
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
-
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
-
-            AssertThat(out_meta.can_pull(), Is().False());
+            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd._file_ptr));
+            AssertThat(out.negate, Is().False());
           });
 
         it("should have sink arcs restricted to a sink sorted [1]", []() {
@@ -495,10 +463,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -567,10 +535,10 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -657,13 +625,13 @@ go_bandit([]() {
             meta_test_stream<arc_t, 2> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(meta_t {3}));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });

--- a/test/adiar/test_file.cpp
+++ b/test/adiar/test_file.cpp
@@ -91,10 +91,10 @@ go_bandit([]() {
 
                   meta_file_writer<int,1> fw(test_file_meta_1);
 
-                  fw.unsafe_push(meta_t { 0 });
-
                   fw.unsafe_push(21);
                   fw.unsafe_push(42);
+
+                  fw.unsafe_push(create_meta(0,2u));
 
                   AssertThat(test_file_meta_1.is_read_only(), Is().False());
                 });
@@ -103,8 +103,8 @@ go_bandit([]() {
                 it("can hook into and write to test_file_meta_2", [&]() {
                   meta_file_writer<int,2> fw(test_file_meta_2);
 
-                  fw.unsafe_push(meta_t { 5 });
-                  fw.unsafe_push(meta_t { 4 });
+                  fw.unsafe_push(create_meta(5,1u));
+                  fw.unsafe_push(create_meta(4,1u));
 
                   fw.unsafe_push(1); // Check idx argument is defaulted to 0
                   fw.unsafe_push(2, 0);
@@ -119,13 +119,12 @@ go_bandit([]() {
                   meta_file<int, 1>* f = new meta_file<int, 1>();
                   meta_file_writer fw(*f);
 
-                  fw.unsafe_push(meta_t { 0 });
-
                   fw.unsafe_push(21);
 
                   delete f;
 
                   fw.unsafe_push(42);
+                  fw.unsafe_push(create_meta(0,1u));
                 });
 
                 describe("node_writer", [&]() {
@@ -146,8 +145,12 @@ go_bandit([]() {
                       AssertThat(arc_test_file.is_read_only(), Is().False());
 
                       aw.unsafe_push_node(node_arc_1);
-                      aw.unsafe_push(meta_t { 0 });
                     });
+
+                    it("can hook into arc_test_file and write meta", [&]() {
+                        aw.unsafe_push(create_meta(0,1u));
+                        aw.unsafe_push(create_meta(1,1u));
+                      });
 
                     it("can hook into arc_test_file, write sink arcs, and then sort them", [&]() {
                       aw.unsafe_push_sink(sink_arc_3);
@@ -363,7 +366,7 @@ go_bandit([]() {
                        meta_stream ms(test_file_meta_1);
 
                        AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(meta_t {0}));
+                       AssertThat(ms.pull(), Is().EqualTo(create_meta(0,2u)));
                        AssertThat(ms.can_pull(), Is().False());
                      });
 
@@ -371,9 +374,9 @@ go_bandit([]() {
                        meta_stream ms(node_test_file);
 
                        AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(meta_t {0}));
+                       AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
                        AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(meta_t {1}));
+                       AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
                        AssertThat(ms.can_pull(), Is().False());
                      });
                 });
@@ -585,13 +588,13 @@ go_bandit([]() {
 
                 it("can compute sizes of test_file_meta_1", [&]() {
                   AssertThat(test_file_meta_1.size(), Is().EqualTo(2u));
-                  AssertThat(test_file_meta_1.file_size(), Is().EqualTo(2u * 4u + 1u * 4u));
+                  AssertThat(test_file_meta_1.file_size(), Is().EqualTo(2u * 4u + 1u * 8u));
                 });
 
                 it("can compute size of test_file_meta_2", [&]() {
                   test_file_meta_2.make_read_only();
                   AssertThat(test_file_meta_2.size(), Is().EqualTo(5u));
-                  AssertThat(test_file_meta_2.file_size(), Is().EqualTo(5u * 4u + 2u * 4u));
+                  AssertThat(test_file_meta_2.file_size(), Is().EqualTo(5u * 4u + 2u * 8u));
                 });
 
                 describe("node_file", [&]() {
@@ -636,25 +639,25 @@ go_bandit([]() {
                         it("can compute size of node_test_file", [&]() {
                           AssertThat(node_test_file.size(), Is().EqualTo(3u));
                           AssertThat(node_test_file.meta_size(), Is().EqualTo(2u));
-                          AssertThat(node_test_file.file_size(), Is().EqualTo(3u * 24u + 2u * 4u));
+                          AssertThat(node_test_file.file_size(), Is().EqualTo(3u * 24u + 2u * 8u));
                         });
 
                         it("can compute size of x0", [&]() {
                           AssertThat(x0.size(), Is().EqualTo(1u));
                           AssertThat(x0.meta_size(), Is().EqualTo(1u));
-                          AssertThat(x0.file_size(), Is().EqualTo(1u * 24u + 1u * 4u));
+                          AssertThat(x0.file_size(), Is().EqualTo(1u * 24u + 1u * 8u));
                         });
 
                         it("can compute size of x0 & x1", [&]() {
                           AssertThat(x0_and_x1.size(), Is().EqualTo(2u));
                           AssertThat(x0_and_x1.meta_size(), Is().EqualTo(2u));
-                          AssertThat(x0_and_x1.file_size(), Is().EqualTo(2u * 24u + 2u * 4u));
+                          AssertThat(x0_and_x1.file_size(), Is().EqualTo(2u * 24u + 2u * 8u));
                         });
 
                         it("can compute size of sink_T", [&]() {
                           AssertThat(sink_T.size(), Is().EqualTo(1u));
                           AssertThat(sink_T.meta_size(), Is().EqualTo(0u));
-                          AssertThat(sink_T.file_size(), Is().EqualTo(1u * 24u + 0u * 4u));
+                          AssertThat(sink_T.file_size(), Is().EqualTo(1u * 24u + 0u * 8u));
                         });
                     });
 

--- a/test/adiar/test_homomorphism.cpp
+++ b/test/adiar/test_homomorphism.cpp
@@ -141,7 +141,7 @@ go_bandit([]() {
              << create_node(0,1, create_node_ptr(1,0), create_node_ptr(1,1));
         }
 
-        it("can compare bdd 1 with x42 and x22", [&]() {
+        it("can compare bdd 1 with x42 and x22 [#nodes + inconsistent levels]", [&]() {
           AssertThat(is_homomorphic(x42_a, bdd_1_a), Is().False());
           AssertThat(is_homomorphic(x42_a, bdd_1_a, true, false), Is().False());
           AssertThat(is_homomorphic(x42_a, bdd_1_a, false, true), Is().False());
@@ -169,7 +169,7 @@ go_bandit([]() {
            AssertThat(is_homomorphic(bdd_1_b, bdd_1b, true, true), Is().False());
          });
 
-        it("can reject bdd 1 shifted by 10 labels", [&]() {
+        it("can reject bdd 1 shifted by 10 labels [inconsistent levels]", [&]() {
           AssertThat(is_homomorphic(bdd_1_a, bdd_1_a_shifted), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_1_a_shifted, true, false), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_1_a_shifted, false, true), Is().False());
@@ -241,14 +241,14 @@ go_bandit([]() {
           AssertThat(is_homomorphic(bdd_2_a, bdd_2_b, true, true), Is().True());
         });
 
-        it("can compare bdd 1 with bdd 2", [&]() {
+        it("can compare bdd 1 with bdd 2 [inconsistent levels]", [&]() {
           AssertThat(is_homomorphic(bdd_1_a, bdd_2_a), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_2_a, true, false), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_2_a, false, true), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_2_a, true, true), Is().False());
         });
 
-        it("can reject bdd 2 with labels of x2 nodes shifted", [&]() {
+        it("can reject bdd 2 with labels of x2 nodes shifted [inconsistent levels]", [&]() {
           AssertThat(is_homomorphic(bdd_2_a, bdd_2_a_shifted), Is().False());
           AssertThat(is_homomorphic(bdd_2_a, bdd_2_a_shifted, true, false), Is().False());
           AssertThat(is_homomorphic(bdd_2_a, bdd_2_a_shifted, false, true), Is().False());
@@ -293,9 +293,9 @@ go_bandit([]() {
         /*
                  _1_     ---- x0
                 /   \
-               2     3   ---- x1
+               2     4   ---- x1
               / \   / \
-             3   4  F T  ---- x2
+             4   5  F T  ---- x2
             / \ / \
             T F F T
          */
@@ -347,18 +347,52 @@ go_bandit([]() {
           AssertThat(is_homomorphic(bdd_3_b, bdd_3_c, true, true), Is().True());
         });
 
-        it("can compare bdd 1 with bdd 3", [&]() {
+        it("can compare bdd 1 with bdd 3 [#nodes + #levels]", [&]() {
           AssertThat(is_homomorphic(bdd_1_a, bdd_3_a), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_3_a, true, false), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_3_a, false, true), Is().False());
           AssertThat(is_homomorphic(bdd_1_a, bdd_3_a, true, true), Is().False());
         });
 
-        it("can compare bdd 2 with bdd 3", [&]() {
+        it("can compare bdd 2 with bdd 3 [#nodes + #levels]", [&]() {
           AssertThat(is_homomorphic(bdd_2_a, bdd_3_a), Is().False());
           AssertThat(is_homomorphic(bdd_2_a, bdd_3_a, true, false), Is().False());
           AssertThat(is_homomorphic(bdd_2_a, bdd_3_a, false, true), Is().False());
           AssertThat(is_homomorphic(bdd_2_a, bdd_3_a, true, true), Is().False());
         });
+
+        /*
+               1     ---- x0
+              / \
+             2  |    ---- x1
+            / \ /
+            F  3     ---- x2
+              / \
+              4 T    ---- x3
+             / \
+             F T
+        */
+        node_file bdd_4;
+        { // Garbage collect writers to free write-lock
+          node_writer aw(bdd_4); // As depicted
+          aw << create_node(3,0, create_sink_ptr(true), create_sink_ptr(false))
+             << create_node(2,0, create_sink_ptr(false), create_sink_ptr(true))
+             << create_node(1,0, create_sink_ptr(false), create_node_ptr(3,0))
+             << create_node(0,0, create_node_ptr(2,0), create_node_ptr(1,0));
+        }
+
+        it("can compare bdd 2 with bdd 4 [#levels]", [&]() {
+            AssertThat(is_homomorphic(bdd_2_a, bdd_4), Is().False());
+            AssertThat(is_homomorphic(bdd_2_a, bdd_4, true, false), Is().False());
+            AssertThat(is_homomorphic(bdd_2_a, bdd_4, false, true), Is().False());
+            AssertThat(is_homomorphic(bdd_2_a, bdd_4, true, true), Is().False());
+          });
+
+        it("can compare bdd 2 with bdd 4 [#levels]", [&]() {
+            AssertThat(is_homomorphic(bdd_3_a, bdd_4), Is().False());
+            AssertThat(is_homomorphic(bdd_3_a, bdd_4, true, false), Is().False());
+            AssertThat(is_homomorphic(bdd_3_a, bdd_4, false, true), Is().False());
+            AssertThat(is_homomorphic(bdd_3_a, bdd_4, true, true), Is().False());
+          });
     });
 });

--- a/test/adiar/test_levelized_priority_queue.cpp
+++ b/test/adiar/test_levelized_priority_queue.cpp
@@ -1,4 +1,4 @@
-#include <adiar/priority_queue.h>
+#include <adiar/levelized_priority_queue.h>
 
 using namespace adiar;
 
@@ -30,13 +30,13 @@ typedef meta_file<pq_test_data, 1u> pq_test_file;
 typedef meta_file_writer<pq_test_data, 1u> pq_test_writer;
 
 template <size_t MetaStreams, size_t Buckets>
-using test_priority_queue = priority_queue<pq_test_data, 1u,
-                                           pq_test_data, pq_test_label_ext,
-                                           pq_test_lt, std::less<label_t>,
-                                           MetaStreams, Buckets>;
+using test_priority_queue = levelized_priority_queue<pq_test_data, 1u,
+                                                     pq_test_data, pq_test_label_ext,
+                                                     pq_test_lt, std::less<label_t>,
+                                                     MetaStreams, Buckets>;
 
 go_bandit([]() {
-  describe("CORE: Priority Queue", []() {
+  describe("CORE: Levelized Priority Queue", []() {
 
     describe("Label Manager", [&]() {
       it("can pull from one meta stream", [&]() {

--- a/test/adiar/test_levelized_priority_queue.cpp
+++ b/test/adiar/test_levelized_priority_queue.cpp
@@ -44,10 +44,10 @@ go_bandit([]() {
         { // Garbage collect the writer
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,1u));
+          fw.unsafe_push(create_meta(3,2u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 1u> mgr;
@@ -75,10 +75,10 @@ go_bandit([]() {
         { // Garbage collect the writer
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,1u));
+          fw.unsafe_push(create_meta(3,2u));
+          fw.unsafe_push(create_meta(2,1u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 1> mgr;
@@ -103,7 +103,7 @@ go_bandit([]() {
          { // Garbage collect the writer
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {1});
+           fw1.unsafe_push(create_meta(1,1u));
          }
 
          pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -125,8 +125,8 @@ go_bandit([]() {
          { // Garbage collect the writer
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {1});
-           fw1.unsafe_push(meta_t {2});
+           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_meta(2,1u));
          }
 
          pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
@@ -150,14 +150,14 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(f1);
 
-          fw1.unsafe_push(meta_t {4});
-          fw1.unsafe_push(meta_t {2});
-          fw1.unsafe_push(meta_t {1});
+          fw1.unsafe_push(create_meta(4,1u));
+          fw1.unsafe_push(create_meta(2,2u));
+          fw1.unsafe_push(create_meta(1,1u));
 
           pq_test_writer fw2(f2);
 
-          fw2.unsafe_push(meta_t {4});
-          fw2.unsafe_push(meta_t {3});
+          fw2.unsafe_push(create_meta(4,1u));
+          fw2.unsafe_push(create_meta(3,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -187,11 +187,11 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(f1);
 
-          fw1.unsafe_push(meta_t {2});
+          fw1.unsafe_push(create_meta(2,1u));
 
           pq_test_writer fw2(f2);
 
-          fw2.unsafe_push(meta_t {1});
+          fw2.unsafe_push(create_meta(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -215,10 +215,10 @@ go_bandit([]() {
          { // Garbage collect the writers
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {2});
+           fw1.unsafe_push(create_meta(2,1u));
            pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(meta_t {1});
+           fw2.unsafe_push(create_meta(1,1u));
          }
 
          pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
@@ -242,14 +242,14 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(f1);
 
-          fw1.unsafe_push(meta_t {4});
-          fw1.unsafe_push(meta_t {2});
+          fw1.unsafe_push(create_meta(4,2u));
+          fw1.unsafe_push(create_meta(2,1u));
 
           pq_test_writer fw2(f2);
 
-          fw2.unsafe_push(meta_t {4});
-          fw2.unsafe_push(meta_t {3});
-          fw2.unsafe_push(meta_t {1});
+          fw2.unsafe_push(create_meta(4,3u));
+          fw2.unsafe_push(create_meta(3,2u));
+          fw2.unsafe_push(create_meta(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -274,14 +274,14 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(*f1);
 
-          fw1.unsafe_push(meta_t {4});
-          fw1.unsafe_push(meta_t {2});
+          fw1.unsafe_push(create_meta(4,2u));
+          fw1.unsafe_push(create_meta(2,1u));
 
           pq_test_writer fw2(*f2);
 
-          fw2.unsafe_push(meta_t {4});
-          fw2.unsafe_push(meta_t {3});
-          fw2.unsafe_push(meta_t {1});
+          fw2.unsafe_push(create_meta(4,1u));
+          fw2.unsafe_push(create_meta(3,2u));
+          fw2.unsafe_push(create_meta(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -306,9 +306,9 @@ go_bandit([]() {
         {
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,1u));
+          fw.unsafe_push(create_meta(3,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,0> pq({f});
@@ -332,10 +332,10 @@ go_bandit([]() {
         {
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,1u));
+          fw.unsafe_push(create_meta(3,2u));
+          fw.unsafe_push(create_meta(2,1u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,0> pq({f});
@@ -410,10 +410,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,2u));
+          fw.unsafe_push(create_meta(3,2u));
+          fw.unsafe_push(create_meta(2,1u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,0> pq({f});
@@ -445,10 +445,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,1u));
+          fw.unsafe_push(create_meta(3,4u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,0> pq({f});
@@ -483,10 +483,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,2u));
+          fw.unsafe_push(create_meta(3,4u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,0> pq({f});
@@ -564,9 +564,9 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {3});
-           fw.unsafe_push(meta_t {2});
-           fw.unsafe_push(meta_t {1});
+           fw.unsafe_push(create_meta(3,2u));
+           fw.unsafe_push(create_meta(2,2u));
+           fw.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<1,0> pq({f});
@@ -602,10 +602,10 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {5});
-           fw.unsafe_push(meta_t {4});
-           fw.unsafe_push(meta_t {3});
-           fw.unsafe_push(meta_t {1});
+           fw.unsafe_push(create_meta(5,2u));
+           fw.unsafe_push(create_meta(4,3u));
+           fw.unsafe_push(create_meta(3,2u));
+           fw.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<1,1> pq({f});
@@ -620,7 +620,7 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -644,7 +644,7 @@ go_bandit([]() {
          {
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {1});
+           fw1.unsafe_push(create_meta(1,1u));
          }
 
          pq_test_file f2;
@@ -661,11 +661,11 @@ go_bandit([]() {
          { // Garbage collect the writers early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {1});
+           fw1.unsafe_push(create_meta(1,1u));
 
            pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(meta_t {2});
+           fw2.unsafe_push(create_meta(2,1u));
          }
 
          test_priority_queue<2,1> pq({f1,f2});
@@ -679,10 +679,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,2u));
+          fw.unsafe_push(create_meta(3,3u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -757,10 +757,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,2u));
+          fw.unsafe_push(create_meta(3,3u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -804,10 +804,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,1u));
+          fw.unsafe_push(create_meta(3,3u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -837,10 +837,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,2u));
+          fw.unsafe_push(create_meta(3,4u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -876,11 +876,11 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {5});
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(5,2u));
+          fw.unsafe_push(create_meta(4,4u));
+          fw.unsafe_push(create_meta(3,4u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -917,10 +917,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(4,2u));
+          fw.unsafe_push(create_meta(3,3u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -995,12 +995,12 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {6});
-           fw.unsafe_push(meta_t {5});
-           fw.unsafe_push(meta_t {4});
-           fw.unsafe_push(meta_t {3});
-           fw.unsafe_push(meta_t {2});
-           fw.unsafe_push(meta_t {1});
+           fw.unsafe_push(create_meta(6,2u));
+           fw.unsafe_push(create_meta(5,4u));
+           fw.unsafe_push(create_meta(4,5u));
+           fw.unsafe_push(create_meta(3,4u));
+           fw.unsafe_push(create_meta(2,2u));
+           fw.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<1,1> pq({f});
@@ -1033,12 +1033,12 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {6});
-           fw.unsafe_push(meta_t {5});
-           fw.unsafe_push(meta_t {4});
-           fw.unsafe_push(meta_t {3});
-           fw.unsafe_push(meta_t {2});
-           fw.unsafe_push(meta_t {1});
+           fw.unsafe_push(create_meta(6,2u));
+           fw.unsafe_push(create_meta(5,2u));
+           fw.unsafe_push(create_meta(4,3u));
+           fw.unsafe_push(create_meta(3,2u));
+           fw.unsafe_push(create_meta(2,2u));
+           fw.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<1,1> pq({f});
@@ -1069,16 +1069,16 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {16}); // overflow
-          fw.unsafe_push(meta_t {15}); // overflow
-          fw.unsafe_push(meta_t {14}); // overflow
-          fw.unsafe_push(meta_t {12}); // overflow
-          fw.unsafe_push(meta_t {10}); // overflow
-          fw.unsafe_push(meta_t {9}); // overflow
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(16,2u)); // overflow
+          fw.unsafe_push(create_meta(15,3u)); // overflow
+          fw.unsafe_push(create_meta(14,5u)); // overflow
+          fw.unsafe_push(create_meta(12,8u)); // overflow
+          fw.unsafe_push(create_meta(10,8u)); // overflow
+          fw.unsafe_push(create_meta(9,7u)); // overflow
+          fw.unsafe_push(create_meta(8,3u)); // overflow
+          fw.unsafe_push(create_meta(6,3u)); // overflow
+          fw.unsafe_push(create_meta(4,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,1> pq({f});
@@ -1142,14 +1142,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {8});
-          fw.unsafe_push(meta_t {7});
-          fw.unsafe_push(meta_t {6});
-          fw.unsafe_push(meta_t {5});
-          fw.unsafe_push(meta_t {4});
-          fw.unsafe_push(meta_t {3});
-          fw.unsafe_push(meta_t {2});
-          fw.unsafe_push(meta_t {1});
+          fw.unsafe_push(create_meta(8,1u));
+          fw.unsafe_push(create_meta(7,3u));
+          fw.unsafe_push(create_meta(6,4u));
+          fw.unsafe_push(create_meta(5,6u));
+          fw.unsafe_push(create_meta(4,5u));
+          fw.unsafe_push(create_meta(3,4u));
+          fw.unsafe_push(create_meta(2,2u));
+          fw.unsafe_push(create_meta(1,1u));
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1161,9 +1161,9 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {4});
-           fw.unsafe_push(meta_t {3});
-           fw.unsafe_push(meta_t {1});
+           fw.unsafe_push(create_meta(4,1u));
+           fw.unsafe_push(create_meta(3,2u));
+           fw.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1175,8 +1175,8 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {2});
-           fw.unsafe_push(meta_t {1});
+           fw.unsafe_push(create_meta(2,1u));
+           fw.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1199,7 +1199,7 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {1});
+           fw1.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<2,4> pq({f1,f2});
@@ -1215,8 +1215,8 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {2});
-           fw1.unsafe_push(meta_t {1});
+           fw1.unsafe_push(create_meta(2,2u));
+           fw1.unsafe_push(create_meta(1,1u));
          }
 
          test_priority_queue<2,4> pq({f1,f2});
@@ -1232,11 +1232,11 @@ go_bandit([]() {
          { // Garbage collect the writers early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(meta_t {1});
+           fw1.unsafe_push(create_meta(1,1u));
 
            pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(meta_t {12});
+           fw2.unsafe_push(create_meta(12,1u));
          }
 
          test_priority_queue<2,4> pq({f1,f2});
@@ -1251,13 +1251,13 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(7,2u)); // overflow
+          fw.unsafe_push(create_meta(6,3u)); // overflow
+          fw.unsafe_push(create_meta(5,6u)); // write bucket
+          fw.unsafe_push(create_meta(4,8u)); // write bucket
+          fw.unsafe_push(create_meta(3,4u)); // write bucket
+          fw.unsafe_push(create_meta(2,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1459,14 +1459,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(8,1u)); // overflow
+          fw.unsafe_push(create_meta(7,4u)); // overflow
+          fw.unsafe_push(create_meta(6,7u)); // overflow
+          fw.unsafe_push(create_meta(5,10u)); // write bucket
+          fw.unsafe_push(create_meta(4,8u)); // write bucket
+          fw.unsafe_push(create_meta(3,4u)); // write bucket
+          fw.unsafe_push(create_meta(2,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1513,14 +1513,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(8,2u)); // overflow
+          fw.unsafe_push(create_meta(7,3u)); // overflow
+          fw.unsafe_push(create_meta(6,4u)); // overflow
+          fw.unsafe_push(create_meta(5,5u)); // write bucket
+          fw.unsafe_push(create_meta(4,3u)); // write bucket
+          fw.unsafe_push(create_meta(3,2u)); // write bucket
+          fw.unsafe_push(create_meta(2,1u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1553,18 +1553,18 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {12}); // overflow
-          fw.unsafe_push(meta_t {11}); // overflow
-          fw.unsafe_push(meta_t {10}); // overflow
-          fw.unsafe_push(meta_t {9}); // overflow
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(12,2u)); // overflow
+          fw.unsafe_push(create_meta(11,4u)); // overflow
+          fw.unsafe_push(create_meta(10,8u)); // overflow
+          fw.unsafe_push(create_meta(9,16u)); // overflow
+          fw.unsafe_push(create_meta(8,32u)); // overflow
+          fw.unsafe_push(create_meta(7,64u)); // overflow
+          fw.unsafe_push(create_meta(6,32u)); // overflow
+          fw.unsafe_push(create_meta(5,16u)); // write bucket
+          fw.unsafe_push(create_meta(4,8u)); // write bucket
+          fw.unsafe_push(create_meta(3,4u)); // write bucket
+          fw.unsafe_push(create_meta(2,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1613,14 +1613,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(8,1u)); // overflow
+          fw.unsafe_push(create_meta(7,1u)); // overflow
+          fw.unsafe_push(create_meta(6,2u)); // overflow
+          fw.unsafe_push(create_meta(5,3u)); // write bucket
+          fw.unsafe_push(create_meta(4,4u)); // write bucket
+          fw.unsafe_push(create_meta(3,3u)); // write bucket
+          fw.unsafe_push(create_meta(2,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1659,14 +1659,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(8,1)); // overflow
+          fw.unsafe_push(create_meta(7,2u)); // overflow
+          fw.unsafe_push(create_meta(6,3u)); // overflow
+          fw.unsafe_push(create_meta(5,2u)); // write bucket
+          fw.unsafe_push(create_meta(4,3u)); // write bucket
+          fw.unsafe_push(create_meta(3,1u)); // write bucket
+          fw.unsafe_push(create_meta(2,1u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1705,14 +1705,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(8,2u)); // overflow
+          fw.unsafe_push(create_meta(7,2u)); // overflow
+          fw.unsafe_push(create_meta(6,4u)); // overflow
+          fw.unsafe_push(create_meta(5,3u)); // write bucket
+          fw.unsafe_push(create_meta(4,5u)); // write bucket
+          fw.unsafe_push(create_meta(3,4u)); // write bucket
+          fw.unsafe_push(create_meta(2,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1940,12 +1940,12 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {6}); // overflow
-           fw.unsafe_push(meta_t {5}); // write bucket
-           fw.unsafe_push(meta_t {4}); // write bucket
-           fw.unsafe_push(meta_t {3}); // write bucket
-           fw.unsafe_push(meta_t {2}); // write bucket
-           fw.unsafe_push(meta_t {1}); // read bucket
+           fw.unsafe_push(create_meta(6,1u)); // overflow
+           fw.unsafe_push(create_meta(5,2u)); // write bucket
+           fw.unsafe_push(create_meta(4,4u)); // write bucket
+           fw.unsafe_push(create_meta(3,4u)); // write bucket
+           fw.unsafe_push(create_meta(2,2u)); // write bucket
+           fw.unsafe_push(create_meta(1,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1971,14 +1971,14 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {8}); // overflow
-           fw.unsafe_push(meta_t {7}); // overflow
-           fw.unsafe_push(meta_t {6}); // overflow
-           fw.unsafe_push(meta_t {5}); // write bucket
-           fw.unsafe_push(meta_t {4}); // write bucket
-           fw.unsafe_push(meta_t {3}); // write bucket
-           fw.unsafe_push(meta_t {2}); // write bucket
-           fw.unsafe_push(meta_t {1}); // read bucket
+           fw.unsafe_push(create_meta(8,1u)); // overflow
+           fw.unsafe_push(create_meta(7,2u)); // overflow
+           fw.unsafe_push(create_meta(6,4u)); // overflow
+           fw.unsafe_push(create_meta(5,8u)); // write bucket
+           fw.unsafe_push(create_meta(4,4u)); // write bucket
+           fw.unsafe_push(create_meta(3,2u)); // write bucket
+           fw.unsafe_push(create_meta(2,2u)); // write bucket
+           fw.unsafe_push(create_meta(1,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -2004,11 +2004,11 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {4}); // write bucket
-           fw.unsafe_push(meta_t {3}); // write bucket
-           fw.unsafe_push(meta_t {2}); // write bucket
-           fw.unsafe_push(meta_t {1}); // write bucket
-           fw.unsafe_push(meta_t {0}); // read bucket
+           fw.unsafe_push(create_meta(4,2u)); // write bucket
+           fw.unsafe_push(create_meta(3,3u)); // write bucket
+           fw.unsafe_push(create_meta(2,4u)); // write bucket
+           fw.unsafe_push(create_meta(1,2u)); // write bucket
+           fw.unsafe_push(create_meta(0,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -2070,9 +2070,9 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {2}); // write bucket
-           fw.unsafe_push(meta_t {1}); // write bucket
-           fw.unsafe_push(meta_t {0}); // read bucket
+           fw.unsafe_push(create_meta(2,2u)); // write bucket
+           fw.unsafe_push(create_meta(1,2u)); // write bucket
+           fw.unsafe_push(create_meta(0,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -2114,14 +2114,14 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(meta_t {8}); // overflow
-           fw.unsafe_push(meta_t {7}); // overflow
-           fw.unsafe_push(meta_t {6}); // overflow
-           fw.unsafe_push(meta_t {5}); // write bucket
-           fw.unsafe_push(meta_t {4}); // write bucket
-           fw.unsafe_push(meta_t {3}); // write bucket
-           fw.unsafe_push(meta_t {2}); // write bucket
-           fw.unsafe_push(meta_t {0}); // read bucket
+           fw.unsafe_push(create_meta(8,2u)); // overflow
+           fw.unsafe_push(create_meta(7,4u)); // overflow
+           fw.unsafe_push(create_meta(6,2u)); // overflow
+           fw.unsafe_push(create_meta(5,6u)); // write bucket
+           fw.unsafe_push(create_meta(4,8u)); // write bucket
+           fw.unsafe_push(create_meta(3,4u)); // write bucket
+           fw.unsafe_push(create_meta(2,2u)); // write bucket
+           fw.unsafe_push(create_meta(0,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -2175,23 +2175,23 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(meta_t {17}); // overflow
-          fw.unsafe_push(meta_t {16}); // overflow
-          fw.unsafe_push(meta_t {15}); // overflow
-          fw.unsafe_push(meta_t {14}); // overflow
-          fw.unsafe_push(meta_t {13}); // overflow
-          fw.unsafe_push(meta_t {12}); // overflow
-          fw.unsafe_push(meta_t {11}); // overflow
-          fw.unsafe_push(meta_t {10}); // overflow
-          fw.unsafe_push(meta_t {9}); // overflow
-          fw.unsafe_push(meta_t {8}); // overflow
-          fw.unsafe_push(meta_t {7}); // overflow
-          fw.unsafe_push(meta_t {6}); // overflow
-          fw.unsafe_push(meta_t {5}); // write bucket
-          fw.unsafe_push(meta_t {4}); // write bucket
-          fw.unsafe_push(meta_t {3}); // write bucket
-          fw.unsafe_push(meta_t {2}); // write bucket
-          fw.unsafe_push(meta_t {1}); // read bucket
+          fw.unsafe_push(create_meta(17,2u)); // overflow
+          fw.unsafe_push(create_meta(16,4u)); // overflow
+          fw.unsafe_push(create_meta(15,8u)); // overflow
+          fw.unsafe_push(create_meta(14,11u)); // overflow
+          fw.unsafe_push(create_meta(13,13u)); // overflow
+          fw.unsafe_push(create_meta(12,17u)); // overflow
+          fw.unsafe_push(create_meta(11,19u)); // overflow
+          fw.unsafe_push(create_meta(10,23u)); // overflow
+          fw.unsafe_push(create_meta(9,19u)); // overflow
+          fw.unsafe_push(create_meta(8,17u)); // overflow
+          fw.unsafe_push(create_meta(7,13u)); // overflow
+          fw.unsafe_push(create_meta(6,11u)); // overflow
+          fw.unsafe_push(create_meta(5,7u)); // write bucket
+          fw.unsafe_push(create_meta(4,5u)); // write bucket
+          fw.unsafe_push(create_meta(3,3u)); // write bucket
+          fw.unsafe_push(create_meta(2,2u)); // write bucket
+          fw.unsafe_push(create_meta(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});

--- a/test/adiar/test_priority_queue.cpp
+++ b/test/adiar/test_priority_queue.cpp
@@ -314,7 +314,7 @@ go_bandit([]() {
         test_priority_queue<1,0> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue with empty meta stream", [&]() {
@@ -323,10 +323,10 @@ go_bandit([]() {
          test_priority_queue<1,0> pq({f});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can push to and pull from immediate next layer", [&]() {
+      it("can push to and pull from immediate next level", [&]() {
         pq_test_file f;
 
         {
@@ -340,10 +340,10 @@ go_bandit([]() {
 
         test_priority_queue<1,0> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
 
         pq.push(pq_test_data {2, 1});
         AssertThat(pq.size(), Is().EqualTo(1u));
@@ -351,10 +351,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -372,10 +372,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -390,10 +390,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -401,10 +401,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can skip unpushed layers", [&]() {
+      it("can skip unpushed levels", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -418,28 +418,28 @@ go_bandit([]() {
 
         test_priority_queue<1,0> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
 
         pq.push(pq_test_data {4, 1});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can skip unpushed layers up until the given stop_label", [&]() {
+      it("can skip unpushed levels up until the given stop_label", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -453,23 +453,23 @@ go_bandit([]() {
 
         test_priority_queue<1,0> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
 
         pq.push(pq_test_data {4, 1});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer(3u);
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(3u);
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -477,7 +477,7 @@ go_bandit([]() {
         AssertThat(pq.can_pull(), Is().False());
       });
 
-      it("can sort elements given out of layer order", [&]() {
+      it("can sort elements given out of level order", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -491,27 +491,27 @@ go_bandit([]() {
 
         test_priority_queue<1,0> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
 
         pq.push(pq_test_data {4, 2});
         AssertThat(pq.size(), Is().EqualTo(1u));
         pq.push(pq_test_data {3, 1});
         AssertThat(pq.size(), Is().EqualTo(2u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.can_pull(), Is().False());
 
         pq.push(pq_test_data {2, 1});
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -523,10 +523,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -542,10 +542,10 @@ go_bandit([]() {
         AssertThat(pq.can_pull(), Is().False());
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -571,18 +571,18 @@ go_bandit([]() {
 
          test_priority_queue<1,0> pq({f});
 
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().False());
          AssertThat(pq.size(), Is().EqualTo(0u));
 
          pq.push(pq_test_data {2, 2});
          AssertThat(pq.size(), Is().EqualTo(1u));
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.peek(), Is().EqualTo(pq_test_data {2, 2}));
@@ -596,7 +596,7 @@ go_bandit([]() {
     });
 
     describe("with 1 Bucket", [&]() {
-      it("can set up priority queue with more layers than buckets", [&]() {
+      it("can set up priority queue with more levels than buckets", [&]() {
          pq_test_file f;
 
          { // Garbage collect the writer early
@@ -611,10 +611,10 @@ go_bandit([]() {
          test_priority_queue<1,1> pq({f});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can set up priority queue with fewer layers than buckets", [&]() {
+      it("can set up priority queue with fewer levels than buckets", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -626,7 +626,7 @@ go_bandit([]() {
         test_priority_queue<1,1> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue with empty meta stream", [&]() {
@@ -635,7 +635,7 @@ go_bandit([]() {
          test_priority_queue<1,1> pq({f});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue for two meta streams, where one is empty", [&]() {
@@ -687,7 +687,7 @@ go_bandit([]() {
 
         test_priority_queue<1,1> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
 
@@ -698,10 +698,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -719,10 +719,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -737,10 +737,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -748,7 +748,7 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into overflow queue [1]", [&]() {
@@ -765,7 +765,7 @@ go_bandit([]() {
 
         test_priority_queue<1,1> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
 
@@ -775,10 +775,10 @@ go_bandit([]() {
         pq.push(pq_test_data {4, 1});
         AssertThat(pq.size(), Is().EqualTo(2u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -786,10 +786,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -812,17 +812,17 @@ go_bandit([]() {
 
         test_priority_queue<1,1> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
 
         pq.push(pq_test_data {4, 1});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -831,7 +831,7 @@ go_bandit([]() {
         AssertThat(pq.can_pull(), Is().False());
       });
 
-      it("can skip unpushed layers up to stop_label [1]", [&]() {
+      it("can skip unpushed levels up to stop_label [1]", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -845,32 +845,32 @@ go_bandit([]() {
 
         test_priority_queue<1,1> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
 
         pq.push(pq_test_data {4, 1});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer(3u);
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(3u);
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can skip unpushed layers up to stop_label [2]", [&]() {
+      it("can skip unpushed levels up to stop_label [2]", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -885,30 +885,30 @@ go_bandit([]() {
 
         test_priority_queue<1,1> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
 
         pq.push(pq_test_data {5, 1});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer(4u);
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(4u);
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(5u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(5u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {5, 1}));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can merge content of bucket with overflow queue", [&]() {
@@ -926,7 +926,7 @@ go_bandit([]() {
         test_priority_queue<1,1> pq({f});
 
         AssertThat(pq.size(), Is().EqualTo(0u));
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.can_pull(), Is().False());
 
         pq.push(pq_test_data {4, 2}); // overflow
@@ -939,10 +939,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -954,10 +954,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -973,10 +973,10 @@ go_bandit([]() {
         AssertThat(pq.can_pull(), Is().False());
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -1011,10 +1011,10 @@ go_bandit([]() {
          AssertThat(pq.size(), Is().EqualTo(1u));
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.peek(), Is().EqualTo(pq_test_data {2, 42}));
@@ -1047,10 +1047,10 @@ go_bandit([]() {
          AssertThat(pq.size(), Is().EqualTo(1u));
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(5u));
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(5u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.peek(), Is().EqualTo(pq_test_data {5, 3}));
@@ -1084,7 +1084,7 @@ go_bandit([]() {
         test_priority_queue<1,1> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {10, 2});
@@ -1092,10 +1092,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(10u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(10u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {10,2}));
@@ -1107,10 +1107,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(10u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(12u));
+        AssertThat(pq.current_level(), Is().EqualTo(10u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(12u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {12,1}));
@@ -1120,10 +1120,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(1u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(12u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(14u));
+        AssertThat(pq.current_level(), Is().EqualTo(12u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(14u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {14,1}));
@@ -1131,12 +1131,12 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
     });
 
     describe("with 4 Bucket", [&]() {
-      it("can set up priority queue with more layers than buckets", [&]() {
+      it("can set up priority queue with more levels than buckets", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -1155,7 +1155,7 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
       });
 
-      it("can set up priority queue with fewer layers than buckets [1]", [&]() {
+      it("can set up priority queue with fewer levels than buckets [1]", [&]() {
          pq_test_file f;
 
          { // Garbage collect the writer early
@@ -1169,7 +1169,7 @@ go_bandit([]() {
          test_priority_queue<1,4> pq({f});
        });
 
-      it("can set up priority queue with fewer layers than buckets [2]", [&]() {
+      it("can set up priority queue with fewer levels than buckets [2]", [&]() {
          pq_test_file f;
 
          { // Garbage collect the writer early
@@ -1188,7 +1188,7 @@ go_bandit([]() {
          test_priority_queue<1,4> pq({f});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
 
@@ -1205,7 +1205,7 @@ go_bandit([]() {
          test_priority_queue<2,4> pq({f1,f2});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue for two meta streams, where one is empty [2]", [&]() {
@@ -1222,7 +1222,7 @@ go_bandit([]() {
          test_priority_queue<2,4> pq({f1,f2});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue for two meta streams", [&]() {
@@ -1242,7 +1242,7 @@ go_bandit([]() {
          test_priority_queue<2,4> pq({f1,f2});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into and pull from buckets", [&]() {
@@ -1262,7 +1262,7 @@ go_bandit([]() {
 
         test_priority_queue<1,4> pq({f});
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
         AssertThat(pq.can_pull(), Is().False());
 
@@ -1278,10 +1278,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(5u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
         AssertThat(pq.size(), Is().EqualTo(5u));
 
         AssertThat(pq.can_pull(), Is().True());
@@ -1307,10 +1307,10 @@ go_bandit([]() {
         pq.push(pq_test_data {3, 1});
         AssertThat(pq.size(), Is().EqualTo(9u));
 
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -1355,10 +1355,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -1379,10 +1379,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(5u));
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(5u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {5, 1}));
@@ -1401,10 +1401,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(5u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(6u));
+        AssertThat(pq.current_level(), Is().EqualTo(5u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(6u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {6, 1}));
@@ -1424,10 +1424,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(6u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(7u));
+        AssertThat(pq.current_level(), Is().EqualTo(6u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(7u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {7, 1}));
@@ -1450,7 +1450,7 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into overflow queue [1]", [&]() {
@@ -1472,7 +1472,7 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {6, 4});
@@ -1482,10 +1482,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(6u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(6u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {6, 4}));
@@ -1493,10 +1493,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(6u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(8u));
+        AssertThat(pq.current_level(), Is().EqualTo(6u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(8u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {8,2}));
@@ -1504,7 +1504,7 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into overflow queue [2]", [&]() {
@@ -1526,17 +1526,17 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {8, 2});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(8u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(8u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {8,2}));
@@ -1544,7 +1544,7 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into overflow queue [3]", [&]() {
@@ -1570,7 +1570,7 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {10, 2});
@@ -1579,10 +1579,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(10u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(10u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {10,1}));
@@ -1593,10 +1593,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(1u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(10u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(12u));
+        AssertThat(pq.current_level(), Is().EqualTo(10u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(12u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {12,3}));
@@ -1604,10 +1604,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can skip unpushed layers until stop_label [1]", [&]() {
+      it("can skip unpushed levels until stop_label [1]", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -1626,23 +1626,23 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {8, 2});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer(3u);
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(3u);
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(8u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(8u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {8,2}));
@@ -1650,10 +1650,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can skip nonempty layers until stop_label [2]", [&]() {
+      it("can skip nonempty levels until stop_label [2]", [&]() {
         pq_test_file f;
 
         { // Garbage collect the writer early
@@ -1672,23 +1672,23 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {8, 2});
         AssertThat(pq.size(), Is().EqualTo(1u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer(7u);
-        AssertThat(pq.current_layer(), Is().EqualTo(7u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(7u);
+        AssertThat(pq.current_level(), Is().EqualTo(7u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(7u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(8u));
+        AssertThat(pq.current_level(), Is().EqualTo(7u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(8u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {8,2}));
@@ -1696,7 +1696,7 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can merge content of bucket with overflow queue", [&]() {
@@ -1718,7 +1718,7 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         // Push something into overflow
@@ -1743,10 +1743,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -1760,10 +1760,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(2u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -1790,10 +1790,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(3u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -1818,10 +1818,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(4u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(5u));
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(5u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {5, 1}));
@@ -1846,10 +1846,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(5u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(6u));
+        AssertThat(pq.current_level(), Is().EqualTo(5u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(6u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {6, 1}));
@@ -1878,10 +1878,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(6u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(7u));
+        AssertThat(pq.current_level(), Is().EqualTo(6u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(7u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {7, 1}));
@@ -1908,10 +1908,10 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.current_layer(), Is().EqualTo(7u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(8u));
+        AssertThat(pq.current_level(), Is().EqualTo(7u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(8u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {8, 1}));
@@ -1953,10 +1953,10 @@ go_bandit([]() {
          pq.push(pq_test_data {3, 42}); // bucket
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(3u));
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(3u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.peek(), Is().EqualTo(pq_test_data {3, 42}));
@@ -1986,10 +1986,10 @@ go_bandit([]() {
          pq.push(pq_test_data {7, 3});  // overflow
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(7u));
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(7u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.peek(), Is().EqualTo(pq_test_data {7, 3}));
@@ -1998,7 +1998,7 @@ go_bandit([]() {
          AssertThat(pq.can_pull(), Is().False());
       });
 
-      it("can deal with exactly as many layers as buckets", [&]() {
+      it("can deal with exactly as many levels as buckets", [&]() {
          pq_test_file f;
 
          { // Garbage collect the writer early
@@ -2017,10 +2017,10 @@ go_bandit([]() {
          pq.push(pq_test_data {2, 1});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(0u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
+         AssertThat(pq.current_level(), Is().EqualTo(0u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -2029,10 +2029,10 @@ go_bandit([]() {
          pq.push(pq_test_data {3, 1});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(3u));
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(3u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -2047,10 +2047,10 @@ go_bandit([]() {
          AssertThat(pq.can_pull(), Is().False());
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(3u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(4u));
+         AssertThat(pq.current_level(), Is().EqualTo(3u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(4u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
@@ -2061,10 +2061,10 @@ go_bandit([]() {
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 3}));
 
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
-      it("can deal with fewer layers as buckets", [&]() {
+      it("can deal with fewer levels as buckets", [&]() {
          pq_test_file f;
 
          { // Garbage collect the writer early
@@ -2081,10 +2081,10 @@ go_bandit([]() {
          pq.push(pq_test_data {1, 1});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(0u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
+         AssertThat(pq.current_level(), Is().EqualTo(0u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {1, 1}));
@@ -2092,10 +2092,10 @@ go_bandit([]() {
          pq.push(pq_test_data {2, 2});
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer();
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
+         AssertThat(pq.current_level(), Is().EqualTo(1u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level();
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
@@ -2105,7 +2105,7 @@ go_bandit([]() {
 
          AssertThat(pq.can_pull(), Is().False());
 
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can forward to stop_label with an empty overflow queue", [&]() {
@@ -2135,23 +2135,23 @@ go_bandit([]() {
          AssertThat(pq.size(), Is().EqualTo(2u));
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(0u));
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer(2u);
+         AssertThat(pq.current_level(), Is().EqualTo(0u));
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level(2u);
 
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
          AssertThat(pq.can_pull(), Is().False());
 
          pq.push(pq_test_data {3, 2});
          AssertThat(pq.size(), Is().EqualTo(3u));
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_layer(), Is().EqualTo(2u));
+         AssertThat(pq.current_level(), Is().EqualTo(2u));
 
-         AssertThat(pq.has_next_layer(), Is().True());
-         pq.setup_next_layer(4u);
+         AssertThat(pq.has_next_level(), Is().True());
+         pq.setup_next_level(4u);
 
-         AssertThat(pq.current_layer(), Is().EqualTo(3u));
+         AssertThat(pq.current_level(), Is().EqualTo(3u));
 
          AssertThat(pq.can_pull(), Is().True());
          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
@@ -2166,7 +2166,7 @@ go_bandit([]() {
          AssertThat(pq.size(), Is().EqualTo(0u));
 
          AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_layer(), Is().False());
+         AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into buckets after bucket level rewrite", [&]() {
@@ -2197,7 +2197,7 @@ go_bandit([]() {
         test_priority_queue<1,4> pq({f});
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
         AssertThat(pq.size(), Is().EqualTo(0u));
 
         pq.push(pq_test_data {9, 2});
@@ -2205,10 +2205,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(1u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(9u));
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(9u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {9,2}));
@@ -2223,10 +2223,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(6u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(9u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(10u));
+        AssertThat(pq.current_level(), Is().EqualTo(9u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(10u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {10,1}));
@@ -2236,30 +2236,30 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(4u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(10u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(11u));
+        AssertThat(pq.current_level(), Is().EqualTo(10u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(11u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {11,1}));
         AssertThat(pq.size(), Is().EqualTo(3u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(11u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(12u));
+        AssertThat(pq.current_level(), Is().EqualTo(11u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(12u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {12,1}));
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(12u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(13u));
+        AssertThat(pq.current_level(), Is().EqualTo(12u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(13u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {13,1}));
@@ -2269,10 +2269,10 @@ go_bandit([]() {
         AssertThat(pq.size(), Is().EqualTo(2u));
 
         AssertThat(pq.can_pull(), Is().False());
-        AssertThat(pq.current_layer(), Is().EqualTo(13u));
-        AssertThat(pq.has_next_layer(), Is().True());
-        pq.setup_next_layer();
-        AssertThat(pq.current_layer(), Is().EqualTo(14u));
+        AssertThat(pq.current_level(), Is().EqualTo(13u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(14u));
 
         AssertThat(pq.can_pull(), Is().True());
         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {14,1}));
@@ -2283,7 +2283,7 @@ go_bandit([]() {
 
         AssertThat(pq.can_pull(), Is().False());
 
-        AssertThat(pq.has_next_layer(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
     });
   });

--- a/test/adiar/test_reduce.cpp
+++ b/test/adiar/test_reduce.cpp
@@ -37,9 +37,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n4,sink_T });
               aw.unsafe_push_sink({ flag(n4),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
             }
 
             // Reduce it
@@ -72,13 +72,13 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -119,10 +119,10 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n5,sink_F });
               aw.unsafe_push_sink({ flag(n5),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
-              aw.unsafe_push(meta_t {3});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
+              aw.unsafe_push(create_meta(3,1u));
             }
 
             // Reduce it
@@ -157,16 +157,16 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {3}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -202,9 +202,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n4,sink_F });
               aw.unsafe_push_sink({ flag(n4),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
             }
 
             // Reduce it
@@ -236,13 +236,13 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -283,9 +283,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n5, sink_F });
               aw.unsafe_push_sink({ flag(n5), sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {2});
-              aw.unsafe_push(meta_t {3});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(2,2u));
+              aw.unsafe_push(create_meta(3,2u));
             }
 
             // Reduce it
@@ -318,13 +318,13 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 3 }));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 2 }));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t { 0 }));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -368,10 +368,10 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n6,sink_T });
               aw.unsafe_push_sink({ flag(n6),sink_F });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
-              aw.unsafe_push(meta_t {3});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
+              aw.unsafe_push(create_meta(3,2u));
             }
 
             // Reduce it
@@ -412,16 +412,16 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {3}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,2u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -462,10 +462,10 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n5,sink_F });
               aw.unsafe_push_sink({ flag(n5),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
-              aw.unsafe_push(meta_t {3});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
+              aw.unsafe_push(create_meta(3,1u));
             }
 
             // Reduce it
@@ -502,16 +502,16 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {3}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -547,9 +547,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n4,sink_F });
               aw.unsafe_push_sink({ flag(n4),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
             }
 
             // Reduce it
@@ -575,10 +575,10 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -625,10 +625,10 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n7,sink_T });
               aw.unsafe_push_sink({ flag(n7),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
-              aw.unsafe_push(meta_t {3});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,2u));
+              aw.unsafe_push(create_meta(2,3u));
+              aw.unsafe_push(create_meta(3,1u));
             }
 
 
@@ -667,13 +667,13 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,2u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -684,9 +684,9 @@ go_bandit([]() {
                  1                         ---- x0
                 / \
                 | 2                        ---- x1
-                |/ \        =>
-                3  4                4      ---- x2
-                |X/                / \
+                |/|         =>
+                3 4                 4      ---- x2
+                |X|                / \
                 F T                F T
             */
 
@@ -710,9 +710,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n4,sink_F });
               aw.unsafe_push_sink({ flag(n4),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_meta(2,2u));
             }
 
             // Reduce it
@@ -730,7 +730,9 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+
+            AssertThat(out_meta.can_pull(), Is().False());
           });
 
         it("can reduce down to a sink [1]", [&]() {
@@ -750,7 +752,7 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n1,sink_F });
               aw.unsafe_push_sink({ flag(n1),sink_F });
 
-              aw.unsafe_push(meta_t {0});
+              aw.unsafe_push(create_meta(0,1u));
             }
 
             // Reduce it
@@ -791,8 +793,8 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n2,sink_T });
               aw.unsafe_push_sink({ flag(n2),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,1u));
             }
 
             // Reduce it
@@ -845,9 +847,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n6,sink_T });
               aw.unsafe_push_sink({ flag(n6),sink_F });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,2u));
+              aw.unsafe_push(create_meta(2,3u));
             }
 
             // Reduce it
@@ -881,13 +883,13 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -929,9 +931,9 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n6,sink_F });
               aw.unsafe_push_sink({ flag(n6),sink_T });
 
-              aw.unsafe_push(meta_t {0});
-              aw.unsafe_push(meta_t {1});
-              aw.unsafe_push(meta_t {2});
+              aw.unsafe_push(create_meta(0,1u));
+              aw.unsafe_push(create_meta(1,2u));
+              aw.unsafe_push(create_meta(2,3u));
             }
 
             // Reduce it
@@ -965,13 +967,13 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {2}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {1}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -993,7 +995,7 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n1,sink_F });
               aw.unsafe_push_sink({ flag(n1),sink_T });
 
-              aw.unsafe_push(meta_t {0});
+              aw.unsafe_push(create_meta(0u,1u));
             }
 
             // Reduce it
@@ -1009,7 +1011,7 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {0}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
             AssertThat(out_meta.can_pull(), Is().False());
           });
 
@@ -1030,7 +1032,7 @@ go_bandit([]() {
               aw.unsafe_push_sink({ n1,sink_F });
               aw.unsafe_push_sink({ flag(n1),sink_T });
 
-              aw.unsafe_push(meta_t {42});
+              aw.unsafe_push(create_meta(42,1u));
             }
 
             // Reduce it
@@ -1046,7 +1048,7 @@ go_bandit([]() {
             meta_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(meta_t {42}));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(42u,1u)));
             AssertThat(out_meta.can_pull(), Is().False());
           });
       });

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -48,7 +48,7 @@ public:
 #include "adiar/test_file.cpp"
 #include "adiar/test_dot.cpp"
 
-#include "adiar/test_priority_queue.cpp"
+#include "adiar/test_levelized_priority_queue.cpp"
 
 #include "adiar/test_homomorphism.cpp"
 #include "adiar/test_reduce.cpp"


### PR DESCRIPTION
Adds level size to all meta files. This can be used later in #98 , but for now it resolves #118 which allows us to do

- Recognise trivially false cases in O(L) time and O(L/B) I/Os due to mismatches in the levels.