### PR TITLE
Add CI Static Analsysis: CPP Check, Inclusion Guards

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -71,8 +71,8 @@ jobs:
         git checkout ${{ needs.fetch-branch.outputs.branch }}
         git status
 
-    - name: Apt | install boost aptitude
-      run: sudo apt install libboost-all-dev aptitude
+    - name: Apt | install boost
+      run: sudo apt install libboost-all-dev
     - name: CMake | build
       run: |
         cmake -E make_directory build

--- a/.github/workflows/cppcheck.py
+++ b/.github/workflows/cppcheck.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import sys
+
+ignored_lines = [
+    "nofile:0:0: information: Cppcheck cannot find all the include files (use --check-config for details) [missingIncludeSystem]\n",
+    "\n"
+]
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print("Missing filename argument")
+        exit(1)
+
+    filename = str(sys.argv[1])
+    unignored_lines = []
+
+    with open(filename, "r") as f:
+        unignored_lines = [l for l in f.readlines() if not l in ignored_lines]
+
+    if len(unignored_lines) > 0:
+        with open(filename, "w") as f:
+            f.writelines(["Cppcheck\n","--------------\n","\n"] + unignored_lines)
+
+        print("Cppcheck found problems!")
+        print("------------------------------------------------------")
+        for l in unignored_lines:
+            print(l)
+        print("------------------------------------------------------")
+        exit(1)
+
+    print("All good!")
+    exit(0)

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -41,8 +41,8 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Apt | install boost aptitude
-      run: sudo apt install libboost-all-dev aptitude
+    - name: Apt | install boost
+      run: sudo apt install libboost-all-dev
     - name: CMake | build
       run: |
         cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,3 +23,31 @@ jobs:
         path: src/adiar
         pattern: 'ADIAR_{file}'
         ignore: 'adiar\.h'
+
+  cppcheck:
+    name: 'Cppcheck'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+          
+      - name: 'Run Cppcheck'
+        uses: deep5050/cppcheck-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable: warning,performance,portability,information,missingInclude
+          force_language: c++
+          output_file: ./cppcheck_report.txt
+
+      - name: 'Print cppcheck_report.txt'
+        run: cat ./cppcheck_report.txt
+
+      - name: 'Filter cppcheck_report.txt (fail if non-empty)'
+        run: sudo python3 .github/workflows/cppcheck.py ./cppcheck_report.txt
+
+      - name: 'Post cppcheck_report.txt on PR (if failed)'
+        if: failure()
+        uses: machine-learning-apps/pr-comment@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: ./cppcheck_report.txt

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,25 @@
+name: static analysis
+
+on: [pull_request]
+
+jobs:
+  include-guards:
+    name: Check include guards
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Check include guard of adiar.h
+      uses: sbeyer/include-guards-check-action@v1.0.0
+      with:
+        path: src/adiar
+        pattern: '{file}'
+        only: 'adiar\.h'
+
+    - name: Check include guards of remaining files
+      uses: sbeyer/include-guards-check-action@v1.0.0
+      with:
+        path: src/adiar
+        pattern: 'ADIAR_{file}'
+        ignore: 'adiar\.h'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Apt | install boost aptitude graphviz lcov
-      run: sudo apt install libboost-all-dev aptitude graphviz lcov
+      run: sudo apt install libboost-all-dev graphviz lcov
 
     - name: CMake | mkdir build
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/src/adiar/adiar.cpp
+++ b/src/adiar/adiar.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_CPP
-#define ADIAR_CPP
-
 #include "adiar.h"
 
 #include <tpie/tempname.h>
@@ -34,6 +31,3 @@ namespace adiar
     tpie::tpie_finish();
   }
 }
-
-
-#endif // ADIAR_CPP

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_APPLY_CPP
-#define ADIAR_APPLY_CPP
-
 #include "apply.h"
 
 #include <adiar/file_stream.h>
@@ -315,5 +312,3 @@ namespace adiar
     return bdd_apply(bdd_1, bdd_2, less_op);
   }
 }
-
-#endif // ADIAR_APPLY_CPP

--- a/src/adiar/bdd/assignment.cpp
+++ b/src/adiar/bdd/assignment.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_ASSIGNMENT_CPP
-#define ADIAR_ASSIGNMENT_CPP
-
 #include <adiar/data.h>
 #include <adiar/file.h>
 #include <adiar/file_stream.h>
@@ -72,5 +69,3 @@ namespace adiar
     return assignment_find(f, true, pick_high);
   }
 }
-
-#endif // ADIAR_ASSIGNMENT_CPP

--- a/src/adiar/bdd/bdd.cpp
+++ b/src/adiar/bdd/bdd.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_BDD_CPP
-#define ADIAR_BDD_CPP
-
 #include "bdd.h"
 
 #include <memory>
@@ -175,5 +172,3 @@ namespace adiar {
     return max_label(bdd.file);
   }
 }
-
-#endif // ADIAR_BDD_CPP

--- a/src/adiar/bdd/bdd.cpp
+++ b/src/adiar/bdd/bdd.cpp
@@ -79,11 +79,11 @@ namespace adiar {
     // TODO: Add adiar_assert on size?
   }
 
-  bdd::bdd(const bdd &o) : file(o.file), negate(o.negate) { }
+  bdd::bdd(const bdd &o) : negate(o.negate), file(o.file) { }
   bdd::bdd(bool v) : bdd(bdd_sink(v)) { }
-  bdd::bdd(bdd &&o) : file(o.file), negate(o.negate) { }
+  bdd::bdd(bdd &&o) : negate(o.negate), file(o.file) { }
 
-  bdd::bdd(__bdd &&o) : file(reduce(std::forward<__bdd>(o))), negate(o.negate) { }
+  bdd::bdd(__bdd &&o) : negate(o.negate), file(reduce(std::forward<__bdd>(o))) { }
 
   //////////////////////////////////////////////////////////////////////////////
   bdd& bdd::operator= (const bdd &other)
@@ -98,8 +98,8 @@ namespace adiar {
     free();
 
     // Reduce and move the resulting node_file into our own
-    this -> file = reduce(std::forward<__bdd>(other));
     this -> negate = other.negate;
+    this -> file = reduce(std::forward<__bdd>(other));
     return *this;
   }
 

--- a/src/adiar/bdd/bdd.h
+++ b/src/adiar/bdd/bdd.h
@@ -24,14 +24,14 @@ namespace adiar {
     friend node_file reduce(__bdd &&maybe_reduced);
 
     ////////////////////////////////////////////////////////////////////////////
-    // Privatize mutating functions from union.h
-  private:
-    using union_t<node_file, arc_file>::set;
-
-    ////////////////////////////////////////////////////////////////////////////
     // Propagating the negation, when given a bdd.
   public:
     const bool negate = false;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Privatize mutating functions from union.h
+  private:
+    using union_t<node_file, arc_file>::set;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -103,8 +103,8 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     // Internal state
   private:
-    node_file file;
     bool negate = false;
+    node_file file;
 
   private:
     void free();

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_BUILD_CPP
-#define ADIAR_BUILD_CPP
-
 #include "build.h"
 
 #include <adiar/file_stream.h>
@@ -172,5 +169,3 @@ namespace adiar {
     return nf;
   }
 }
-
-#endif // ADIAR_BUILD_CPP

--- a/src/adiar/bdd/count.cpp
+++ b/src/adiar/bdd/count.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_COUNT_CPP
-#define ADIAR_COUNT_CPP
-
 #include "count.h"
 
 #include <adiar/file_stream.h>
@@ -221,5 +218,3 @@ namespace adiar
       : count<sat_sum>(bdd, bdd_varcount(bdd));
   }
 }
-
-#endif // ADIAR_COUNT_CPP

--- a/src/adiar/bdd/count.h
+++ b/src/adiar/bdd/count.h
@@ -1,5 +1,5 @@
-#ifndef ADIAR_COUNT_PATHS_H
-#define ADIAR_COUNT_PATHS_H
+#ifndef ADIAR_COUNT_H
+#define ADIAR_COUNT_H
 
 #include <adiar/data.h>
 
@@ -45,4 +45,4 @@ namespace adiar
   uint64_t bdd_satcount(const bdd &bdd);
 }
 
-#endif // ADIAR_COUNT_PATHS_H
+#endif // ADIAR_COUNT_H

--- a/src/adiar/bdd/evaluate.cpp
+++ b/src/adiar/bdd/evaluate.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_EVALUATE_CPP
-#define ADIAR_EVALUATE_CPP
-
 #include "evaluate.h"
 
 #include <adiar/file_stream.h>
@@ -43,5 +40,3 @@ namespace adiar
     }
   }
 }
-
-#endif // ADIAR_EVALUATE_CPP

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_IF_THEN_ELSE_CPP
-#define ADIAR_IF_THEN_ELSE_CPP
-
 #include "if_then_else.h"
 
 #include <adiar/file_stream.h>
@@ -482,5 +479,3 @@ namespace adiar
     return out_arcs;
   }
 }
-
-#endif // ADIAR_IF_THEN_ELSE_CPP

--- a/src/adiar/bdd/negate.cpp
+++ b/src/adiar/bdd/negate.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_NEGATE_CPP
-#define ADIAR_NEGATE_CPP
-
 #include "negate.h"
 
 #include <adiar/file_stream.h>
@@ -23,5 +20,3 @@ namespace adiar
     return b;
   }
 }
-
-#endif // ADIAR_NEGATE_CPP

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_QUANTIFY_CPP
-#define ADIAR_QUANTIFY_CPP
-
 #include "quantify.h"
 
 #include <adiar/file_stream.h>
@@ -330,5 +327,3 @@ namespace adiar
     multi_quantify_macro(in_bdd, labels, and_op);
   }
 }
-
-#endif // ADIAR_QUANTIFY_CPP

--- a/src/adiar/bdd/restrict.cpp
+++ b/src/adiar/bdd/restrict.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_RESTRICT_CPP
-#define ADIAR_RESTRICT_CPP
-
 #include "restrict.h"
 
 #include <tpie/file_stream.h>
@@ -153,5 +150,3 @@ namespace adiar
     return out_arcs;
   }
 }
-
-#endif // ADIAR_RESTRICT_CPP

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_DATA_CPP
-#define ADIAR_DATA_CPP
-
 #include "data.h"
 
 #include <assert.h>
@@ -446,5 +443,3 @@ namespace adiar {
     return !(a==b);
   }
 }
-
-#endif // ADIAR_DATA_CPP

--- a/src/adiar/dot.cpp
+++ b/src/adiar/dot.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_DOT_CPP
-#define ADIAR_DOT_CPP
-
 #include "dot.h"
 
 namespace adiar {
@@ -44,5 +41,3 @@ namespace adiar {
     out.close();
   }
 }
-
-#endif // ADIAR_DOT_CPP

--- a/src/adiar/file.cpp
+++ b/src/adiar/file.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_FILE_CPP
-#define ADIAR_FILE_CPP
-
 #include "file.h"
 
 #include <adiar/assert.h>
@@ -69,5 +66,3 @@ namespace adiar
     return nodes.meta_size();
   }
 }
-
-#endif // ADIAR_FILE_CPP

--- a/src/adiar/file_stream.cpp
+++ b/src/adiar/file_stream.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_FILE_STREAM_CPP
-#define ADIAR_FILE_STREAM_CPP
-
 #include "file_stream.h"
 
 namespace adiar
@@ -17,5 +14,3 @@ namespace adiar
   template<>
   meta_stream<arc_t, 2, true>::meta_stream(const __bdd& bdd) : meta_stream(bdd.get<arc_file>()) { }
 }
-
-#endif // ADIAR_FILE_STREAM_CPP

--- a/src/adiar/file_writer.cpp
+++ b/src/adiar/file_writer.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_FILE_WRITER_CPP
-#define ADIAR_FILE_WRITER_CPP
-
 #include "file_writer.h"
 
 namespace adiar {
@@ -10,5 +7,3 @@ namespace adiar {
     return nw;
   }
 }
-
-#endif // ADIAR_FILE_WRITER_CPP

--- a/src/adiar/file_writer.h
+++ b/src/adiar/file_writer.h
@@ -37,7 +37,7 @@ namespace adiar {
 
     Comp _comp = Comp();
 
-    bool _has_latest;
+    bool _has_latest = false;
     T _latest;
 
   public:

--- a/src/adiar/homomorphism.cpp
+++ b/src/adiar/homomorphism.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_HOMOMORPHISM_CPP
-#define ADIAR_HOMOMORPHISM_CPP
-
 #include "homomorphism.h"
 
 #include <adiar/file_stream.h>
@@ -185,5 +182,3 @@ namespace adiar
     return true;
   }
 }
-
-#endif // ADIAR_HOMOMORPHISM_CPP

--- a/src/adiar/levelized_priority_queue.cpp
+++ b/src/adiar/levelized_priority_queue.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_PRIORITY_QUEUE_CPP
-#define ADIAR_PRIORITY_QUEUE_CPP
-
 #include <tpie/priority_queue.h> // imports tpie::consecutive_memory_available
 
 #include "levelized_priority_queue.h"
@@ -16,5 +13,3 @@ namespace adiar {
     return static_cast<float>(memory_given) / static_cast<float>(mm_avail);
   }
 }
-
-#endif // ADIAR_PRIORITY_QUEUE_CPP

--- a/src/adiar/levelized_priority_queue.h
+++ b/src/adiar/levelized_priority_queue.h
@@ -1,5 +1,5 @@
-#ifndef ADIAR_PRIORITY_QUEUE_H
-#define ADIAR_PRIORITY_QUEUE_H
+#ifndef ADIAR_LEVELIZED_PRIORITY_QUEUE_H
+#define ADIAR_LEVELIZED_PRIORITY_QUEUE_H
 
 #include <tpie/tpie.h>
 
@@ -657,4 +657,4 @@ namespace adiar {
   using levelized_arc_priority_queue = levelized_priority_queue<arc_t, 2u, T, LabelExt, TComparator, LabelComparator, MetaStreams, Buckets>;
 }
 
-#endif // ADIAR_PRIORITY_QUEUE_H
+#endif // ADIAR_LEVELIZED_PRIORITY_QUEUE_H

--- a/src/adiar/reduce.cpp
+++ b/src/adiar/reduce.cpp
@@ -1,6 +1,3 @@
-#ifndef ADIAR_REDUCE_CPP
-#define ADIAR_REDUCE_CPP
-
 #include "reduce.h"
 
 #include <tpie/sort.h>
@@ -269,6 +266,4 @@ namespace adiar
     }
     return out_file;
   }
-} // namespace adiar
-
-#endif // ADIAR_REDUCE_CPP
+}


### PR DESCRIPTION
Adds basic code quality control, such as _inclusion guard_ checks and running _CPP Check_. For the latter I had to turn off the `style` checks, since they complain about the implicit one-argument constructors of `bdd` and `__bdd`, though our entire garbage collection works based on these.

As part of these checks I have fixed the following problems
- Inclusion guards in _.cpp_ files should not be there
- Initialization of some variables in the `levelized_priority_queue` private constructor were not in the initialization list.
- `_memory_occupied_by_meta` was not updated correctly in `setup_buckets` for the input being completely without any labels.