### PR TITLE
Simplify CMake and improve submodule interaction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,14 @@ jobs:
 
     - name: CMake | mkdir build
       run: cmake -E make_directory ${{runner.workspace}}/build
+
     - name: CMake | configure
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -D CMAKE_BUILD_TYPE=Debug -D CODE_COVERAGE=ON
+      env:
+        C_FLAGS: "-g -O0 -Wall -fprofile-arcs -ftest-coverage"
+        EXE_LINKER_FLAGS: "-fprofile-arcs -ftest-coverage"
+      run: cmake $GITHUB_WORKSPACE -D CMAKE_BUILD_TYPE=DEBUG -D CMAKE_C_FLAGS="${C_FLAGS}" -D CMAKE_CXX_FLAGS="${C_FLAGS}" -D CMAKE_EXE_LINKER_FLAGS="${EXE_LINKER_FLAGS}" ..
+
     - name: CMake | build unit tests
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --target test_unit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 cmake_minimum_required(VERSION 3.10)
 project (adiar
-  VERSION 1.0
+  VERSION 1.0.0
   DESCRIPTION "Adiar, an external memory decision diagram library"
   HOMEPAGE_URL "https://ssoelvsten.github.io/adiar/"
   LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,34 @@
-# Parts of this CMakeLists.txt is derived from the files of the tpie and
+# Parts of this CMakeLists.txt is derived from the files of the tpie, lace and
 # sylvan projects.
 
-cmake_minimum_required(VERSION 3.8)
+# Check if this is used as part of a solo project.
+if(DEFINED PROJECT_NAME)
+  set(MAIN_PROJECT OFF)
+else()
+  set(MAIN_PROJECT ON)
+endif()
+
+cmake_minimum_required(VERSION 3.10)
 project (adiar
   VERSION 1.0
   DESCRIPTION "Adiar, an external memory decision diagram library"
+  HOMEPAGE_URL "https://ssoelvsten.github.io/adiar/"
   LANGUAGES CXX
 )
 
-message(STATUS "CMake build configuration for Adiar ${PROJECT_VERSION}")
 enable_language(CXX)
 
-set(CMAKE_C_STANDARD 17)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-option(CODE_COVERAGE "Build with coverage profiling" OFF)
-option(ADIAR_TEST "Build adiar unit tests" OFF)
-
-if (CODE_COVERAGE)
-  set(CMAKE_C_FLAGS "-g -O0 -Wall -W -fprofile-arcs -ftest-coverage ${CMAKE_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "-g -O0 -Wall -fprofile-arcs -ftest-coverage ${CMAKE_CXX_FLAGS}")
-  set(CMAKE_EXE_LINKER_FLAGS "-fprofile-arcs -ftest-coverage")
-elseif (ADIAR_TEST)
-  set(CMAKE_C_FLAGS "-g -O2 ${CMAKE_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "-g -O2 ${CMAKE_CXX_FLAGS}")
-endif()
+message(STATUS "CMake build configuration for Adiar ${PROJECT_VERSION}")
+message(STATUS "  OS: ${CMAKE_SYSTEM_NAME}")
+message(STATUS "  Compiler: ${CMAKE_CXX_COMPILER_ID}")
+message(STATUS "    C Flags: ${CMAKE_C_FLAGS}")
+message(STATUS "    CXX Flags: ${CMAKE_CXX_FLAGS}")
+message(STATUS "    EXE Linker Flags: ${CMAKE_EXE_LINKER_FLAGS}")
+message(STATUS "  Tests and Examples: ${MAIN_PROJECT}")
+message(STATUS "")
 
 # ============================================================================ #
-# Common Dependencies
+# Dependencies
 # ============================================================================ #
 add_subdirectory (external/tpie tpie)
 
@@ -37,25 +36,24 @@ add_subdirectory (external/tpie tpie)
 # Core project
 # ============================================================================ #
 option(ADIAR_SHARED "Build adiar as a shared library" OFF)
+message(STATUS "  Shared library: ${ADIAR_SHARED}")
 
 add_subdirectory (src)
 
-# ============================================================================ #
-# Test Files
-# ============================================================================ #
-if (ADIAR_TEST OR CODE_COVERAGE)
-  # enable_testing() # No need, as we use Bandit
-  add_subdirectory (test)
-endif()
-
-# ============================================================================ #
-# install Adiar as a library to use
-# ============================================================================ #
 install(DIRECTORY src/adiar
         DESTINATION include
         FILES_MATCHING REGEX "\\.h$")
 
 # ============================================================================ #
+# Unit Tests
+# ============================================================================ #
+if (MAIN_PROJECT)
+  add_subdirectory (test)
+endif()
+
+# ============================================================================ #
 # Examples
 # ============================================================================ #
-add_subdirectory (example)
+if (MAIN_PROJECT)
+  add_subdirectory (example)
+endif ()

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,11 +57,7 @@ _CMakeLists.txt_ file with the following lines.
 ```cmake
 add_executable(<target> <source>)
 target_link_libraries(<target> adiar)
-set_target_properties(<target> PROPERTIES CXX_STANDARD 17)
 ```
-
-You only need to include the third line if the `CXX_STANDARD` has not been set
-project-wide to 17 or higher.
 
 ## Usage
 After having linked the C++ source file with _Adiar_ as described above, then

--- a/makefile
+++ b/makefile
@@ -22,9 +22,11 @@ clean: | clean-files
 # ============================================================================ #
 #  TEST
 # ============================================================================ #
+TEST_C_FLAGS = "-g -O2"
+
 test:
 	@mkdir -p build/
-	@cd build/ && cmake -D CMAKE_BUILD_TYPE=Debug -D ADIAR_TEST=ON ..
+	@cd build/ && cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=$(TEST_C_FLAGS) -D CMAKE_CXX_FLAGS=$(TEST_C_FLAGS) ..
 	@cd build/ && make $(MAKE_FLAGS) test_unit
 
 	$(MAKE) clean-files
@@ -32,9 +34,12 @@ test:
 	@./build/test/test_unit --reporter=info --colorizer=light
 	$(MAKE) clean-files
 
+COV_C_FLAGS = "-g -O0 -Wall -fprofile-arcs -ftest-coverage"
+COV_EXE_LINKER_FLAGS = "-fprofile-arcs -ftest-coverage"
+
 coverage:
 	@mkdir -p build/
-	@cd build/ && cmake -D CMAKE_BUILD_TYPE=Debug -D CODE_COVERAGE=ON ..
+	@cd build/ && cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=$(COV_C_FLAGS) -D CMAKE_CXX_FLAGS=$(COV_C_FLAGS) -D CMAKE_EXE_LINKER_FLAGS=$(COV_EXE_LINKER_FLAGS) ..
 	@cd build/ && make $(MAKE_FLAGS) test_unit
 
 	@lcov --directory build/src/adiar/ --zerocounters

--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -98,6 +98,8 @@ set_target_properties(adiar PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
 
+target_compile_features(adiar PUBLIC cxx_std_17)
+
 install(TARGETS adiar
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -67,7 +67,9 @@ else()
 endif()
 
 include(GenerateExportHeader)
-generate_export_header(adiar)
+generate_export_header(adiar
+  EXPORT_MACRO_NAME ADIAR_API
+)
 
 # ============================================================================ #
 # Link dependencies
@@ -77,7 +79,7 @@ target_link_libraries(adiar tpie)
 # Setup as library
 
 target_include_directories(adiar PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/..
-                                       ${CMAKE_CURRENT_SOURCE_DIR}/..)
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 set_target_properties(adiar PROPERTIES
   # Language settings
@@ -97,5 +99,8 @@ set_target_properties(adiar PROPERTIES
 )
 
 install(TARGETS adiar
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${LIBLEGACY_INCLUDE_DIRS}
+)


### PR DESCRIPTION
Clean up and improvements to CMake

- Output build configuration output to console
- Add missing _patch_ number in semantic versioning and _homepage url_
- Make unit tests and examples not included in the build targets when _Adiar_ is included as a submodule (shamelessly stolen from the [lace](https://github.com/trolando/lace/) CMake files).
  - Moves the compiler flags completely out of the CMake files and into the hands of the user.
- Remove the need for `set_target_properties(<target> PROPERTIES CXX_STANDARD 17)` when linking to _Adiar_.