### PR TITLE
Fix bdd_counter returns trivially true on trivially false cases

### DIFF
--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -123,7 +123,7 @@ namespace adiar {
     ptr_t lt_sink = create_sink_ptr(false); // create_sink(comparator(threshold - 1, threshold));
 
     if (max_label - min_label + 1 < threshold) {
-      return bdd_sink(lt_sink);
+      return bdd_sink(false);
     }
 
     node_file nf;

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -236,14 +236,28 @@ go_bandit([]() {
         describe("bdd_counter", [&]() {
             it("creates trivially do counting to 10 in [0,8]", [&]() {
                 bdd res = bdd_counter(0, 8, 10);
-                AssertThat(is_sink(res), Is().True());
-                AssertThat(is_sink(res, is_true), Is().True());
+
+                node_test_stream ns(res);
+
+                AssertThat(ns.can_pull(), Is().True());
+                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+                AssertThat(ns.can_pull(), Is().False());
+
+                meta_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+                AssertThat(ms.can_pull(), Is().False());
               });
 
             it("creates trivially do counting to 10 in [10,18]", [&]() {
                 bdd res = bdd_counter(10, 18, 10);
-                AssertThat(is_sink(res), Is().True());
-                AssertThat(is_sink(res, is_true), Is().True());
+
+                node_test_stream ns(res);
+
+                AssertThat(ns.can_pull(), Is().True());
+                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+                AssertThat(ns.can_pull(), Is().False());
+
+                meta_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+                AssertThat(ms.can_pull(), Is().False());
               });
 
             it("creates counting to 0 in [1,5]", [&]() {


### PR DESCRIPTION
The `lt_sink` variable was of type `ptr_t` not `bool`. So while it was representing the false sink, the number itself was non-zero and hence not falsy.