### PR TITLE
Updating FUTURE_WORK

### DIFF
--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -19,7 +19,6 @@ may constitute interesting undergraduate and graduate projects.
         - [Proof Logging](#proof-logging)
     - [Other Decision Diagrams](#other-decision-diagrams)
         - [Multi-Terminal Binary Decision Diagrams](#multi-terminal-binary-decision-diagrams)
-        - [Zero-suppressed Decision Diagrams](#zero-suppressed-decision-diagrams)
         - [Multi-valued Decision Diagrams](#multi-valued-decision-diagrams)
         - [Free Boolean Decision Diagrams](#free-boolean-decision-diagrams)
     - [Optimising the current algorithms](#optimising-the-current-algorithms)
@@ -225,49 +224,6 @@ One can easily extend the proposed representation of sink nodes to encompass
 non-boolean values, such as integers or floats. Thereby, the algorithms
 immediately yield an I/O efficient implementation of the _Multi-Terminal Binary
 Decision Diagrams_ (MTBDD) of [[Fujita97](#references)].
-
-### Zero-suppressed Decision Diagrams
-A Zero-suppressed Decision Diagram [[Minato93,Minato01](#references)] is a binary
-decision diagram, which is very compresed when representing sparse sets of bit
-vectors. This has been shown to be great for solving NP-Complete problems and
-symbolic model checking algorithms on sparse sets of states.
-
-To achieve this, ZDDs make use of a different reduction rule than BDDs to do so.
-So, to implement them we need to:
-
-- Generalize the _Reduce_ with a strategy pattern with lambdas.
-
-- Repurpose/Generalize current algorithms wherever possible
- 
-  - `zdd_empty`: Same as `bdd_false`
-
-  - `zdd_null`/`zdd_base`: Same as `bdd_true`
-
-  - `zdd_ithvar`: Same as `bdd_ithvar`
-
-  - `zdd_union`, `zdd_intsec`, `zdd_diff`: A generalized `bdd_apply` algorithm with
-    _or_, _and_ and _diff_ as the operators. The recursion request generation for ZDDs
-    need to take into account the operator and the reduction rule to be optimal. So, a
-    it is needed to add a strategy pattern in that spot (and to make Apply work with
-    `nil` inside of the request tuples?).
-
-  - `zdd_onset`/`zdd_subset1` and `zdd_offset`/`zdd_subset0`: Can be done with `bdd_restrict`
-
-  - `zdd_count`: Same as `bdd_pathcount`
-  
-- Implement other 'new' and more complex algorithms.
-
-  - `zdd_change`: Should be possible to do in a single bottom-up sweep, though one
-    needs to remove/add nodes based on the reduction rules above the given label.
-  
-  - Unate Cube operations `zdd_prod`, `zdd_div`, `zdd_mod` [[Minato01](#references)]:
-    These seem to again do a double-recursion similar to `bdd_exists` and `bdd_forall`.
-    So, we can probably reuse the same technique to make this more efficient.
-
-- Finally, the functions for reasoning about state-transition systems into ZDDs, such
-  as `bdd_ite`, `bdd_exists` and `bdd_relprod` needs to be translated. See
-  [[Hajighasemi14](#references)] for a recursive version of these.
-
 
 ### Multi-valued Decision Diagrams
 By solely using an edge-based representation of the data-structure one can also

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -1,22 +1,22 @@
 # Future Work
 In the following we list multiple avenues for optimisations and extensions which
-may constitute interesting undergraduate research projects.
+may constitute interesting undergraduate and graduate projects.
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [Future Work](#future-work)
-    - [Implementation of missing BDD algorithms](#implementation-of-missing-bdd-algorithms)
+    - [Missing BDD algorithms](#missing-bdd-algorithms)
         - [Data type conversions](#data-type-conversions)
         - [Projection](#projection)
         - [Set manipulation](#set-manipulation)
         - [Composition](#composition)
         - [Advanced satisfiability functions](#advanced-satisfiability-functions)
         - [Coudert's and Madre's BDD functions](#couderts-and-madres-bdd-functions)
-    - [Optimising the BDD](#optimising-the-bdd)
-        - [Complement Edges](#complement-edges)
-    - [Extensions](#extensions)
+    - [Additional Featyres](#additional-features)
+        - [Attributed Edges](#attributed-edges)
         - [Proof Logging](#proof-logging)
+    - [Other Decision Diagrams](#other-decision-diagrams)
         - [Multi-Terminal Binary Decision Diagrams](#multi-terminal-binary-decision-diagrams)
         - [Zero-suppressed Decision Diagrams](#zero-suppressed-decision-diagrams)
         - [Multi-valued Decision Diagrams](#multi-valued-decision-diagrams)
@@ -30,8 +30,8 @@ may constitute interesting undergraduate research projects.
 <!-- markdown-toc end -->
 
 
-## Implementation of missing BDD algorithms
-There are still many features for BDDs not yet addressed in the _Adiar_ library,
+## Missing BDD algorithms
+There are still many algorithms for BDDs not yet present in the _Adiar_ library,
 and valuable additions to the current project can be made in implementing these.
 All of these of course should be made in the style of _Time-Forward Processing_
 like the rest.
@@ -52,7 +52,7 @@ Similarly, the `bdd_and` and `bdd_or` functions in `bdd/build.cpp` should maybe
 be extended to also take an array, `std::vector`, or even make them variadic.
 
 The simple way to do this would be by _O(N)_ time and _(N/B)_ I/O algorithms that
-use _O(N)_ more space on disk. I would expect though, that with some templating
+use _O(N)_ more space on disk. I would expect though that (with some templating)
 it should be possible to reuse the original files and convert the types on-the-fly.
 
 ### Projection
@@ -114,16 +114,19 @@ are:
 - `bdd_expand`: Their _Expand_ function
 
 
-## Optimising the BDD
+## Additional features
 
-### Complement Edges
+### Attributed edges
 Currently, we do not support complement edges, though one can expect about a 7%
 factor decrease in the size of the OBDD from using said technique. In the
 recursive algorithms, one can even expect a factor two decrease in the
 algorithms execution time [[Brace90](#references)].
 
+Our bit representation of _unique identifiers_ already has a single bit-flag,
+which is currently unused in a _node_ and on the _target_ of an _arc_. These are
+currently reserved for implementation of this very feature, meaning we primarily
+are lacking the additional logic in all of the algorithms.
 
-## Extensions
 
 ### Proof Logging
 A problem in SAT solving is trusting the solver when it claims a formula to be
@@ -181,6 +184,8 @@ Since most of the work is placed within the Reduce algorithm, then almost all
 other algorithms (such as quantification) can also immediately create the
 relevant proof.
 
+
+## Other Decision Diagrams
 
 ### Multi-Terminal Binary Decision Diagrams
 One can easily extend the proposed representation of sink nodes to encompass
@@ -291,10 +296,15 @@ See also the discussion in issue [#98](https://github.com/SSoelvsten/adiar/issue
 
 ## References
 
+- [[Blum80](https://www.sciencedirect.com/science/article/pii/S0020019080900782)]
+  Manuel Blum, Ashok K. Chandra, and Mark N.Wegman. “_Equivalence of free boolean
+  graphs can be decided probabilistically in polynomial time_”. In: _27th ACM/IEEE Design Automation
+  Conference_. pp. 40 – 45 (1990)
+
 - [[Brace90](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=114826)]
   Karl S. Brace, Richard L. Rudell, and Randal E. Bryant. “_Efficient
-  implementation of a BDD package_”. In: _27th ACM/IEEE Design Automation
-  Conference_. pp. 40 – 45 (1990)
+  implementation of a BDD package_”. In: _Information Processing Letters 10.2_.
+  (1980)
 
 - [[Bryant21](https://arxiv.org/abs/2105.00885)]
   Randal E. Bryant, Marijn J. H. Heule. “_Generating Extended Resolution Proofs

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -15,6 +15,7 @@ may constitute interesting undergraduate and graduate projects.
         - [Coudert's and Madre's BDD functions](#couderts-and-madres-bdd-functions)
     - [Additional Featyres](#additional-features)
         - [Attributed Edges](#attributed-edges)
+        - [Hash Values](#hash-values)
         - [Proof Logging](#proof-logging)
     - [Other Decision Diagrams](#other-decision-diagrams)
         - [Multi-Terminal Binary Decision Diagrams](#multi-terminal-binary-decision-diagrams)
@@ -126,6 +127,38 @@ Our bit representation of _unique identifiers_ already has a single bit-flag,
 which is currently unused in a _node_ and on the _target_ of an _arc_. These are
 currently reserved for implementation of this very feature, meaning we primarily
 are lacking the additional logic in all of the algorithms.
+
+
+### Hash Values
+This approach is based on a suggestion by Bryant for how to improve the
+performance of equality checking. His idea is based on [[Blum80](#references)].
+His intention was to obtain an O(N/B) I/O comparison at price of increased
+memory, but the equality checking in
+[#127](https://github.com/SSoelvsten/adiar/pull/127) obtains the same bound
+without any increase in size by exploiting a feature of our _Reduce_ algorithm.
+Yet, this idea of hashing could be useful for further improving the speed of our
+equality checking in the negative cases.
+
+Let _p_ be a prime number (though the math may work out even when doing all
+computations with the non-prime p = 2<sup>k</sup>, i.e. by abusing the overflow
+of unsigned integers). Consider a hash function _H_ (all numbers computed modulo
+_p_) defined as follows
+
+- Leaves hash to their value, i.e. H(0) = 0 and H(1) = 1
+
+- Variables x<sub>i</sub> hash to a random value in [0;_p_)
+
+- Internal nodes has as follows:
+  H((x<sub>i</sub>), v<sub>0</sub>, v<sub>1</sub>) =
+  H(x<sub>i</sub>) H(v<sub>1</sub>) + (1 - H(x<sub>i</sub>) H(v<sub>0</sub>))
+
+Then the probability of two different BDDs share the same hash value is 1/_p_.
+
+Notice, we only care about the hash value at the root, so we do not need to
+store the hash value within each and every node. Instead, similar to
+_canonicity_ in [#127](https://github.com/SSoelvsten/adiar/pull/127), we can
+store the hash of the root (and its negation) as two numbers in the `node_file`
+and merely propagate the hash values in the priority queue of `adiar::reduce`.
 
 
 ### Proof Logging

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -13,7 +13,6 @@ may constitute interesting undergraduate research projects.
         - [Composition](#composition)
         - [Advanced satisfiability functions](#advanced-satisfiability-functions)
         - [Coudert's and Madre's BDD functions](#couderts-and-madres-bdd-functions)
-        - [Variable reordering](#variable-reordering)
     - [Optimising the BDD](#optimising-the-bdd)
         - [Complement Edges](#complement-edges)
     - [Extensions](#extensions)
@@ -113,28 +112,6 @@ are:
 - `bdd_simplify`: Their _Restrict_ function
 - `bdd_constrain`: Their _Constrain_ function
 - `bdd_expand`: Their _Expand_ function
-
-
-### Variable reordering
-
-Currently, _Adiar_ only uses a static ordering of the variables, but since the
-size of the BDD is heavily influenced by the order chosen then many BDD
-libraries provide variable reordering algorithms, or even do these themselves
-behind the scenes.
-
-This essentially involves two steps:
-
-- Implement a `bdd_replace` function that is given a label_tuple file
-- Implement heuristics that generate the label_tuple file for the `bdd_replace`,
-  that then can be run with a `bdd_reorder` function.
-
-How one can rephrase these within the design of _Adiar_ will probably require
-quite a bit of creativity, understanding of the I/O model and also of the original
-variable reordering algorithms.
-
-The question also is, what should we do when using a reordered BDD? Should the
-renaming be explicit to the user, or should it stay transparent? The latter would
-result in many more changes in the data types and all other algorithms.
 
 
 ## Optimising the BDD


### PR DESCRIPTION
Adds information for _proof logging_ and _hashing_, since they might be interesting projects. This also removes the addition of _zero-suppressed decision diagrams_ since they are added in #128 and finally removes variable reordering, since we may actually look into this ourselves. 