### PR TITLE
Fix/memory in bytes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -83,4 +83,4 @@ jobs:
         cmake ../ -D CMAKE_BUILD_TYPE=Release && cmake --build . --target ${{ matrix.exec }}
 
     - name: Run Benchmark
-      run: for n in ${{ matrix.N }}; do build/src/${{ matrix.exec }} $n 1024; done
+      run: for n in ${{ matrix.N }}; do build/src/${{ matrix.exec }} -N $n -M 1024; done

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -70,7 +70,7 @@ terminates.
 
 int main()
 {
-  adiar::adiar_init(128);
+  adiar::adiar_init(128 * 1024 * 1024);
 
   {
     // do your stuff here...
@@ -82,9 +82,9 @@ int main()
 
 The `adiar_init` function initialises the BDD library given the following arguments
 
-- `memory_limit_mb`
+- `memory_limit_bytes`
 
-  The amount of internal memory in MiB that the _Adiar_ BDD library is allowed
+  The amount of internal memory (in bytes) that the _Adiar_ BDD library is allowed
   to use.
 
 - `temp_dir` (optional)

--- a/example/queens.cpp
+++ b/example/queens.cpp
@@ -451,7 +451,7 @@ int main(int argc, char* argv[])
 
   // ===== ADIAR =====
   // Initialize
-  adiar::adiar_init(M);
+  adiar::adiar_init(M*1024*1024);
   tpie::log_info() << "| Initialized Adiar with " << M << " MB of memory"  << std::endl << "|" << std::endl;
 
   // ===== N Queens =====

--- a/src/adiar/adiar.cpp
+++ b/src/adiar/adiar.cpp
@@ -4,12 +4,12 @@
 
 namespace adiar
 {
-  void adiar_init(size_t memory_limit_mb, std::string temp_dir)
+  void adiar_init(size_t memory_limit_bytes, std::string temp_dir)
   {
     tpie::tpie_init();
 
     // Memory usage
-    set_limit(memory_limit_mb);
+    set_limit(memory_limit_bytes);
 
     // Temporary files
     tpie::tempname::set_default_base_name("ADIAR");
@@ -20,10 +20,11 @@ namespace adiar
     }
   }
 
-  void set_limit(size_t memory_limit_mb)
+  void set_limit(size_t memory_limit_bytes)
   {
-    adiar_assert(memory_limit_mb >= 128, "ADIAR requires at least 128 MB of memory");
-    tpie::get_memory_manager().set_limit(memory_limit_mb * 1024 * 1024);
+    adiar_assert(memory_limit_bytes >= 128 * 1024 * 1024,
+                 "ADIAR requires at least 128 MiB of memory");
+    tpie::get_memory_manager().set_limit(memory_limit_bytes);
   }
 
   void adiar_deinit()

--- a/src/adiar/adiar.h
+++ b/src/adiar/adiar.h
@@ -34,18 +34,18 @@
 namespace adiar
 {
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Initiates ADIAR with the given amount of memory in MB
+  /// \brief Initiates ADIAR with the given amount of memory (given in bytes)
   ///
   /// TODO: Should we provide an option to change the maximum variable number?
   ///       What about opening files by others? Should we store that somehow in
   ///       the first element of the meta stream?
   //////////////////////////////////////////////////////////////////////////////
-  void adiar_init(size_t memory_limit_mb, std::string temp_dir = "");
+  void adiar_init(size_t memory_limit_bytes, std::string temp_dir = "");
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Changes the memory limit used by ADIAR
+  /// \brief Changes the memory limit used by ADIAR (given in bytes)
   //////////////////////////////////////////////////////////////////////////////
-  void set_limit(size_t memory_limit_mb);
+  void set_limit(size_t memory_limit_bytes);
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Closes and cleans up everything by ADIAR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
     tpie::log_info() << "Number out of range: " << argv[1] << std::endl;
   }
 
-  adiar::adiar_init(M);
+  adiar::adiar_init(M * 1024 * 1024);
 
   {
     // ===== Your code starts here =====

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
 #endif
 
   // Initialize ADIAR and TPIE
-  adiar_init(1024);
+  adiar_init(1024 * 1024 * 1024);
 
   // Run tests
   auto bandit_ret = bandit::run(argc, argv);


### PR DESCRIPTION
Every other library (TPIE, Sylvan, CUDD) has its memory argument given in _bytes_ rather than _MiB_. There is no reason for us not to align our interface with the rest of the world.