### PR TITLE
Add performance benchmarking action

### DIFF
--- a/.github/workflows/benchmark.py
+++ b/.github/workflows/benchmark.py
@@ -1,50 +1,118 @@
 import re
+import io
+import selectors
 import subprocess
 import sys
 
+
+# ------------------------------------------------------------------------------
+# From 'nawatts/capture-and-print-subprocess-output.py'
+
+def capture_subprocess_output(subprocess_args):
+    # Start subprocess
+    # bufsize = 1 means output is line buffered
+    # universal_newlines = True is required for line buffering
+    process = subprocess.Popen(subprocess_args,
+                               bufsize=1,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT,
+                               universal_newlines=True)
+
+    # Create callback function for process output
+    buf = io.StringIO()
+    def handle_output(stream, mask):
+        # Because the process' output is line buffered, there's only ever one
+        # line to read when this function is called
+        line = stream.readline()
+        buf.write(line)
+        sys.stdout.write(line)
+
+    # Register callback for an "available for read" event from subprocess' stdout stream
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, handle_output)
+
+    # Loop until subprocess is terminated
+    while process.poll() is None:
+        # Wait for events and handle them with their registered callbacks
+        events = selector.select()
+        for key, mask in events:
+            callback = key.data
+            callback(key.fileobj, mask)
+
+    # Get process return code
+    return_code = process.wait()
+    selector.close()
+
+    success = (return_code == 0)
+
+    # Store buffered output
+    output = buf.getvalue()
+    buf.close()
+
+    return (success, output)
+
+
 # ------------------------------------------------------------------------------
 # Branch switching
-def git_checkout(branch_name):
-    #print('git', 'checkout', branch_name)
-    subprocess.run(['git', 'checkout', branch_name], capture_output=True)
-    return
+def remote_name(remote):
+    return remote.replace('/','_')
+
+
+def git_remove_remote(remote):
+    if (remote == 'origin'):
+        return # origin should not be purged
+
+    subprocess.run(['git', 'remote', 'remove', remote_name(remote)])
+
+
+def git_add_remote(remote):
+    if (remote == 'origin'):
+        return # origin hopefully exists
+
+    git_remove_remote(remote)
+    subprocess.run(['git', 'remote', 'add', remote_name(remote), f'https://github.com/{remote}.git'])
+
+
+def git_fetch():
+    subprocess.run(['git', 'fetch', '--all'])
+
+
+def git_checkout(remote, branch):
+    subprocess.run(['git', 'checkout', f'{remote_name(remote)}/{branch}'])
+    subprocess.run(['git', 'status'])
 
 # ------------------------------------------------------------------------------
 # Running benchmarks
 QUEENS_N = 14
 
 def run_queens():
-    out = subprocess.run(['make', 'example/queens', 'N='+str(QUEENS_N), 'M=8096'],
-                         capture_output=True,
-                         text=True)
-
-    # The output ends on the error due to the CMake warnings during build
-    out_txt = out.stderr
+    out_txt = capture_subprocess_output(['make', 'example/queens', 'N='+str(QUEENS_N), 'M=8096'])[1]
 
     matches = re.findall("time:\s*([0-9\.]+)\s*s", out_txt)
     timing = sum([float(t) for t in matches])
     return timing
 
+
 # ------------------------------------------------------------------------------
 # Markdown helper functions
-def markdown_table(timings):
-    keys = list(timings.keys())
-
-    header = ' | '.join(keys)
-    line   = '-|-'.join([re.sub('.','-',b) for b in keys])
+def markdown_table(args, timings):
+    header = ' | '.join([f'{r}/{b}' for (r,b) in args])
+    line   = '-|-'.join([re.sub('.','-',f'{r}/{b}') for (r,b) in args])
 
     # assumes every value is a list of the same length
-    number_of_rows = len(timings[keys[0]])
+    number_of_rows = len(timings[args[0][0]][args[0][1]])
     rows = []
 
     for r in range(0, number_of_rows):
         rows.append(' | '.join([t + ' ' * (len(b)-len(str(t)))
-                                  for (b, t) in [(b, str(timings[b][r])) for b in keys]]))
+                                for (b, t) in [(f'{r}/{b}', str(timings[r][b])) for (r,b) in args]]))
 
     return '\n'.join(['| '+ header +' |', '|-'+ line +'-|'] + ['| '+ r +' |' for r in rows])
 
+
 def bold(txt):
     return "**"+txt+"**"
+
 
 def spoiler(txt, summary):
     return '> ' + ('<details>\n' +
@@ -52,31 +120,42 @@ def spoiler(txt, summary):
                    + txt + '\n' +
                    '</details>').replace('\n', '\n> ')
 
-def performance_report(branches, timings):
-    output_txt = (f'# Benchmark Report `{branches[0]}`\n' +
-                  f'Minimum running time for {QUEENS_N}-Queens: {min(timings[branches[0]])}s\n\n' +
-                  spoiler(f'Running times (s) for {QUEENS_N}-Queens:\n' + ', '.join([str(t) for t in timings[branches[0]]]), 'Raw Data'))
+
+def performance_report(args, timings):
+    output_txt = (f'# Benchmark Report `{args[0]}/{args[1]}`\n' +
+                  f'Minimum running time for {QUEENS_N}-Queens: {min(timings[args[0][1]])}s\n\n' +
+                  spoiler(f'Running times (s) for {QUEENS_N}-Queens:\n' +
+                          ', '.join([str(t) for t in timings[args[0][1]]]), 'Raw Data'))
 
     return (0, output_txt)
 
-def comparison_report(branches, timings):
+
+def comparison_report(args, timings):
     # Create table of raw data
-    raw_data_txt = spoiler(f'Running times (s) for {QUEENS_N}-Queens:\n' + markdown_table(timings), 'Raw Data')
+    raw_data_txt = spoiler(f'Running times (s) for {QUEENS_N}-Queens:\n' + markdown_table(args, timings),
+                           'Raw Data')
 
     # Compute minimum
-    for k in timings.keys():
-        timings[k] = [min(timings[k])]
+    for (r,b) in args:
+        timings[r][b] = [min(timings[r][b])]
 
     minimum_data_txt = (f'Minimum running time (s) for {QUEENS_N}-Queens:\n' +
-                        markdown_table(timings) + '\n')
+                        markdown_table(args, timings) + '\n')
 
     output_txt = ''
 
     # Compute differences
-    reference_t = min(timings[branches[0]])
-    tested_t = [(b, min(timings[b])) for b in branches[1::]]
+    reference_t = min(timings[args[0][0]][args[0][1]])
+    tested_t = [(b, min(timings[b[0]][b[1]])) for b in args[1::]]
 
-    diffs = [(b, (t - reference_t) / reference_t) for (b,t) in tested_t]
+    diffs = []
+
+    if reference_t > 0.0:
+        diffs = [(b, (t - reference_t) / reference_t)
+                 for (b,t) in tested_t]
+    else:
+        diffs = [(b, float('inf') if t > 0 else float(0))
+                 for (b,t) in tested_t]
 
     # Check if any diffs violate the threshold
     worst_diff = 0.0 if len(diffs) == 0 else max([t for (b,t) in diffs])
@@ -85,15 +164,18 @@ def comparison_report(branches, timings):
 
     diffs_txt = [f'`{b}` ' + ('does not impact performance'
                               if t == 0.0
-                              else ('is '+('an improvement' if t < 0.0 else 'a regression')+f' of {abs(t)*100.0:.2f}%'))
+                              else ('is '+('an improvement' if t < 0.0 else 'a regression')+
+                                    f' of {abs(t)*100.0:.2f}%'))
                  for (b,t) in diffs]
 
     output_txt = (f'# Benchmark Report :{report_color}_circle:\n' +
-                  bold(' and '.join(diffs_txt) + ' (compared to `'+branches[0]+'`).') + '\n\n' +
+                  bold(' and '.join(diffs_txt) + f' (compared to `{args[0][0]}/{args[0][1]}`).') +
+                  '\n\n' +
                   minimum_data_txt + '\n' +
                   raw_data_txt)
 
     return (exit_code, output_txt)
+
 
 # ------------------------------------------------------------------------------
 # Main
@@ -112,23 +194,43 @@ if __name__ == '__main__':
         print('\n  time: ', min(timings), ' s')
 
     elif len(sys.argv) > 1:
-        branches = [b for b in sys.argv[1::]]
-        timings = { }
+        if sys.argv == 2:
+            sys.argv = [sys.argv[0], 'origin', sys.argv[1]]
 
-        for branch in branches:
-            timings[branch] = []
+        if len(sys.argv) % 2 != 1:
+            print('Please provide pairs of remote , branch')
+            exit(-1)
+
+        args = list(zip(*[iter(sys.argv[1::])]*2))
+
+        for remote in list(set([r for (r,b) in args])):
+            git_add_remote(remote)
+
+        git_fetch()
+
+        # Initialise results data
+        timings  = {  }
+
+        for (remote, branch) in args:
+            timings[remote] = {}
+
+        for (remote, branch) in args:
+            timings[remote][branch] = []
 
         # Run benchmarks on all branches as fairly as possible
         for run in range(0, REPETITIONS):
-            for branch in branches:
-                git_checkout(branch)
-                timings[branch].append(run_queens())
+            for (remote, branch) in args:
+                git_checkout(remote, branch)
+                timings[remote][branch].append(run_queens())
+
+        for remote in list(set([r for (r,b) in args])):
+            git_remove_remote(remote)
 
         exit_code = 0
         with open('benchmark.out', 'w') as file:
-            report = (comparison_report(branches, timings)
-                      if len(branches) > 1
-                      else performance_report(branches, timings))
+            report = (comparison_report(args, timings)
+                      if len(args) > 1
+                      else performance_report(args, timings))
 
             exit_code = report[0]
 

--- a/.github/workflows/benchmark.py
+++ b/.github/workflows/benchmark.py
@@ -103,9 +103,9 @@ def markdown_table(args, timings):
     number_of_rows = len(timings[args[0][0]][args[0][1]])
     rows = []
 
-    for r in range(0, number_of_rows):
-        rows.append(' | '.join([t + ' ' * (len(b)-len(str(t)))
-                                for (b, t) in [(f'{r}/{b}', str(timings[r][b])) for (r,b) in args]]))
+    for i in range(0, number_of_rows):
+        rows.append(' | '.join([t + ' ' * (len(b)-len(t))
+                                for (b, t) in [(f'{r}/{b}', f'{timings[r][b][i]:.2f}') for (r,b) in args]]))
 
     return '\n'.join(['| '+ header +' |', '|-'+ line +'-|'] + ['| '+ r +' |' for r in rows])
 

--- a/.github/workflows/benchmark.py
+++ b/.github/workflows/benchmark.py
@@ -1,0 +1,141 @@
+import re
+import subprocess
+import sys
+
+# ------------------------------------------------------------------------------
+# Branch switching
+def git_checkout(branch_name):
+    #print('git', 'checkout', branch_name)
+    subprocess.run(['git', 'checkout', branch_name], capture_output=True)
+    return
+
+# ------------------------------------------------------------------------------
+# Running benchmarks
+QUEENS_N = 14
+
+def run_queens():
+    out = subprocess.run(['make', 'example/queens', 'N='+str(QUEENS_N), 'M=8096'],
+                         capture_output=True,
+                         text=True)
+
+    # The output ends on the error due to the CMake warnings during build
+    out_txt = out.stderr
+
+    matches = re.findall("time:\s*([0-9\.]+)\s*s", out_txt)
+    timing = sum([float(t) for t in matches])
+    return timing
+
+# ------------------------------------------------------------------------------
+# Markdown helper functions
+def markdown_table(timings):
+    keys = list(timings.keys())
+
+    header = ' | '.join(keys)
+    line   = '-|-'.join([re.sub('.','-',b) for b in keys])
+
+    # assumes every value is a list of the same length
+    number_of_rows = len(timings[keys[0]])
+    rows = []
+
+    for r in range(0, number_of_rows):
+        rows.append(' | '.join([t + ' ' * (len(b)-len(str(t)))
+                                  for (b, t) in [(b, str(timings[b][r])) for b in keys]]))
+
+    return '\n'.join(['| '+ header +' |', '|-'+ line +'-|'] + ['| '+ r +' |' for r in rows])
+
+def bold(txt):
+    return "**"+txt+"**"
+
+def spoiler(txt, summary):
+    return '> ' + ('<details>\n' +
+                   f'<summary><b>{summary}</b></summary>\n\n'
+                   + txt + '\n' +
+                   '</details>').replace('\n', '\n> ')
+
+def performance_report(branches, timings):
+    output_txt = (f'# Benchmark Report `{branches[0]}`\n' +
+                  f'Minimum running time for {QUEENS_N}-Queens: {min(timings[branches[0]])}s\n\n' +
+                  spoiler(f'Running times (s) for {QUEENS_N}-Queens:\n' + ', '.join([str(t) for t in timings[branches[0]]]), 'Raw Data'))
+
+    return (0, output_txt)
+
+def comparison_report(branches, timings):
+    # Create table of raw data
+    raw_data_txt = spoiler(f'Running times (s) for {QUEENS_N}-Queens:\n' + markdown_table(timings), 'Raw Data')
+
+    # Compute minimum
+    for k in timings.keys():
+        timings[k] = [min(timings[k])]
+
+    minimum_data_txt = (f'Minimum running time (s) for {QUEENS_N}-Queens:\n' +
+                        markdown_table(timings) + '\n')
+
+    output_txt = ''
+
+    # Compute differences
+    reference_t = min(timings[branches[0]])
+    tested_t = [(b, min(timings[b])) for b in branches[1::]]
+
+    diffs = [(b, (t - reference_t) / reference_t) for (b,t) in tested_t]
+
+    # Check if any diffs violate the threshold
+    worst_diff = 0.0 if len(diffs) == 0 else max([t for (b,t) in diffs])
+    report_color = 'green' if worst_diff < 0.01 else ('yellow' if worst_diff < 0.05 else 'red')
+    exit_code = -1 if report_color == 'red' else 0
+
+    diffs_txt = [f'`{b}` ' + ('does not impact performance'
+                              if t == 0.0
+                              else ('is '+('an improvement' if t < 0.0 else 'a regression')+f' of {abs(t)*100.0:.2f}%'))
+                 for (b,t) in diffs]
+
+    output_txt = (f'# Benchmark Report :{report_color}_circle:\n' +
+                  bold(' and '.join(diffs_txt) + ' (compared to `'+branches[0]+'`).') + '\n\n' +
+                  minimum_data_txt + '\n' +
+                  raw_data_txt)
+
+    return (exit_code, output_txt)
+
+# ------------------------------------------------------------------------------
+# Main
+REPETITIONS = 4
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        timings = []
+
+        print('Queens', end='', flush=True)
+
+        for run in range(0, REPETITIONS):
+            print(' .', end='', flush=True)
+            timings.append(run_queens())
+
+        print('\n  time: ', min(timings), ' s')
+
+    elif len(sys.argv) > 1:
+        branches = [b for b in sys.argv[1::]]
+        timings = { }
+
+        for branch in branches:
+            timings[branch] = []
+
+        # Run benchmarks on all branches as fairly as possible
+        for run in range(0, REPETITIONS):
+            for branch in branches:
+                git_checkout(branch)
+                timings[branch].append(run_queens())
+
+        exit_code = 0
+        with open('benchmark.out', 'w') as file:
+            report = (comparison_report(branches, timings)
+                      if len(branches) > 1
+                      else performance_report(branches, timings))
+
+            exit_code = report[0]
+
+            print(report[1])
+            file.write(report[1])
+
+        exit(exit_code)
+    else:
+        print('bad state: len(sys.argv) == 0')
+        exit(-1)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,3 +71,15 @@ jobs:
         with:
           path: ./benchmark.out
 
+  run_dummy:
+    name: 'Run benchmark report'
+    runs-on: ubuntu-latest
+
+    needs: [skip_duplicate]
+    if: ${{ needs.skip_duplicate.outputs.should_skip == 'true' }}
+
+    steps:
+    - name: Echo skip
+      run: |
+        echo "Running benchmarks is skipped"
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,6 +52,7 @@ jobs:
           python3 ./.github/workflows/benchmark.py main ${{ needs.fetch-branch.outputs.branch }}
 
       - name: 'Post benchmark.out on PR'
+        if: always()
         uses: machine-learning-apps/pr-comment@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,60 @@
+name: 'benchmark (pull request)'
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  fetch-branch:
+    name: 'Fetch branch name'
+    runs-on: ubuntu-latest  
+
+    steps:
+    - id: identify
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
+
+    outputs:
+      branch: ${{ steps.identify.outputs.branch }}
+
+  skip_duplicate:
+    name: 'Check whether to skip job'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          paths: '["src/adiar/**"]'
+
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+
+  run_benchmark:
+    name: 'Run benchmark report'
+    runs-on: ubuntu-latest
+
+    needs: [fetch-branch, skip_duplicate]
+    if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: 'Apt install'
+        run: |
+          sudo apt update
+          sudo apt install libboost-all-dev
+
+      - name: 'Run benchmark.py'
+        run: |
+          python3 ./.github/workflows/benchmark.py main ${{ needs.fetch-branch.outputs.branch }}
+
+      - name: 'Post benchmark.out on PR'
+        uses: machine-learning-apps/pr-comment@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: ./benchmark.out
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,18 @@ jobs:
     outputs:
       branch: ${{ steps.identify.outputs.branch }}
 
+  fetch-remote:
+    name: 'Fetch remote'
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: identify
+        run: |
+          echo "##[set-output name=remote;]$(if [ ${GITHUB_REPOSITORY} == 'SSoelvsten/adiar' ]; then echo 'origin'; else echo '${GITHUB_REPOSITORY}'; fi)"
+
+    outputs:
+      remote: ${{ steps.identify.outputs.remote }}
+
   skip_duplicate:
     name: 'Check whether to skip job'
     continue-on-error: true
@@ -34,7 +46,7 @@ jobs:
     name: 'Run benchmark report'
     runs-on: ubuntu-latest
 
-    needs: [fetch-branch, skip_duplicate]
+    needs: [fetch-branch, fetch-remote, skip_duplicate]
     if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
 
     steps:
@@ -49,7 +61,7 @@ jobs:
 
       - name: 'Run benchmark.py'
         run: |
-          python3 ./.github/workflows/benchmark.py main ${{ needs.fetch-branch.outputs.branch }}
+          python3 ./.github/workflows/benchmark.py origin main ${{ needs.fetch-remote.outputs.remote }} ${{ needs.fetch-branch.outputs.branch }}
 
       - name: 'Post benchmark.out on PR'
         if: always()

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: styfle/cancel-workflow-action@0.9.0
         name: 'Benchmarks'
         with:
-          workflow_id: 'benchmarks.yml'
+          workflow_id: 'benchmark.yml'
           access_token: ${{ github.token }}
       - uses: styfle/cancel-workflow-action@0.9.0
         name: 'Examples'

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -22,3 +22,8 @@ jobs:
         with:
           workflow_id: 'test.yml'
           access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.9.0
+        name: 'System Tests'
+        with:
+          workflow_id: 'system_test.yml'
+          access_token: ${{ github.token }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
 
-  queens:
+  run-example:
     name: 'Example: ${{ matrix.name }}'
     runs-on: ubuntu-latest
 
@@ -55,3 +55,21 @@ jobs:
     - name: Run example
       working-directory: ${{runner.workspace}}/build
       run: for n in ${{ matrix.N }}; do ./example/${{ matrix.exec }} -N $n -M 1024; done
+
+  run-dummy:
+    name: 'Example: ${{ matrix.name }}'
+    runs-on: ubuntu-latest
+
+    needs: skip_duplicate
+    if: ${{ needs.skip_duplicate.outputs.should_skip == 'true' }}
+
+    strategy:
+      matrix:
+        include:
+          - name: 'Queens'
+
+    steps:
+    - name: Echo skip
+      run: |
+        echo "Running examples is skipped"
+

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -1,4 +1,4 @@
-name: benchmarks
+name: 'system test'
 
 on:
   pull_request:

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Git | checkout pull request
       run: |
         cd external/adiar
+        git remote set-url origin https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
         git fetch
         git checkout ${{ needs.fetch-branch.outputs.branch }}
         git status

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,4 +1,4 @@
-name: test
+name: 'unit test'
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Adiar
-[![MIT License](https://img.shields.io/badge/license-MIT%20License-blue.svg)](LICENSE.md)
-[![Built with TPIE](https://img.shields.io/badge/built%20with-TPIE-blue)](https://users-cs.au.dk/~rav/tpie/)
-[![test](https://github.com/SSoelvsten/adiar/workflows/test/badge.svg?branch=main)](/actions?query=workflow%3Atest)
-[![codecov](https://codecov.io/gh/SSoelvsten/adiar/branch/main/graph/badge.svg?token=106RCIR4DJ)](https://codecov.io/gh/SSoelvsten/adiar)
-[![examples](https://github.com/SSoelvsten/adiar/workflows/examples/badge.svg?branch=main)](/actions?query=workflow%3Aexamples)
+[![MIT License](https://img.shields.io/github/license/ssoelvsten/adiar)](LICENSE.md)
+&nbsp;
+[![Release](https://img.shields.io/github/v/release/ssoelvsten/adiar)](https://github.com/SSoelvsten/adiar/releases)
+&nbsp;
+[![Documentation](https://img.shields.io/website?down_message=not%20available&label=docs&up_message=available&url=https%3A%2F%2Fssoelvsten.github.io%2Fadiar)](ssoelvsten.github.io/adiar)
+&nbsp;
+[![codecov](https://img.shields.io/codecov/c/github/ssoelvsten/adiar?logo=codecov&logoColor=white&token=106RCIR4DJ)](https://codecov.io/gh/SSoelvsten/adiar)
+&nbsp;
+[![test](https://img.shields.io/github/workflow/status/ssoelvsten/adiar/test/main?label=test&logo=github&logoColor=white)](/actions?query=workflow%3Atest)
+&nbsp;
+[![examples](https://img.shields.io/github/workflow/status/ssoelvsten/adiar/examples/main?label=examples&logo=github&logoColor=white)](/actions?query=workflow%3Aexamples)
 
-Following up on the work of [[Arge96](#references)], Adiar<sup>[1](#footnotes)</sup> is a BDD
-[[Bryant86](#references)] library that makes use of _Time-Forward Processing_ to
-improve the I/O complexity of BDD Manipulation to achieve efficient manipulation
-of BDDs, that far outgrow the memory limit of the given machine.
+Based on the work of Lars Arge [[Arge96](#references)], Adiar<sup>[1](#footnotes)</sup>
+is a BDD package [[Bryant86](#references)] that makes use of _Time-Forward Processing_
+to improve the I/O complexity of BDD Manipulation. This makes it able to achieve
+efficient manipulation of BDDs, even when they outgrow the memory limit of the
+given machine.
 
 **Table of Contents**
 
@@ -36,7 +43,7 @@ The implementation is dependant on the the following external libraries
   Framework for implementation of I/O efficient algorithms. It directly provides
   sorting algorithms and a priotity queue. Both are much faster than the
   algorithms in the _C++_ standard library
-  [[Vengroff94,Mølhave12](#references)].
+  [[Vengroff94](#references), [Mølhave12](#references)].
 
 - [**Bandit**](https://github.com/banditcpp/bandit):
 
@@ -125,6 +132,7 @@ The value **T** can either be _all_or _closed_.
 | _M_      | Memory in MiB (default: 1024)                    |
 
 ## Contributions
+
 Adiar is not yet feature complete, and there are still many interesting things
 left for _you_ to do. We already list lots of suggestions for possible projects
 as [future work](/FUTURE_WORK.md) and other possible things to contribute with

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 &nbsp;
 [![codecov](https://img.shields.io/codecov/c/github/ssoelvsten/adiar?logo=codecov&logoColor=white&token=106RCIR4DJ)](https://codecov.io/gh/SSoelvsten/adiar)
 &nbsp;
-[![test](https://img.shields.io/github/workflow/status/ssoelvsten/adiar/test/main?label=test&logo=github&logoColor=white)](/actions?query=workflow%3Atest)
+[![test](https://img.shields.io/github/workflow/status/ssoelvsten/adiar/unit%20test/main?label=test&logo=github&logoColor=white)](/actions?query=workflow%3Atest)
 &nbsp;
 [![examples](https://img.shields.io/github/workflow/status/ssoelvsten/adiar/examples/main?label=examples&logo=github&logoColor=white)](/actions?query=workflow%3Aexamples)
 


### PR DESCRIPTION
1. Adds new badges and prettifies the prior badges on the Readme.
2. Adds `benchmark.yml` as a new GitHub Action
   - Runs a set of benchmarks on both the branch from the pull request and `main`
   - Prints a performance report as a comment on the pull request.
   - Fails if performance decreases by more than 5%.
3. Fixes the benchmarking system tests also work from forks ( #158 )

Currently, we only run the _14-Queens_ in the _example_ folder. It would be useful to have more benchmarks to use. Can we somehow "run" the `benchmark.py` script on the _benchmarking repository_ instead? This way we can run
- _14_-Queens
- _22_ Tic-Tac-Toe
- _Picotrav_ on _EPFL/Random-Control/voter_. This would currently take more than a day to do a single run, but it should be feasible when we have a critical number of many _internal memory_ features in.

At this point it still is a good step. These larger tests can be done by hand whenever we create a release.

Regardless, this should be merged in after #128 .