### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[**.{c, cpp, gitignore, h, hpp, md, txt, yaml, yml}]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+tab_width = 2
+trim_trailing_whitespace = true
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@
 
 root = true
 
-[**.{c, cpp, gitignore, h, hpp, md, txt, yaml, yml}]
+[**.{c, cpp, gitignore, h, hpp, md, py, pyw, txt, yaml, yml}]
 indent_style = space
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
Helps editors enforce file encoding and indentation.
Read more at https://editorconfig.org/