### PR TITLE
chore: add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+*.c            text eol=lf working-tree-encoding=UTF-8
+*.cpp          text eol=lf working-tree-encoding=UTF-8
+*.h            text eol=lf working-tree-encoding=UTF-8
+*.hpp          text eol=lf working-tree-encoding=UTF-8
+*.md           text eol=lf working-tree-encoding=UTF-8
+*.py           text eol=lf working-tree-encoding=UTF-8
+*.pyw          text eol=lf working-tree-encoding=UTF-8
+*.txt          text eol=lf working-tree-encoding=UTF-8
+*.yaml         text eol=lf working-tree-encoding=UTF-8
+*.yml          text eol=lf working-tree-encoding=UTF-8
+.editorconfig  text eol=lf working-tree-encoding=UTF-8
+.gitattributes text eol=lf working-tree-encoding=UTF-8
+.gitignore     text eol=lf working-tree-encoding=UTF-8
+


### PR DESCRIPTION
This change helps enforce end of line character and file encoding.
Read more at
https://git-scm.com/docs/gitattributes
https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes