### PR TITLE
Fix TPIE license notice is based on GPL rather than LGPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,11 @@ The software and documentation files in this repository are provided under the
 [MIT License](/LICENSE.md).
 
 Using Adiar will indirectly use [TPIE](https://github.com/thomasmoelhave/tpie)
-underneath, which in turn is licensed under the _GPL 3_ license. Hence, your
-resulting binaries linked to Adiar will also be under that license. If you share
-that binary with others, then you will be obliged to make the source public.
-This can be resolved by making Adiar use an alternative, such as
+underneath, which in turn is licensed under the _LGPL v3_ license. Hence, a
+binary of yours that is statically linked to Adiar will be affected by that
+license. That is, if you share that binary with others, then you will be obliged
+to make the source public. This can be resolved by using Adiar as a shared
+library or have it use an alternative to TPIE, such as
 [STXXL](https://github.com/stxxl/stxxl).
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,8 +57,9 @@ The software and documentation files in this repository are distributed under th
 [MIT License](https://github.com/SSoelvsten/adiar/blob/main/LICENSE.md).
 
 Using Adiar will indirectly use [TPIE](https://github.com/thomasmoelhave/tpie)
-underneath, which in turn is licensed under the _GPL 3_ license. Hence, your
-resulting binaries linked to Adiar will also be under that license. If you share
-that binary with others, then you will be obliged to make the source public.
-This can be resolved by making Adiar use an alternative to TPIE, such as
-[STXXL](https://github.com/stxxl/stxxl).
+underneath, which in turn is licensed under the _LGPL v3_ license. Hence, a
+binary of yours that is statically linked to Adiar will be affected by that
+license. That is, if you share that binary with others, then you will be obliged
+to make the source public. This can be resolved by using Adiar as a shared
+library or have it use an alternative to TPIE, such as
+[STXXL](https://stxxl.org/).


### PR DESCRIPTION
Updates the License notice in the README and in the documentation to not say that TPIE is under GPL 3 but LGPL 3. This does allow the user to use TPIE (and by extension Adiar) as a shared library.

The reason for this misunderstanding is that GitHub extracts the wrong license from the TPIE project, as it looks into 'COPYING.md' rather than the combination with 'COPYNIG.LESSER.md'.