### PR TITLE
Rename `create_meta` and reindentation

### DIFF
--- a/src/adiar/assert.h
+++ b/src/adiar/assert.h
@@ -13,11 +13,11 @@ namespace adiar
   // Based on the assert with messages as described here:
   // https://stackoverflow.com/a/37264642
 
-#   define adiar_assert(Expr, Msg)                     \
+#   define adiar_assert(Expr, Msg)                      \
   __adiar_assert(#Expr, Expr, __FILE__, __LINE__, Msg)
 
 #ifndef NDEBUG
-#   define adiar_debug(Expr, Msg)                      \
+#   define adiar_debug(Expr, Msg)                       \
   __adiar_assert(#Expr, Expr, __FILE__, __LINE__, Msg)
 #else
 #   define adiar_debug(Expr, Msg) ;
@@ -37,7 +37,7 @@ namespace adiar
   }
 
 #ifndef NDEBUG
-#   define adiar_invariant(Expr, Name)                  \
+#   define adiar_invariant(Expr, Name)                      \
   __adiar_invariant(#Expr, Expr, __FILE__, __LINE__, Name)
 #else
 #   define adiar_invariant(Expr, Name) ;

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -56,7 +56,7 @@ namespace adiar
   bdd bdd_counter(label_t min_label, label_t max_label, label_t threshold)
   {
     adiar_assert(min_label <= max_label,
-                "The given min_label should be smaller than the given max_label");
+                 "The given min_label should be smaller than the given max_label");
 
     ptr_t gt_sink = create_sink_ptr(false); // create_sink(comparator(threshold + 1, threshold));
     ptr_t eq_sink = create_sink_ptr(true);  // create_sink(comparator(threshold, threshold));

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -103,7 +103,7 @@ namespace adiar
         nw.unsafe_push(adiar::create_node(curr_label, curr_id, low, high));
 
       } while (curr_id-- > min_id);
-      nw.unsafe_push(create_meta(curr_label, (max_id - min_id) + 1));
+      nw.unsafe_push(create_level_info(curr_label, (max_id - min_id) + 1));
     } while (curr_label-- > min_label);
 
     return nf;

--- a/src/adiar/bdd/evaluate.cpp
+++ b/src/adiar/bdd/evaluate.cpp
@@ -21,11 +21,11 @@ namespace adiar
     while (true) {
       while(label_of(current_node) > label_of(a)) {
         adiar_assert(as.can_pull(),
-                    "Given assignment insufficient to traverse BDD");
+                     "Given assignment insufficient to traverse BDD");
         a = as.pull();
       }
       adiar_assert(label_of(current_node) == label_of(a),
-                  "Missing assignment for node visited in BDD");
+                   "Missing assignment for node visited in BDD");
 
       ptr_t next_ptr = unflag(value_of(a) ? current_node.high : current_node.low);
 

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -58,44 +58,44 @@ namespace adiar
     ptr_t root_then = NIL, root_else = NIL;
 
     node_file out_nodes;
-      node_writer nw(out_nodes);
+    node_writer nw(out_nodes);
 
-      // zip 'then' and 'else' cases
-      node_stream<true> in_nodes_then(bdd_then);
-      node_stream<true> in_nodes_else(bdd_else);
+    // zip 'then' and 'else' cases
+    node_stream<true> in_nodes_then(bdd_then);
+    node_stream<true> in_nodes_else(bdd_else);
 
-      while (in_nodes_then.can_pull() || in_nodes_else.can_pull()) {
-        bool from_then = in_nodes_then.can_pull()
-          && (!in_nodes_else.can_pull()
-              || in_nodes_then.peek() > in_nodes_else.peek());
+    while (in_nodes_then.can_pull() || in_nodes_else.can_pull()) {
+      bool from_then = in_nodes_then.can_pull()
+        && (!in_nodes_else.can_pull()
+            || in_nodes_then.peek() > in_nodes_else.peek());
 
-        node_t n = from_then ? in_nodes_then.pull() : in_nodes_else.pull();
+      node_t n = from_then ? in_nodes_then.pull() : in_nodes_else.pull();
 
-        if (from_then && !in_nodes_then.can_pull()) { root_then = n.uid; }
-        if (!from_then && !in_nodes_else.can_pull()) { root_else = n.uid; }
+      if (from_then && !in_nodes_then.can_pull()) { root_then = n.uid; }
+      if (!from_then && !in_nodes_else.can_pull()) { root_else = n.uid; }
 
-        nw << n;
-      }
+      nw << n;
+    }
 
-      // push all nodes from 'if' conditional and remap its sinks
-      adiar_debug(!is_nil(root_then), "Did not obtain root from then stream");
-      adiar_debug(!is_nil(root_else), "Did not obtain root from else stream");
+    // push all nodes from 'if' conditional and remap its sinks
+    adiar_debug(!is_nil(root_then), "Did not obtain root from then stream");
+    adiar_debug(!is_nil(root_else), "Did not obtain root from else stream");
 
-      node_stream<true> in_nodes_if(bdd_if);
+    node_stream<true> in_nodes_if(bdd_if);
 
-      while (in_nodes_if.can_pull()) {
-        node_t n = in_nodes_if.pull();
+    while (in_nodes_if.can_pull()) {
+      node_t n = in_nodes_if.pull();
 
-        n.low = is_sink(n.low)
-          ? (value_of(n.low) ? root_then : root_else)
-          : n.low;
+      n.low = is_sink(n.low)
+        ? (value_of(n.low) ? root_then : root_else)
+        : n.low;
 
-        n.high = is_sink(n.high)
-          ? (value_of(n.high) ? root_then : root_else)
-          : n.high;
+      n.high = is_sink(n.high)
+        ? (value_of(n.high) ? root_then : root_else)
+        : n.high;
 
-        nw << n;
-      }
+      nw << n;
+    }
 
     return out_nodes;
   }

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -239,7 +239,7 @@ namespace adiar
     // Process all nodes in topological order of both BDDs
     while (ite_pq_1.can_pull() || ite_pq_1.has_next_level() || !ite_pq_2.empty() || !ite_pq_3.empty()) {
       if (!ite_pq_1.can_pull() && ite_pq_2.empty() && ite_pq_3.empty()) {
-        aw.unsafe_push(create_meta(out_label, out_id));
+        aw.unsafe_push(create_level_info(out_label, out_id));
 
         ite_pq_1.setup_next_level();
         out_label = ite_pq_1.current_level();
@@ -448,7 +448,7 @@ namespace adiar
     }
 
     // Push the level of the very last iteration
-    aw.unsafe_push(create_meta(out_label, out_id));
+    aw.unsafe_push(create_level_info(out_label, out_id));
 
     return out_arcs;
   }

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -55,19 +55,19 @@ namespace adiar
   };
 
   //////////////////////////////////////////////////////////////////////////////
-# define multi_quantify_macro(bdd_var, labels, op)                             \
-  if (labels.size() == 0) { return bdd_var; }                                  \
-  label_stream<> ls(labels);                                                   \
-  while(true) {                                                                \
-    if (is_sink(bdd_var, is_any)) { return bdd_var; }                          \
-                                                                               \
-    label_t label = ls.pull();                                                 \
-    if (!ls.can_pull()) {                                                      \
-      return quantify<bdd_quantify_policy>(bdd_var, label, op);                \
-    } else {                                                                   \
-      bdd_var = quantify<bdd_quantify_policy>(bdd_var, label, op);             \
-    }                                                                          \
- }                                                                             \
+# define multi_quantify_macro(bdd_var, labels, op)                  \
+  if (labels.size() == 0) { return bdd_var; }                       \
+  label_stream<> ls(labels);                                        \
+  while(true) {                                                     \
+    if (is_sink(bdd_var, is_any)) { return bdd_var; }               \
+                                                                    \
+    label_t label = ls.pull();                                      \
+    if (!ls.can_pull()) {                                           \
+      return quantify<bdd_quantify_policy>(bdd_var, label, op);     \
+    } else {                                                        \
+      bdd_var = quantify<bdd_quantify_policy>(bdd_var, label, op);  \
+    }                                                               \
+  }                                                                 \
 
   //////////////////////////////////////////////////////////////////////////////
   __bdd bdd_exists(const bdd &in_bdd, const label_t &label)

--- a/src/adiar/data.cpp
+++ b/src/adiar/data.cpp
@@ -437,7 +437,7 @@ namespace adiar {
     return m;
   }
 
-  level_info_t create_meta(label_t label, size_t level_size)
+  level_info_t create_level_info(label_t label, size_t level_size)
   {
     return { label, level_size };
   }

--- a/src/adiar/data.h
+++ b/src/adiar/data.h
@@ -306,7 +306,7 @@ namespace adiar {
 
   typedef level_info level_info_t;
 
-  level_info_t create_meta(label_t label, size_t size);
+  level_info_t create_level_info(label_t label, size_t size);
 
   label_t label_of(const level_info_t &m);
   size_t size_of(const level_info_t &m);

--- a/src/adiar/file_writer.h
+++ b/src/adiar/file_writer.h
@@ -136,7 +136,7 @@ namespace adiar {
 
       // Check is sorted input
       adiar_assert(!_has_latest || _comp(_latest, t),
-                  "The given element must be provided in order");
+                   "The given element must be provided in order");
 
       unsafe_push(t);
     }
@@ -304,18 +304,18 @@ namespace adiar {
 
         // Check it is topologically sorted
         adiar_assert(n.uid < _latest_node.uid,
-                    "Pushed node is required to be prior to the existing nodes");
+                     "Pushed node is required to be prior to the existing nodes");
         adiar_assert(!is_node(n.low) || label_of(n.uid) < label_of(n.low),
-                    "Low child must point to a node with a higher label");
+                     "Low child must point to a node with a higher label");
         adiar_assert(!is_node(n.high) || label_of(n.uid) < label_of(n.high),
-                    "High child must point to a node with a higher label");
+                     "High child must point to a node with a higher label");
 
         // Check it is canonically sorted
         if (_canonical) {
           if (label_of(_latest_node) == label_of(n)) {
             bool id_diff = id_of(n.uid) == id_of(_latest_node) - 1u;
             bool children_ordered = n.high < _latest_node.high
-                                    || (n.high == _latest_node.high && n.low < _latest_node.low);
+              || (n.high == _latest_node.high && n.low < _latest_node.low);
 
             _canonical = id_diff && children_ordered;
           } else {
@@ -327,7 +327,7 @@ namespace adiar {
         // Check if the level_info file has to be updated
         if (label_of(n) != label_of(_latest_node)) {
           meta_file_writer::unsafe_push(create_level_info(label_of(_latest_node),
-                                                    _level_size));
+                                                          _level_size));
           _level_size = 0u;
         }
       } else {
@@ -365,7 +365,7 @@ namespace adiar {
 
       if (!is_nil(_latest_node.uid) && !is_sink(_latest_node)) {
         meta_file_writer::unsafe_push(create_level_info(label_of(_latest_node),
-                                                  _level_size));
+                                                        _level_size));
         _level_size = 0u; // move to attach...
       }
       return meta_file_writer::detach();

--- a/src/adiar/file_writer.h
+++ b/src/adiar/file_writer.h
@@ -326,7 +326,7 @@ namespace adiar {
 
         // Check if the level_info file has to be updated
         if (label_of(n) != label_of(_latest_node)) {
-          meta_file_writer::unsafe_push(create_meta(label_of(_latest_node),
+          meta_file_writer::unsafe_push(create_level_info(label_of(_latest_node),
                                                     _level_size));
           _level_size = 0u;
         }
@@ -364,7 +364,7 @@ namespace adiar {
       _file_ptr -> canonical = _canonical;
 
       if (!is_nil(_latest_node.uid) && !is_sink(_latest_node)) {
-        meta_file_writer::unsafe_push(create_meta(label_of(_latest_node),
+        meta_file_writer::unsafe_push(create_level_info(label_of(_latest_node),
                                                   _level_size));
         _level_size = 0u; // move to attach...
       }

--- a/src/adiar/internal/build.h
+++ b/src/adiar/internal/build.h
@@ -24,7 +24,7 @@ namespace adiar
     node_file nf;
     node_writer nw(nf);
     nw.unsafe_push(create_node(label, 0, create_sink_ptr(false), create_sink_ptr(true)));
-    nw.unsafe_push(create_meta(label,1u));
+    nw.unsafe_push(create_level_info(label,1u));
     return nf;
   }
 
@@ -60,7 +60,7 @@ namespace adiar
         }
 
       nw.unsafe_push(next_node);
-      nw.unsafe_push(create_meta(next_label,1u));
+      nw.unsafe_push(create_level_info(next_label,1u));
     }
 
     return nf;

--- a/src/adiar/internal/build.h
+++ b/src/adiar/internal/build.h
@@ -29,42 +29,42 @@ namespace adiar
   }
 
   template<bool on_empty, bool link_low, bool link_high,
-           bool init_low = false,
-           bool init_high = true>
-  inline node_file build_chain(const label_file &labels)
-  {
-    if (labels.size() == 0) {
-      return build_sink(on_empty);
+    bool init_low = false,
+    bool init_high = true>
+    inline node_file build_chain(const label_file &labels)
+    {
+      if (labels.size() == 0) {
+        return build_sink(on_empty);
+      }
+
+      ptr_t low = create_sink_ptr(init_low);
+      ptr_t high = create_sink_ptr(init_high);
+
+      node_file nf;
+      node_writer nw(nf);
+
+      label_stream<true> ls(labels);
+      while(ls.can_pull()) {
+        label_t next_label = ls.pull();
+        node_t next_node = create_node(next_label, MAX_ID, low, high);
+
+        adiar_assert(next_label <= MAX_LABEL, "Cannot represent that large a label");
+        adiar_assert(is_sink(high) || next_label < label_of(high),
+                     "Labels not given in increasing order");
+
+        if constexpr(link_low) {
+            low = next_node.uid;
+          }
+        if constexpr(link_high) {
+            high = next_node.uid;
+          }
+
+        nw.unsafe_push(next_node);
+        nw.unsafe_push(create_level_info(next_label,1u));
+      }
+
+      return nf;
     }
-
-    ptr_t low = create_sink_ptr(init_low);
-    ptr_t high = create_sink_ptr(init_high);
-
-    node_file nf;
-    node_writer nw(nf);
-
-    label_stream<true> ls(labels);
-    while(ls.can_pull()) {
-      label_t next_label = ls.pull();
-      node_t next_node = create_node(next_label, MAX_ID, low, high);
-
-      adiar_assert(next_label <= MAX_LABEL, "Cannot represent that large a label");
-      adiar_assert(is_sink(high) || next_label < label_of(high),
-                   "Labels not given in increasing order");
-
-      if constexpr(link_low) {
-          low = next_node.uid;
-        }
-      if constexpr(link_high) {
-          high = next_node.uid;
-        }
-
-      nw.unsafe_push(next_node);
-      nw.unsafe_push(create_level_info(next_label,1u));
-    }
-
-    return nf;
-  }
 
 }
 

--- a/src/adiar/internal/levelized_priority_queue.h
+++ b/src/adiar/internal/levelized_priority_queue.h
@@ -57,7 +57,7 @@ namespace adiar {
     bool can_pull()
     {
       adiar_debug(_files_given == MetaStreams,
-                 "Cannot check existence of next element before being attached to all level_info streams");
+                  "Cannot check existence of next element before being attached to all level_info streams");
 
       for (size_t idx = 0u; idx < MetaStreams; idx++) {
         if (_meta_streams[idx] -> can_pull()) {
@@ -70,9 +70,9 @@ namespace adiar {
     label_t peek()
     {
       adiar_debug(_files_given == MetaStreams,
-                 "Peeking element before being attached to all expected level_info streams");
+                  "Peeking element before being attached to all expected level_info streams");
       adiar_debug(can_pull(),
-                 "Cannot peek past end of all streams");
+                  "Cannot peek past end of all streams");
 
       bool has_min_label = false;
       label_t min_label = 0u;
@@ -90,9 +90,9 @@ namespace adiar {
     label_t pull()
     {
       adiar_debug(_files_given == MetaStreams,
-                 "Pulling element before being attached to all expected level_info streams");
+                  "Pulling element before being attached to all expected level_info streams");
       adiar_debug(can_pull(),
-                 "Cannot pull past end of all streams");
+                  "Cannot pull past end of all streams");
 
       label_t min_label = peek();
 
@@ -236,7 +236,7 @@ namespace adiar {
     : levelized_priority_queue(files, tpie::get_memory_manager().available()) { }
 
     levelized_priority_queue(const decision_diagram (& dds) [MetaStreams])
-    : levelized_priority_queue(dds, tpie::get_memory_manager().available()) { }
+      : levelized_priority_queue(dds, tpie::get_memory_manager().available()) { }
 
     ////////////////////////////////////////////////////////////////////////////
     // Private constructor methods
@@ -284,7 +284,7 @@ namespace adiar {
       label_t label = LabelExt::label_of(t);
 
       adiar_debug(_label_comparator(front_bucket_label(), label),
-                 "Element pushed prior to currently active bucket");
+                  "Element pushed prior to currently active bucket");
 
       for (size_t bucket = 1; bucket <= Buckets && bucket <= active_buckets(); bucket++) {
         size_t bucket_idx = (_front_bucket_idx + bucket) % (Buckets + 1);
@@ -336,16 +336,16 @@ namespace adiar {
       bool has_stop_label = stop_label <= MAX_LABEL;
 
       adiar_debug(!has_stop_label || _label_comparator(front_bucket_label(), stop_label),
-                 "Stop label should be past the current front bucket");
+                  "Stop label should be past the current front bucket");
 
       adiar_debug(!can_pull(),
-                 "Level should be emptied before moving on");
+                  "Level should be emptied before moving on");
 
       adiar_debug(has_next_level(),
-                 "Has no next level to go to");
+                  "Has no next level to go to");
 
       adiar_debug(_label_comparator(front_bucket_label(), back_bucket_label()),
-                 "Front bucket run ahead of back bucket");
+                  "Front bucket run ahead of back bucket");
 
       // Sort active buckets until we find one with some content
       for (size_t b = 0;
@@ -397,9 +397,9 @@ namespace adiar {
       }
 
       adiar_debug(!has_next_bucket() || _label_comparator(front_bucket_label(), back_bucket_label()),
-                 "Inconsistency in has_next_bucket predicate");
+                  "Inconsistency in has_next_bucket predicate");
       adiar_debug(has_next_bucket() || front_bucket_label() == back_bucket_label(),
-                 "Inconsistency in has_next_bucket predicate");
+                  "Inconsistency in has_next_bucket predicate");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -527,7 +527,7 @@ namespace adiar {
     void setup_next_bucket()
     {
       adiar_debug(has_next_bucket() && _label_comparator(front_bucket_label(), back_bucket_label()),
-                 "Inconsistency in has_next_bucket predicate");
+                  "Inconsistency in has_next_bucket predicate");
 
       if (label_mgr::can_pull()) {
         label_t next_label = label_mgr::pull();
@@ -537,9 +537,9 @@ namespace adiar {
       _front_bucket_idx = (_front_bucket_idx + 1) % (Buckets + 1);
 
       adiar_debug(!has_next_bucket() || _label_comparator(front_bucket_label(), back_bucket_label()),
-                 "Inconsistency in has_next_bucket predicate");
+                  "Inconsistency in has_next_bucket predicate");
       adiar_debug(has_next_bucket() || front_bucket_label() == back_bucket_label(),
-                 "Inconsistency in has_next_bucket predicate");
+                  "Inconsistency in has_next_bucket predicate");
     }
 
     void sort_front_bucket()

--- a/src/adiar/internal/pred.cpp
+++ b/src/adiar/internal/pred.cpp
@@ -64,7 +64,7 @@ namespace adiar
     {
       ret_value = is_sink(v1) && is_sink(v2) && value_of(v1) == value_of(v2);
 #ifdef ADIAR_STATS
-        stats_equality.slow_check.exit_on_root++;
+      stats_equality.slow_check.exit_on_root++;
 #endif
       return true;
     }

--- a/src/adiar/internal/product_construction.h
+++ b/src/adiar/internal/product_construction.h
@@ -307,7 +307,7 @@ namespace adiar
     while (prod_pq_1.can_pull() || prod_pq_1.has_next_level() || !prod_pq_2.empty()) {
       if (!prod_pq_1.can_pull() && prod_pq_2.empty()) {
         if (prod_policy::no_skip || out_id > 0) { // Only output level_info information on prior level, if output
-          aw.unsafe_push(create_meta(out_label, out_id));
+          aw.unsafe_push(create_level_info(out_label, out_id));
         }
 
         prod_pq_1.setup_next_level();
@@ -402,7 +402,7 @@ namespace adiar
 
     if (prod_policy::no_skip || out_id > 0) {
       // Push the level of the very last iteration
-      aw.unsafe_push(create_meta(out_label, out_id));
+      aw.unsafe_push(create_level_info(out_label, out_id));
     }
 
     return out_arcs;

--- a/src/adiar/internal/quantify.h
+++ b/src/adiar/internal/quantify.h
@@ -177,7 +177,7 @@ namespace adiar
     while(quantify_pq_1.can_pull() || quantify_pq_1.has_next_level() || !quantify_pq_2.empty()) {
       if (!quantify_pq_1.can_pull() && quantify_pq_2.empty()) {
         if (out_label != label) {
-          aw.unsafe_push(create_meta(out_label, out_id));
+          aw.unsafe_push(create_level_info(out_label, out_id));
         }
 
         quantify_pq_1.setup_next_level();
@@ -267,7 +267,7 @@ namespace adiar
 
     // Push the level of the very last iteration
     if (out_label != label) {
-      aw.unsafe_push(create_meta(out_label, out_id));
+      aw.unsafe_push(create_level_info(out_label, out_id));
     }
 
     return out_arcs;

--- a/src/adiar/internal/reduce.h
+++ b/src/adiar/internal/reduce.h
@@ -138,7 +138,7 @@ namespace adiar
                                             e_low.target,
                                             e_high.target));
 
-        out_writer.unsafe_push(create_meta(label,1u));
+        out_writer.unsafe_push(create_level_info(label,1u));
       }
 
       return out_file;
@@ -218,7 +218,7 @@ namespace adiar
           }
         }
 
-        out_writer.unsafe_push(create_meta(label, MAX_ID - out_id));
+        out_writer.unsafe_push(create_level_info(label, MAX_ID - out_id));
       }
 
       // Sort mappings for Reduction rule 2 back in order of node_arcs

--- a/src/adiar/internal/reduce.h
+++ b/src/adiar/internal/reduce.h
@@ -135,8 +135,8 @@ namespace adiar
       } else {
         label_t label = label_of(e_low.source);
         out_writer.unsafe_push(create_node(label, MAX_ID,
-                                            e_low.target,
-                                            e_high.target));
+                                           e_low.target,
+                                           e_high.target));
 
         out_writer.unsafe_push(create_level_info(label,1u));
       }
@@ -246,7 +246,7 @@ namespace adiar
         mapping current_map = is_red1_current ? next_red1 : next_red2;
 
         adiar_invariant(!node_arcs.can_pull() || current_map.old_uid == node_arcs.peek().target,
-                       "Mapping forwarded in sync with node_arcs");
+                        "Mapping forwarded in sync with node_arcs");
 
         // Find all arcs that have sources that match the current mapping's old_uid
         while (node_arcs.can_pull() && current_map.old_uid == node_arcs.peek().target) {
@@ -281,7 +281,7 @@ namespace adiar
         label = reduce_pq.current_level();
       } else if (!out_writer.has_pushed()) {
         adiar_debug(!node_arcs.can_pull() && !sink_arcs.can_pull(),
-                   "Nodes are still left to be processed");
+                    "Nodes are still left to be processed");
         out_writer.unsafe_push({ next_red1.new_uid, NIL, NIL });
 
         return out_file;

--- a/src/adiar/internal/substitution.h
+++ b/src/adiar/internal/substitution.h
@@ -125,7 +125,7 @@ namespace adiar
     while(!substitute_pq.empty()) {
       if (substitute_pq.empty_level()) {
         if (level_size > 0) {
-          aw.unsafe_push(create_meta(level, level_size));
+          aw.unsafe_push(create_level_info(level, level_size));
         }
         substitute_pq.setup_next_level();
 
@@ -179,7 +179,7 @@ namespace adiar
 
     // Push the level of the very last iteration
     if (level_size > 0) {
-      aw.unsafe_push(create_meta(level, level_size));
+      aw.unsafe_push(create_level_info(level, level_size));
     }
 
     return out_arcs;

--- a/src/adiar/internal/substitution.h
+++ b/src/adiar/internal/substitution.h
@@ -72,8 +72,8 @@ namespace adiar
   }
 
   inline void substitute_resolve_request(const arc_t &request,
-                                       substitute_priority_queue_t &pq,
-                                       arc_writer &aw)
+                                         substitute_priority_queue_t &pq,
+                                         arc_writer &aw)
   {
     if(is_sink(request.target)) {
       aw.unsafe_push_sink(request);

--- a/src/adiar/statistics.cpp
+++ b/src/adiar/statistics.cpp
@@ -10,9 +10,9 @@ namespace adiar
   stats_t adiar_stats()
   {
     return {
-             stats_equality,
-             stats_priority_queue,
-             stats_reduce,
+      stats_equality,
+      stats_priority_queue,
+      stats_reduce,
     };
   }
 

--- a/src/adiar/tuple.h
+++ b/src/adiar/tuple.h
@@ -121,8 +121,8 @@ namespace adiar {
     bool operator()(const triple &a, const triple &b)
     {
       return fst(a) < fst(b)
-         // If they are tied, sort them coordinate-wise
-         || (fst(a) == fst(b) && triple_lt()(a,b));
+        // If they are tied, sort them coordinate-wise
+        || (fst(a) == fst(b) && triple_lt()(a,b));
     }
   };
 
@@ -131,8 +131,8 @@ namespace adiar {
     bool operator()(const triple &a, const triple &b)
     {
       return snd(a) < snd(b)
-         // If they are tied, sort them coordinate-wise
-         || (snd(a) == snd(b) && triple_lt()(a,b));
+        // If they are tied, sort them coordinate-wise
+        || (snd(a) == snd(b) && triple_lt()(a,b));
     }
   };
 
@@ -141,8 +141,8 @@ namespace adiar {
     bool operator()(const triple &a, const triple &b)
     {
       return trd(a) < trd(b)
-         // If they are tied, sort them coordinate-wise
-         || (trd(a) == trd(b) && triple_lt()(a,b));
+        // If they are tied, sort them coordinate-wise
+        || (trd(a) == trd(b) && triple_lt()(a,b));
     }
   };
 }

--- a/src/adiar/zdd/build.cpp
+++ b/src/adiar/zdd/build.cpp
@@ -33,7 +33,7 @@ namespace adiar
     nw.unsafe_push(create_node(label, MAX_ID,
                                create_sink_ptr(false),
                                create_sink_ptr(true)));
-    nw.unsafe_push(create_meta(label,1u));
+    nw.unsafe_push(create_level_info(label,1u));
     return nf;
   }
 

--- a/src/adiar/zdd/build.h
+++ b/src/adiar/zdd/build.h
@@ -213,7 +213,7 @@ namespace adiar
       } while (curr_id-- > min_id);
 
       adiar_debug(level_size > 0, "Should have output a node");
-      nw.unsafe_push(create_meta(curr_label, level_size));
+      nw.unsafe_push(create_level_info(curr_label, level_size));
 
       prior_label = curr_label;
       prior_min_id = curr_id + 1;

--- a/src/adiar/zdd/change.cpp
+++ b/src/adiar/zdd/change.cpp
@@ -162,7 +162,7 @@ namespace adiar
 
       aw.unsafe_push_sink({ out_uid, create_sink_ptr(false) });
       aw.unsafe_push_node({ flag(out_uid), create_node_uid(next_label, 0) });
-      aw.unsafe_push(create_meta(out_label, 1));
+      aw.unsafe_push(create_level_info(out_label, 1));
     }
 
     out_label = label_of(n);
@@ -198,7 +198,7 @@ namespace adiar
 
     // Process nodes of ZDD in topological order
     while (change_pq_1.has_next_level() || !change_pq_2.empty()) {
-      if (out_id > 0) { aw.unsafe_push(create_meta(out_label, out_id)); }
+      if (out_id > 0) { aw.unsafe_push(create_level_info(out_label, out_id)); }
 
       if (change_pq_1.has_next_level()) {
         if (!change_pq_2.empty()) {
@@ -285,7 +285,7 @@ namespace adiar
 
     // Push the level of the very last iteration
     if (out_id > 0) {
-      aw.unsafe_push(create_meta(out_label, out_id));
+      aw.unsafe_push(create_level_info(out_label, out_id));
     }
 
     return out_arcs;

--- a/test/adiar/bdd/test_apply.cpp
+++ b/test/adiar/bdd/test_apply.cpp
@@ -1,308 +1,308 @@
 go_bandit([]() {
-    describe("BDD: Apply", [&]() {
-        // == CREATE SINK-ONLY BDD FOR UNIT TESTS ==
-        //                  START
-        node_file bdd_F;
-        node_file bdd_T;
+  describe("BDD: Apply", [&]() {
+    // == CREATE SINK-ONLY BDD FOR UNIT TESTS ==
+    //                  START
+    node_file bdd_F;
+    node_file bdd_T;
 
-        { // Garbage collect writers to free write-lock
-          node_writer nw_F(bdd_F);
-          nw_F << create_sink(false);
+    { // Garbage collect writers to free write-lock
+      node_writer nw_F(bdd_F);
+      nw_F << create_sink(false);
 
-          node_writer nw_T(bdd_T);
-          nw_T << create_sink(true);
-        }
+      node_writer nw_T(bdd_T);
+      nw_T << create_sink(true);
+    }
 
-        //                   END
-        // == CREATE SINK-ONLY BDD FOR UNIT TESTS ==
+    //                   END
+    // == CREATE SINK-ONLY BDD FOR UNIT TESTS ==
 
-        it("should XOR F and T sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_T, xor_op);
-            node_test_stream out_nodes(out);
+    it("should XOR F and T sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_T, xor_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should XOR T and T sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_T, bdd_T, xor_op);
-            node_test_stream out_nodes(out);
+    it("should XOR T and T sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_T, bdd_T, xor_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True()) ;
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True()) ;
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should AND F and T sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_T, and_op);
-            node_test_stream out_nodes(out);
+    it("should AND F and T sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_T, and_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should AND T and T sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_T, bdd_T, and_op);
-            node_test_stream out_nodes(out);
+    it("should AND T and T sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_T, bdd_T, and_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should OR T and F sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_T, bdd_F, or_op);
-            node_test_stream out_nodes(out);
+    it("should OR T and F sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_T, bdd_F, or_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should OR T and F sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_F, or_op);
-            node_test_stream out_nodes(out);
+    it("should OR T and F sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_F, or_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should IMPLIES F and T sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_T, imp_op);
-            node_test_stream out_nodes(out);
+    it("should IMPLIES F and T sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_T, imp_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should IMPLIES T and F sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_T, bdd_F, imp_op);
-            node_test_stream out_nodes(out);
+    it("should IMPLIES T and F sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_T, bdd_F, imp_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should IMPLIES T and T sink-only BDDs", [&]() {
-            __bdd out = bdd_apply(bdd_T, bdd_T, imp_op);
-            node_test_stream out_nodes(out);
+    it("should IMPLIES T and T sink-only BDDs", [&]() {
+      __bdd out = bdd_apply(bdd_T, bdd_T, imp_op);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        // == CREATE SINGLE VARIABLE BDDs FOR UNIT TESTS ==
-        //                    START
-        node_file bdd_x0;
-        node_file bdd_not_x0;
-        node_file bdd_x1;
-        node_file bdd_x2;
+    // == CREATE SINGLE VARIABLE BDDs FOR UNIT TESTS ==
+    //                    START
+    node_file bdd_x0;
+    node_file bdd_not_x0;
+    node_file bdd_x1;
+    node_file bdd_x2;
 
-        { // Garbage collect writers early
-          node_writer nw_x0(bdd_x0);
-          nw_x0 << create_node(0,MAX_ID, sink_F, sink_T);
+    { // Garbage collect writers early
+      node_writer nw_x0(bdd_x0);
+      nw_x0 << create_node(0,MAX_ID, sink_F, sink_T);
 
-          node_writer nw_not_x0(bdd_not_x0);
-          nw_not_x0 << create_node(0,MAX_ID, sink_T, sink_F);
+      node_writer nw_not_x0(bdd_not_x0);
+      nw_not_x0 << create_node(0,MAX_ID, sink_T, sink_F);
 
-          node_writer nw_x1(bdd_x1);
-          nw_x1 << create_node(1,MAX_ID, sink_F, sink_T);
+      node_writer nw_x1(bdd_x1);
+      nw_x1 << create_node(1,MAX_ID, sink_F, sink_T);
 
-          node_writer nw_x2(bdd_x2);
-          nw_x2 << create_node(2,MAX_ID, sink_F, sink_T);
-        }
+      node_writer nw_x2(bdd_x2);
+      nw_x2 << create_node(2,MAX_ID, sink_F, sink_T);
+    }
 
-        //                     END
-        // == CREATE SINGLE VARIABLE FOR UNIT TESTS ==
+    //                     END
+    // == CREATE SINGLE VARIABLE FOR UNIT TESTS ==
 
-        it("should AND (and shortcut on irrelevance) x0 and T", [&]() {
-            __bdd out = bdd_apply(bdd_x0, bdd_T, and_op);
+    it("should AND (and shortcut on irrelevance) x0 and T", [&]() {
+      __bdd out = bdd_apply(bdd_x0, bdd_T, and_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should OR (and shortcut on irrelevance) x0 and F", [&]() {
-            __bdd out = bdd_apply(bdd_x0, bdd_F, or_op);
+    it("should OR (and shortcut on irrelevance) x0 and F", [&]() {
+      __bdd out = bdd_apply(bdd_x0, bdd_F, or_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should IMPLIES (and shortcut on irrelevance) T and x0", [&]() {
-            __bdd out = bdd_apply(bdd_T, bdd_x0, imp_op);
+    it("should IMPLIES (and shortcut on irrelevance) T and x0", [&]() {
+      __bdd out = bdd_apply(bdd_T, bdd_x0, imp_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should OR (and shortcut on irrelevance) F and x0", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_x0, or_op);
+    it("should OR (and shortcut on irrelevance) F and x0", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_x0, or_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should XOR (and shortcut on negating) x0 and T", [&]() {
-            __bdd out = bdd_apply(bdd_x0, bdd_T, xor_op);
+    it("should XOR (and shortcut on negating) x0 and T", [&]() {
+      __bdd out = bdd_apply(bdd_x0, bdd_T, xor_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().True());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        it("should XOR (and shortcut on negating) T and x0", [&]() {
-           __bdd out = bdd_apply(bdd_x0, bdd_T, xor_op);
+    it("should XOR (and shortcut on negating) T and x0", [&]() {
+      __bdd out = bdd_apply(bdd_x0, bdd_T, xor_op);
 
-           AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-           AssertThat(out.negate, Is().True());
-         });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        it("should NAND (and shortcut on negating) T and x0", [&]() {
-            __bdd out = bdd_apply(bdd_x0, bdd_T, nand_op);
+    it("should NAND (and shortcut on negating) T and x0", [&]() {
+      __bdd out = bdd_apply(bdd_x0, bdd_T, nand_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().True());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        it("should NAND (and shortcut on negating) T and x0", [&]() {
-           __bdd out = bdd_apply(bdd_x0, bdd_T, nand_op);
+    it("should NAND (and shortcut on negating) T and x0", [&]() {
+      __bdd out = bdd_apply(bdd_x0, bdd_T, nand_op);
 
-           AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-           AssertThat(out.negate, Is().True());
-         });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        it("should XOR x0 and x1", [&]() {
-            /* The order on the leaves are due to the sorting of sink requests
-               after evaluating x0
+    it("should XOR x0 and x1", [&]() {
+      /* The order on the leaves are due to the sorting of sink requests
+         after evaluating x0
 
                    1     ---- x0
                   / \
                  2   3   ---- x1
                 / \ / \
                 F T T F
-             */
+      */
 
-            __bdd out = bdd_apply(bdd_x0, bdd_x1, xor_op);
+      __bdd out = bdd_apply(bdd_x0, bdd_x1, xor_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should IMPLY (and shortcut) on x0 and x1", [&]() {
-            /* The order on the leaves are due to the sorting of sink requests
-               after evaluating x0
+    it("should IMPLY (and shortcut) on x0 and x1", [&]() {
+      /* The order on the leaves are due to the sorting of sink requests
+         after evaluating x0
 
                    1     ---- x0
                   / \
                   T 2    ---- x1
                    / \
                    F T
-             */
+      */
 
-            __bdd out = bdd_apply(bdd_x0, bdd_x1, imp_op);
+      __bdd out = bdd_apply(bdd_x0, bdd_x1, imp_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should OR (and shortcut) on x0 and x2", [&]() {
-            /*
+    it("should OR (and shortcut) on x0 and x2", [&]() {
+      /*
                    1     ---- x0
                   / \
                   | T
@@ -310,89 +310,89 @@ go_bandit([]() {
                   2      ---- x2
                  / \
                  F T
-             */
+      */
 
-            __bdd out = bdd_apply(bdd_x0, bdd_x2, or_op);
+      __bdd out = bdd_apply(bdd_x0, bdd_x2, or_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should AND x0 and !x0", [&]() {
-            /*
+    it("should AND x0 and !x0", [&]() {
+      /*
                    1     ---- x0
                   / \
                   F F
-             */
+      */
 
-            __bdd out = bdd_apply(bdd_x0, bdd_not_x0, and_op);
+      __bdd out = bdd_apply(bdd_x0, bdd_not_x0, and_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should AND (and shortcut) F and x0", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_x0, and_op);
+    it("should AND (and shortcut) F and x0", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_x0, and_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        // == CREATE BIG BDDs FOR UNIT TESTS ==
-        //                START
+    // == CREATE BIG BDDs FOR UNIT TESTS ==
+    //                START
 
-        /*      OBBD 1
+    /*      OBBD 1
 
             1        ---- x0
            / \
@@ -403,21 +403,21 @@ go_bandit([]() {
           F T T 5    ---- x3
                / \
                F T
-         */
-        node_file bdd_1;
+    */
+    node_file bdd_1;
 
-        node_t n1_5 = create_node(3,MAX_ID, sink_F, sink_T);
-        node_t n1_4 = create_node(2,MAX_ID, sink_T, n1_5.uid);
-        node_t n1_3 = create_node(2,MAX_ID-1, sink_F, sink_T);
-        node_t n1_2 = create_node(1,MAX_ID, n1_3.uid, n1_4.uid);
-        node_t n1_1 = create_node(0,MAX_ID, n1_3.uid, n1_2.uid);
+    node_t n1_5 = create_node(3,MAX_ID, sink_F, sink_T);
+    node_t n1_4 = create_node(2,MAX_ID, sink_T, n1_5.uid);
+    node_t n1_3 = create_node(2,MAX_ID-1, sink_F, sink_T);
+    node_t n1_2 = create_node(1,MAX_ID, n1_3.uid, n1_4.uid);
+    node_t n1_1 = create_node(0,MAX_ID, n1_3.uid, n1_2.uid);
 
-        { // Garbage collect early and free write-lock
-          node_writer nw_1(bdd_1);
-          nw_1 << n1_5 << n1_4 << n1_3 << n1_2 << n1_1;
-        }
+    { // Garbage collect early and free write-lock
+      node_writer nw_1(bdd_1);
+      nw_1 << n1_5 << n1_4 << n1_3 << n1_2 << n1_1;
+    }
 
-        /*      OBBD 2
+    /*      OBBD 2
 
                    ---- x0
 
@@ -428,19 +428,19 @@ go_bandit([]() {
             2      ---- x3
            / \
            T F
-         */
-        node_file bdd_2;
+    */
+    node_file bdd_2;
 
-        node_t n2_2 = create_node(3,MAX_ID, sink_T, sink_F);
-        node_t n2_1 = create_node(1,MAX_ID, n2_2.uid, sink_T);
+    node_t n2_2 = create_node(3,MAX_ID, sink_T, sink_F);
+    node_t n2_1 = create_node(1,MAX_ID, n2_2.uid, sink_T);
 
-        { // Garbage collect early and free write-lock
-          node_writer nw_2(bdd_2);
-          nw_2 << n2_2 << n2_1;
-        }
+    { // Garbage collect early and free write-lock
+      node_writer nw_2(bdd_2);
+      nw_2 << n2_2 << n2_1;
+    }
 
 
-        /*     BDD 3
+    /*     BDD 3
 
                 1         ---- x0
                / \
@@ -455,80 +455,80 @@ go_bandit([]() {
               / \
               F T
 
-         */
-        node_file bdd_3;
+    */
+    node_file bdd_3;
 
-        node_t n3_8 = create_node(3,MAX_ID, sink_F, sink_T);
-        node_t n3_7 = create_node(2,MAX_ID, sink_T, sink_F);
-        node_t n3_6 = create_node(2,MAX_ID - 1, n3_8.uid, sink_T);
-        node_t n3_5 = create_node(2,MAX_ID - 2, sink_T, n3_8.uid);
-        node_t n3_4 = create_node(2,MAX_ID - 3, sink_F, sink_T);
-        node_t n3_3 = create_node(1,MAX_ID, n3_4.uid, n3_6.uid);
-        node_t n3_2 = create_node(1,MAX_ID - 1, n3_5.uid, n3_7.uid);
-        node_t n3_1 = create_node(0,MAX_ID, n3_2.uid, n3_3.uid);
+    node_t n3_8 = create_node(3,MAX_ID, sink_F, sink_T);
+    node_t n3_7 = create_node(2,MAX_ID, sink_T, sink_F);
+    node_t n3_6 = create_node(2,MAX_ID - 1, n3_8.uid, sink_T);
+    node_t n3_5 = create_node(2,MAX_ID - 2, sink_T, n3_8.uid);
+    node_t n3_4 = create_node(2,MAX_ID - 3, sink_F, sink_T);
+    node_t n3_3 = create_node(1,MAX_ID, n3_4.uid, n3_6.uid);
+    node_t n3_2 = create_node(1,MAX_ID - 1, n3_5.uid, n3_7.uid);
+    node_t n3_1 = create_node(0,MAX_ID, n3_2.uid, n3_3.uid);
 
-        { // Garbage collect early and free write-lock
-          node_writer nw_3(bdd_3);
-          nw_3 << n3_8 << n3_7 << n3_6 << n3_5 << n3_4 << n3_3 << n3_2 << n3_1;
-        }
+    { // Garbage collect early and free write-lock
+      node_writer nw_3(bdd_3);
+      nw_3 << n3_8 << n3_7 << n3_6 << n3_5 << n3_4 << n3_3 << n3_2 << n3_1;
+    }
 
-        //                 END
-        // == CREATE BIG BDDs FOR UNIT TESTS ==
+    //                 END
+    // == CREATE BIG BDDs FOR UNIT TESTS ==
 
-        it("should IMPLY (and shortcut) F and OBBD1", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_1, imp_op);
+    it("should IMPLY (and shortcut) F and OBBD1", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_1, imp_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should OR (and shortcut) OBBD 1 and T", [&]() {
-            __bdd out = bdd_apply(bdd_1, bdd_T, or_op);
+    it("should OR (and shortcut) OBBD 1 and T", [&]() {
+      __bdd out = bdd_apply(bdd_1, bdd_T, or_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should OR (and shortcut) OBBD 2 and T", [&]() {
-            __bdd out = bdd_apply(bdd_2, bdd_T, or_op);
+    it("should OR (and shortcut) OBBD 2 and T", [&]() {
+      __bdd out = bdd_apply(bdd_2, bdd_T, or_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should AND (and shortcut) F and OBBD 2", [&]() {
-            __bdd out = bdd_apply(bdd_F, bdd_2, and_op);
+    it("should AND (and shortcut) F and OBBD 2", [&]() {
+      __bdd out = bdd_apply(bdd_F, bdd_2, and_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should XOR OBBD 2 and x2", [&]() {
-            /*
+    it("should XOR OBBD 2 and x2", [&]() {
+      /*
                                          ---- x0
 
                          (1,1)           ---- x1
@@ -540,61 +540,61 @@ go_bandit([]() {
                 (2,F)     (2,T)          ---- x3
                 /   \     /   \
                 T   F     F   T
-             */
-            __bdd out = bdd_apply(bdd_2, bdd_x2, xor_op);
+      */
+      __bdd out = bdd_apply(bdd_2, bdd_x2, xor_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        /* The product construction of bbd_1 and bdd_2 above is as follows in sorted order.
+    /* The product construction of bbd_1 and bdd_2 above is as follows in sorted order.
 
                                             (1,1)                       ---- x0
                                             \_ _/
@@ -616,10 +616,10 @@ go_bandit([]() {
                                          (5,T)         (F,2)     (T,2)   ---- x3
                                          /   \         /   \     /   \
                                       (F,T) (T,T)   (F,T)(F,F)  (T,T)(T,F)
-         */
+    */
 
-        it("should OR (and shortcut) OBBD 1 and OBBD 2", [&]() {
-            /*
+    it("should OR (and shortcut) OBBD 1 and OBBD 2", [&]() {
+      /*
                            1       ---- x0
                           / \
                          2   3     ---- x1
@@ -631,67 +631,67 @@ go_bandit([]() {
                          5  T      ---- x3
                         / \
                         T F
-             */
+      */
 
-            __bdd out = bdd_apply(bdd_1, bdd_2, or_op);
+      __bdd out = bdd_apply(bdd_1, bdd_2, or_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should AND (and shortcut) BBD 1 and 2", [&]() {
-            /*
+    it("should AND (and shortcut) BBD 1 and 2", [&]() {
+      /*
                             1                        ---- x0
                             X
                            / \
@@ -706,164 +706,164 @@ go_bandit([]() {
                      / \           / \
                      T F           F T
 
-             */
+      */
 
-            __bdd out = bdd_apply(bdd_1, bdd_2, and_op);
+      __bdd out = bdd_apply(bdd_1, bdd_2, and_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should XOR BBD 1 and 2", [&]() {
-            /* There is no shortcutting possible on an XOR, so see the product
-               construction above. */
+    it("should XOR BBD 1 and 2", [&]() {
+      /* There is no shortcutting possible on an XOR, so see the product
+         construction above. */
 
-            __bdd out = bdd_apply(bdd_1, bdd_2, xor_op);
+      __bdd out = bdd_apply(bdd_1, bdd_2, xor_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should XOR BDD 3 and 1", [&]() {
-            /* The queue appD_data is used to forward data across the level. When
-               BDD 1 and 3 are combined, this is needed
+    it("should XOR BDD 3 and 1", [&]() {
+      /* The queue appD_data is used to forward data across the level. When
+         BDD 1 and 3 are combined, this is needed
 
                   The product between the BDD 3 and BDD 1 then is
 
@@ -886,100 +886,100 @@ go_bandit([]() {
                                  (8,T)      (T,5)             ---- x3
                                  /   \      /   \
                               (F,T) (T,T) (T,F) (T,T)
-            */
+      */
 
-            __bdd out = bdd_apply(bdd_3, bdd_1, xor_op);
+      __bdd out = bdd_apply(bdd_3, bdd_1, xor_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (4,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (4,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (5,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (5,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (6,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (6,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (7,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,3) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (7,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,3) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (8,T)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (8,T)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (T,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (T,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should group all recursion requests together", [&]() {
-            // This is a counter-example to the prior "break ties on fst() with
-            // snd()" approach. Here we will have three requests to the level of
-            // x2, but in the following order:
-            //
-            // [((2,0),(2,1)), ((2,1),(2,0)), ((2,0),(2,1))]
-            //
-            // which all are tied, and hence the prior version would create
-            // three nodes on this level rather than just two.
+    it("should group all recursion requests together", [&]() {
+      // This is a counter-example to the prior "break ties on fst() with
+      // snd()" approach. Here we will have three requests to the level of
+      // x2, but in the following order:
+      //
+      // [((2,0),(2,1)), ((2,1),(2,0)), ((2,0),(2,1))]
+      //
+      // which all are tied, and hence the prior version would create
+      // three nodes on this level rather than just two.
 
-            /*
+      /*
                  1    ---- x0
                 / \
                 2 |   ---- x1
@@ -987,154 +987,154 @@ go_bandit([]() {
                3  4   ---- x2
               / \/ \
               T  F T
-            */
+      */
 
-            // The second version is the same but has the nodes 3 and 4 mirrored
-            // and the T sinks are replaced with an arc to a node for x3.
+      // The second version is the same but has the nodes 3 and 4 mirrored
+      // and the T sinks are replaced with an arc to a node for x3.
 
-            node_file bdd_group_1, bdd_group_2;
-            { // Garbage collect writers to free write-lock
-              node_writer w1(bdd_group_1);
-              w1 << create_node(2,1, create_sink_ptr(false), create_sink_ptr(true))
-                 << create_node(2,0, create_sink_ptr(true), create_sink_ptr(false))
-                 << create_node(1,0, create_node_ptr(2,0), create_node_ptr(2,1))
-                 << create_node(0,1, create_node_ptr(1,0), create_node_ptr(2,1));
+      node_file bdd_group_1, bdd_group_2;
+      { // Garbage collect writers to free write-lock
+        node_writer w1(bdd_group_1);
+        w1 << create_node(2,1, create_sink_ptr(false), create_sink_ptr(true))
+           << create_node(2,0, create_sink_ptr(true), create_sink_ptr(false))
+           << create_node(1,0, create_node_ptr(2,0), create_node_ptr(2,1))
+           << create_node(0,1, create_node_ptr(1,0), create_node_ptr(2,1));
 
-              node_writer w2(bdd_group_2);
-              w2 << create_node(3,0, create_sink_ptr(false), create_sink_ptr(true))
-                 << create_node(2,1, create_node_ptr(3,0), create_sink_ptr(false))
-                 << create_node(2,0, create_sink_ptr(false), create_node_ptr(3,0))
-                 << create_node(1,0, create_node_ptr(2,1), create_node_ptr(2,0))
-                 << create_node(0,1, create_node_ptr(1,0), create_node_ptr(2,0));
-            }
+        node_writer w2(bdd_group_2);
+        w2 << create_node(3,0, create_sink_ptr(false), create_sink_ptr(true))
+           << create_node(2,1, create_node_ptr(3,0), create_sink_ptr(false))
+           << create_node(2,0, create_sink_ptr(false), create_node_ptr(3,0))
+           << create_node(1,0, create_node_ptr(2,1), create_node_ptr(2,0))
+           << create_node(0,1, create_node_ptr(1,0), create_node_ptr(2,0));
+      }
 
-            __bdd out = bdd_apply(bdd_group_1, bdd_group_2, and_op);
+      __bdd out = bdd_apply(bdd_group_1, bdd_group_2, and_op);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (4,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (4,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (T,5) i.e. the added node
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (T,5) i.e. the added node
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
 
-        it("should collapse an XOR on the same BDD twice", [&]() {
-            __bdd out = bdd_apply(bdd_1, bdd_1, xor_op);
+    it("should collapse an XOR on the same BDD twice", [&]() {
+      __bdd out = bdd_apply(bdd_1, bdd_1, xor_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should collapse a NAND on the same BDD twice, where one is negated [1]", [&]() {
-            __bdd out = bdd_apply(bdd_2, bdd_not(bdd_2), nand_op);
+    it("should collapse a NAND on the same BDD twice, where one is negated [1]", [&]() {
+      __bdd out = bdd_apply(bdd_2, bdd_not(bdd_2), nand_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should collapse a NOR on the same BDD twice to a sink, where one is negated [2]", [&]() {
-            __bdd out = bdd_apply(bdd_not(bdd_3), bdd_3, nor_op);
+    it("should collapse a NOR on the same BDD twice to a sink, where one is negated [2]", [&]() {
+      __bdd out = bdd_apply(bdd_not(bdd_3), bdd_3, nor_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should collapse an XOR on the same BDD twice to a sink, when both are negated", [&]() {
-            __bdd out = bdd_apply(bdd_not(bdd_1), bdd_not(bdd_1), xor_op);
+    it("should collapse an XOR on the same BDD twice to a sink, when both are negated", [&]() {
+      __bdd out = bdd_apply(bdd_not(bdd_1), bdd_not(bdd_1), xor_op);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-          });
+      AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+    });
 
-        it("should do an AND on being given the same BDD twice", [&]() {
-            __bdd out = bdd_apply(bdd_1, bdd_1, and_op);
+    it("should do an AND on being given the same BDD twice", [&]() {
+      __bdd out = bdd_apply(bdd_1, bdd_1, and_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_1._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_1._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should do an IMPLIES on being given the same BDD twice, where one is negated [1]", [&]() {
-            __bdd out = bdd_apply(bdd_not(bdd_2), bdd_2, imp_op);
+    it("should do an IMPLIES on being given the same BDD twice, where one is negated [1]", [&]() {
+      __bdd out = bdd_apply(bdd_not(bdd_2), bdd_2, imp_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_2._file_ptr));
-            AssertThat(out.negate, Is().False()); // negated the already negated input doubly-negating
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_2._file_ptr));
+      AssertThat(out.negate, Is().False()); // negated the already negated input doubly-negating
+    });
 
-        it("should do an IMPLIES on being given the same BDD twice, where one is negated [2]", [&]() {
-            __bdd out = bdd_apply(bdd_2, bdd_not(bdd_2), imp_op);
+    it("should do an IMPLIES on being given the same BDD twice, where one is negated [2]", [&]() {
+      __bdd out = bdd_apply(bdd_2, bdd_not(bdd_2), imp_op);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_2._file_ptr));
-            AssertThat(out.negate, Is().True()); // negated the first of the two
-          });
-      });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_2._file_ptr));
+      AssertThat(out.negate, Is().True()); // negated the first of the two
+    });
   });
+ });

--- a/test/adiar/bdd/test_apply.cpp
+++ b/test/adiar/bdd/test_apply.cpp
@@ -249,10 +249,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -293,10 +293,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -337,10 +337,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -371,7 +371,7 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -583,13 +583,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -676,16 +676,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -762,16 +762,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -847,16 +847,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -955,16 +955,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,4u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1049,16 +1049,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });

--- a/test/adiar/bdd/test_assignment.cpp
+++ b/test/adiar/bdd/test_assignment.cpp
@@ -1,10 +1,10 @@
 go_bandit([]() {
-    describe("BDD: Assignment", []() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+  describe("BDD: Assignment", []() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        node_file bdd_1;
-        /*
+    node_file bdd_1;
+    /*
               1      ---- x0
              / \
              2 |     ---- x1
@@ -14,21 +14,21 @@ go_bandit([]() {
           F 5 T F    ---- x3
            / \
            F T
-        */
+    */
 
-        {
-          node_t n5 = create_node(3,0, sink_F, sink_T);
-          node_t n4 = create_node(2,1, sink_T, sink_F);
-          node_t n3 = create_node(2,0, sink_F, n5.uid);
-          node_t n2 = create_node(1,0, n3.uid, n4.uid);
-          node_t n1 = create_node(0,0, n2.uid, n4.uid);
+    {
+      node_t n5 = create_node(3,0, sink_F, sink_T);
+      node_t n4 = create_node(2,1, sink_T, sink_F);
+      node_t n3 = create_node(2,0, sink_F, n5.uid);
+      node_t n2 = create_node(1,0, n3.uid, n4.uid);
+      node_t n1 = create_node(0,0, n2.uid, n4.uid);
 
-          node_writer nw(bdd_1);
-          nw << n5 << n4 << n3 << n2 << n1;
-        }
+      node_writer nw(bdd_1);
+      nw << n5 << n4 << n3 << n2 << n1;
+    }
 
-        node_file bdd_2;
-        /*
+    node_file bdd_2;
+    /*
                1       ---- x0
               / \
              2   \     ---- x1
@@ -40,22 +40,22 @@ go_bandit([]() {
                6
               / \
               T F
-        */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_t n6 = create_node(3,0, sink_T, sink_F);
-          node_t n5 = create_node(2,2, n6.uid, sink_T);
-          node_t n4 = create_node(2,1, sink_T, sink_F);
-          node_t n3 = create_node(2,0, sink_F, n6.uid);
-          node_t n2 = create_node(1,0, n3.uid, n4.uid);
-          node_t n1 = create_node(0,0, n2.uid, n5.uid);
+    { // Garbage collect writer to free write-lock
+      node_t n6 = create_node(3,0, sink_T, sink_F);
+      node_t n5 = create_node(2,2, n6.uid, sink_T);
+      node_t n4 = create_node(2,1, sink_T, sink_F);
+      node_t n3 = create_node(2,0, sink_F, n6.uid);
+      node_t n2 = create_node(1,0, n3.uid, n4.uid);
+      node_t n1 = create_node(0,0, n2.uid, n5.uid);
 
-          node_writer nw(bdd_2);
-          nw << n6 << n5 << n4 << n3 << n2 << n1;
-        }
+      node_writer nw(bdd_2);
+      nw << n6 << n5 << n4 << n3 << n2 << n1;
+    }
 
-        node_file bdd_3;
-        /*
+    node_file bdd_3;
+    /*
 
                       1     ---- x1
                      / \
@@ -64,213 +64,213 @@ go_bandit([]() {
                    3   4    ---- x5
                   / \ / \
                   T F F T
-         */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_t n4 = create_node(5,1, sink_F, sink_T);
-          node_t n3 = create_node(5,0, sink_T, sink_F);
-          node_t n2 = create_node(3,0, n3.uid, n4.uid);
-          node_t n1 = create_node(1,0, n2.uid, n4.uid);
+    { // Garbage collect writer to free write-lock
+      node_t n4 = create_node(5,1, sink_F, sink_T);
+      node_t n3 = create_node(5,0, sink_T, sink_F);
+      node_t n2 = create_node(3,0, n3.uid, n4.uid);
+      node_t n1 = create_node(1,0, n2.uid, n4.uid);
 
-          node_writer nw(bdd_3);
-          nw << n4 << n3 << n2 << n1;
-        }
+      node_writer nw(bdd_3);
+      nw << n4 << n3 << n2 << n1;
+    }
 
-        it("should retrieve minimal assignment [1]", [&]() {
-            assignment_file result = bdd_satmin(bdd_1);
-            assignment_stream<> out_assignment(result);
+    it("should retrieve minimal assignment [1]", [&]() {
+      assignment_file result = bdd_satmin(bdd_1);
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve minimal assignment [~1]", [&]() {
-            assignment_file result = bdd_satmin(bdd_not(bdd_1));
-            assignment_stream<> out_assignment(result);
+    it("should retrieve minimal assignment [~1]", [&]() {
+      assignment_file result = bdd_satmin(bdd_not(bdd_1));
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve minimal assignment [2]", [&]() {
-            assignment_file result = bdd_satmin(bdd_2);
-            assignment_stream<> out_assignment(result);
+    it("should retrieve minimal assignment [2]", [&]() {
+      assignment_file result = bdd_satmin(bdd_2);
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve minimal assignment [3]", [&]() {
-            assignment_file result = bdd_satmin(bdd_3);
-            assignment_stream<> out_assignment(result);
+    it("should retrieve minimal assignment [3]", [&]() {
+      assignment_file result = bdd_satmin(bdd_3);
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve minimal assignment [3]", [&]() {
-            assignment_file result = bdd_satmin(bdd_not(bdd_3));
-            assignment_stream<> out_assignment(result);
+    it("should retrieve minimal assignment [3]", [&]() {
+      assignment_file result = bdd_satmin(bdd_not(bdd_3));
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve maximal assignment [1]", [&]() {
-            assignment_file result = bdd_satmax(bdd_1);
-            assignment_stream<> out_assignment(result);
+    it("should retrieve maximal assignment [1]", [&]() {
+      assignment_file result = bdd_satmax(bdd_1);
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve maximal assignment [~1]", [&]() {
-            assignment_file result = bdd_satmax(bdd_not(bdd_1));
-            assignment_stream<> out_assignment(result);
+    it("should retrieve maximal assignment [~1]", [&]() {
+      assignment_file result = bdd_satmax(bdd_not(bdd_1));
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve maximal assignment [2]", [&]() {
-            assignment_file result = bdd_satmax(bdd_2);
-            assignment_stream<> out_assignment(result);
+    it("should retrieve maximal assignment [2]", [&]() {
+      assignment_file result = bdd_satmax(bdd_2);
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve maximal assignment [~2]", [&]() {
-            assignment_file result = bdd_satmax(bdd_not(bdd_2));
-            assignment_stream<> out_assignment(result);
+    it("should retrieve maximal assignment [~2]", [&]() {
+      assignment_file result = bdd_satmax(bdd_not(bdd_2));
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(0, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(2, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve maximal assignment [3]", [&]() {
-            assignment_file result = bdd_satmax(bdd_3);
-            assignment_stream<> out_assignment(result);
+    it("should retrieve maximal assignment [3]", [&]() {
+      assignment_file result = bdd_satmax(bdd_3);
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
 
-        it("should retrieve maximal assignment [3]", [&]() {
-            assignment_file result = bdd_satmax(bdd_not(bdd_3));
-            assignment_stream<> out_assignment(result);
+    it("should retrieve maximal assignment [3]", [&]() {
+      assignment_file result = bdd_satmax(bdd_not(bdd_3));
+      assignment_stream<> out_assignment(result);
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(1, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(3, true)));
 
-            AssertThat(out_assignment.can_pull(), Is().True());
-            AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, false)));
+      AssertThat(out_assignment.can_pull(), Is().True());
+      AssertThat(out_assignment.pull(), Is().EqualTo(create_assignment(5, false)));
 
-            AssertThat(out_assignment.can_pull(), Is().False());
-          });
-      });
+      AssertThat(out_assignment.can_pull(), Is().False());
+    });
   });
+ });

--- a/test/adiar/bdd/test_bdd.cpp
+++ b/test/adiar/bdd/test_bdd.cpp
@@ -95,8 +95,8 @@ go_bandit([]() {
               aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(true)});
               aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
 
-              aw.unsafe_push(create_meta(0,1u));
-              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_level_info(0,1u));
+              aw.unsafe_push(create_level_info(1,1u));
             }
 
             it("should copy-construct values from arc_file", [&]() {

--- a/test/adiar/bdd/test_bdd.cpp
+++ b/test/adiar/bdd/test_bdd.cpp
@@ -1,264 +1,264 @@
 go_bandit([]() {
-    describe("BDD: BDD Class", [&]() {
-        node_file x0_nf;
+  describe("BDD: BDD Class", [&]() {
+    node_file x0_nf;
 
-        {
-          node_writer nw_0(x0_nf);
-          nw_0 << create_node(0,MAX_ID,
-                              create_sink_ptr(false),
-                              create_sink_ptr(true));
-        }
+    {
+      node_writer nw_0(x0_nf);
+      nw_0 << create_node(0,MAX_ID,
+                          create_sink_ptr(false),
+                          create_sink_ptr(true));
+    }
 
-        bdd x0(x0_nf);
+    bdd x0(x0_nf);
 
-        node_file x1_nf;
+    node_file x1_nf;
 
-        {
-          node_writer nw_1(x1_nf);
-          nw_1 << create_node(1,MAX_ID,
-                              create_sink_ptr(false),
-                              create_sink_ptr(true));
-        }
+    {
+      node_writer nw_1(x1_nf);
+      nw_1 << create_node(1,MAX_ID,
+                          create_sink_ptr(false),
+                          create_sink_ptr(true));
+    }
 
-        bdd x1(x1_nf);
+    bdd x1(x1_nf);
 
-        node_file x0_and_x1_nf;
+    node_file x0_and_x1_nf;
 
-        {
-          node_writer nw_01(x0_and_x1_nf);
+    {
+      node_writer nw_01(x0_and_x1_nf);
 
-          nw_01 << create_node(1, MAX_ID,
-                               create_sink_ptr(false),
-                               create_sink_ptr(true));
+      nw_01 << create_node(1, MAX_ID,
+                           create_sink_ptr(false),
+                           create_sink_ptr(true));
 
-          nw_01 << create_node(0, MAX_ID,
-                               create_sink_ptr(false),
-                               create_node_ptr(1, MAX_ID));
-        }
+      nw_01 << create_node(0, MAX_ID,
+                           create_sink_ptr(false),
+                           create_node_ptr(1, MAX_ID));
+    }
 
-        bdd x0_and_x1(x0_and_x1_nf);
-        bdd x0_nand_x1(x0_and_x1_nf, true);
+    bdd x0_and_x1(x0_and_x1_nf);
+    bdd x0_nand_x1(x0_and_x1_nf, true);
 
-        node_file sink_T_nf;
+    node_file sink_T_nf;
 
-        {
-          node_writer nw_T(sink_T_nf);
-          nw_T << create_sink(true);
-        }
+    {
+      node_writer nw_T(sink_T_nf);
+      nw_T << create_sink(true);
+    }
 
-        bdd sink_T(sink_T_nf);
+    bdd sink_T(sink_T_nf);
 
-        node_file sink_F_nf;
+    node_file sink_F_nf;
 
-        {
-          node_writer nw_F(sink_F_nf);
-          nw_F << create_sink(false);
-        }
+    {
+      node_writer nw_F(sink_F_nf);
+      nw_F << create_sink(false);
+    }
 
-        bdd sink_F(sink_F_nf);
+    bdd sink_F(sink_F_nf);
 
-        describe("__bdd class", [&]() {
-            it("should copy-construct values from bdd", [&]() {
-                __bdd t1 = x0_and_x1;
-                AssertThat(t1.has<node_file>(), Is().True());
-                AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
-                AssertThat(t1.negate, Is().False());
+    describe("__bdd class", [&]() {
+      it("should copy-construct values from bdd", [&]() {
+        __bdd t1 = x0_and_x1;
+        AssertThat(t1.has<node_file>(), Is().True());
+        AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
+        AssertThat(t1.negate, Is().False());
 
-                __bdd t2 = x0_nand_x1;
-                AssertThat(t2.has<node_file>(), Is().True());
-                AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
-                AssertThat(t2.negate, Is().True());
-              });
+        __bdd t2 = x0_nand_x1;
+        AssertThat(t2.has<node_file>(), Is().True());
+        AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
+        AssertThat(t2.negate, Is().True());
+      });
 
-            it("should copy-construct values from __bdd", [&]() {
-                __bdd t1 = x0_and_x1;
-                __bdd t2 = t1;
-                AssertThat(t2.has<node_file>(), Is().True());
-                AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
-                AssertThat(t2.negate, Is().False());
-              });
+      it("should copy-construct values from __bdd", [&]() {
+        __bdd t1 = x0_and_x1;
+        __bdd t2 = t1;
+        AssertThat(t2.has<node_file>(), Is().True());
+        AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
+        AssertThat(t2.negate, Is().False());
+      });
 
-            it("should copy-construct values from node_file", [&]() {
-                __bdd t1 = x0_and_x1;
-                AssertThat(t1.has<node_file>(), Is().True());
-                AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
-                AssertThat(t1.negate, Is().False());
-              });
+      it("should copy-construct values from node_file", [&]() {
+        __bdd t1 = x0_and_x1;
+        AssertThat(t1.has<node_file>(), Is().True());
+        AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
+        AssertThat(t1.negate, Is().False());
+      });
 
-            arc_file af;
+      arc_file af;
 
-            {
-              arc_writer aw(af);
-              aw.unsafe_push_node(arc {flag(create_node_ptr(0,0)), create_node_ptr(1,0)});
+      {
+        arc_writer aw(af);
+        aw.unsafe_push_node(arc {flag(create_node_ptr(0,0)), create_node_ptr(1,0)});
 
-              aw.unsafe_push_sink(arc {create_node_ptr(0,0), create_sink_ptr(false)});
-              aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(true)});
-              aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
+        aw.unsafe_push_sink(arc {create_node_ptr(0,0), create_sink_ptr(false)});
+        aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(true)});
+        aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
 
-              aw.unsafe_push(create_level_info(0,1u));
-              aw.unsafe_push(create_level_info(1,1u));
-            }
+        aw.unsafe_push(create_level_info(0,1u));
+        aw.unsafe_push(create_level_info(1,1u));
+      }
 
-            it("should copy-construct values from arc_file", [&]() {
-                __bdd t1 = af;
-                AssertThat(t1.has<arc_file>(), Is().True());
-                AssertThat(t1.get<arc_file>()._file_ptr, Is().EqualTo(af._file_ptr));
-                AssertThat(t1.negate, Is().False());
-              });
+      it("should copy-construct values from arc_file", [&]() {
+        __bdd t1 = af;
+        AssertThat(t1.has<arc_file>(), Is().True());
+        AssertThat(t1.get<arc_file>()._file_ptr, Is().EqualTo(af._file_ptr));
+        AssertThat(t1.negate, Is().False());
+      });
 
-            it("should reduce on copy construct to bdd with arc_file", [&]() {
-                bdd out = __bdd(af);
-                AssertThat(out, Is().EqualTo(x0));
-              });
-          });
-
-        it("should copy-construct boolean value as a sink", [&]() {
-            bdd t1 = true;
-            AssertThat(t1, Is().EqualTo(sink_T));
-            bdd t2 = false;
-            AssertThat(t2, Is().EqualTo(sink_F));
-          });
-
-        it("should copy-construct node_file and negation back to bdd", [&]() {
-            // Since we know the __bdd copy constructor works, then we can use
-            // it to peek into the 'bdd' class
-            __bdd t2 = __bdd(bdd(__bdd(x0_and_x1)));
-            AssertThat(t2.has<node_file>(), Is().True());
-            AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
-            AssertThat(t2.negate, Is().False());
-          });
-
-        describe("operators", [&]() {
-            it("should check sink_F != sink_T", [&]() {
-                AssertThat(sink_F, Is().Not().EqualTo(sink_T));
-              });
-
-            it("should check sink_F != ~sink_F", [&]() {
-                AssertThat(sink_F, Is().Not().EqualTo(~sink_F));
-              });
-
-            it("should check sink_F == ~sink_T", [&]() {
-                AssertThat(sink_F, Is().EqualTo(~sink_T));
-              });
-
-            it("should check ~(x0 & x1) != (x0 & x1)", [&]() {
-                AssertThat(x0_and_x1, Is().Not().EqualTo(x0_nand_x1));
-              });
-
-            node_file x0_and_x1_nf2;
-
-            {
-              node_writer nw_01(x0_and_x1_nf2);
-
-              nw_01 << create_node(1, MAX_ID,
-                                   create_sink_ptr(false),
-                                   create_sink_ptr(true));
-
-              nw_01 << create_node(0, MAX_ID,
-                                   create_sink_ptr(false),
-                                   create_node_ptr(1, MAX_ID));
-            }
-
-            it("should check (x0 & x1) == (x0 & x1)", [&]() {
-                bdd other(x0_and_x1_nf2);
-                AssertThat(x0_and_x1, Is().EqualTo(other));
-              });
-
-            it("should compute x0 & x1", [&]() {
-                AssertThat(x0_and_x1 == (x0 & x1), Is().True());
-              });
-
-            it("should compute bdd& in x0 ?= x1", [&]() {
-                bdd out1 = x0; out1 &= x1;
-                AssertThat(out1 == (x0 & x1), Is().True());
-                AssertThat(out1 != (x0 & x1), Is().False());
-
-                bdd out2 = x0; out2 |= x1;
-                AssertThat(out2 == (x0 | x1), Is().True());
-                AssertThat(out2 != (x0 | x1), Is().False());
-                AssertThat(out2 != (x0 & x1), Is().True());
-
-                bdd out3 = x0; out3 ^= x1;
-                AssertThat(out3 == (x0 ^ x1), Is().True());
-                AssertThat(out3 != (x0 ^ x1), Is().False());
-                AssertThat(out3 != (x0 | x1), Is().True());
-              });
-
-            it("should negate __bdd&& in ~(x0 & x1)", [&]() {
-                AssertThat(x0_nand_x1 == ~(x0 & x1), Is().True());
-                AssertThat(x0_nand_x1 != ~(x0 & x1), Is().False());
-              });
-
-            it("should compute with __bdd&& operators", [&]() {
-                bdd out = ((x0 & ~x1) | (~x0 & x1)) ^ ((x1 ^ x0) & (~x0 & x1));
-                AssertThat((x0 & ~x1) == out, Is().True());
-                AssertThat((x0 & ~x1) != out, Is().False());
-              });
-
-            it("should compute with __bdd&& and bdd& in operators [1]", [&]() {
-                // Notice, that the two expressions with sink_T and sink_F
-                // shortcut with the operator for a bdd with the negation flag
-                // set correctly.
-                bdd out = ((x0 & x1) | (~x0 & x1)) ^ ((sink_T ^ x0) & (sink_F | x1));
-                AssertThat((x0 & x1) == out, Is().True());
-                AssertThat((x0 & x1) != out, Is().False());
-              });
-
-            it("should compute with __bdd&& and bdd& in operators [2]", [&]() {
-                // The right-hand-side will evaluate to a bdd, since sink_F negates.
-                bdd out = ((~x0 | (x0 & x1)) ^ (sink_T ^ (x1 ^ x0)));
-                AssertThat((~x0 & x1) == out, Is().True());
-                AssertThat((~x0 & x1) != out, Is().False());
-              });
-
-            it("should x0 ?= __bdd&&", [&]() {
-                bdd out = x0;
-                out &= x0 & x1;
-                AssertThat((x0 & x1) == out, Is().True());
-                AssertThat((x0 & x1) != out, Is().False());
-              });
-
-            it("should check two derivations of same __bdd&&", [&]() {
-                AssertThat((x0 ^ x1) == ((x0 & ~x1) | (~x0 & x1)), Is().True());
-                AssertThat((x0 ^ x1) != ((x0 & ~x1) | (~x0 & x1)), Is().False());
-              });
-
-            it("should check two derivations of different __bdd&&", [&]() {
-                AssertThat((x0 | x1) == ((x0 & x1) | (~x0 & x1)), Is().False());
-                AssertThat((x0 | x1) != ((x0 & x1) | (~x0 & x1)), Is().True());
-              });
-          });
-
-        describe("is_sink predicate", [&]() {
-            it("should reject x0 as a sink file", [&]() {
-              AssertThat(is_sink(x0, is_true), Is().False());
-              AssertThat(is_sink(x0, is_false), Is().False());
-              AssertThat(is_sink(x0), Is().False());
-            });
-
-            it("should reject x0 & x1 as a sink file", [&]() {
-              AssertThat(is_sink(x0_and_x1, is_true), Is().False());
-              AssertThat(is_sink(x0_and_x1, is_false), Is().False());
-              AssertThat(is_sink(x0_and_x1), Is().False());
-            });
-
-            it("should recognise a true sink", [&]() {
-              AssertThat(is_sink(sink_T, is_true), Is().True());
-            });
-
-            it("should recognise a false sink", [&]() {
-              AssertThat(is_sink(sink_F, is_false), Is().True());
-            });
-
-            it("should not recognise sink file as the other sink", [&]() {
-              AssertThat(is_sink(sink_T, is_false), Is().False());
-              AssertThat(is_sink(sink_F, is_true), Is().False());
-            });
-
-            it("should have any sink as default", [&]() {
-              AssertThat(is_sink(sink_T), Is().True());
-              AssertThat(is_sink(sink_F), Is().True());
-            });
-        });
+      it("should reduce on copy construct to bdd with arc_file", [&]() {
+        bdd out = __bdd(af);
+        AssertThat(out, Is().EqualTo(x0));
+      });
     });
-});
+
+    it("should copy-construct boolean value as a sink", [&]() {
+      bdd t1 = true;
+      AssertThat(t1, Is().EqualTo(sink_T));
+      bdd t2 = false;
+      AssertThat(t2, Is().EqualTo(sink_F));
+    });
+
+    it("should copy-construct node_file and negation back to bdd", [&]() {
+      // Since we know the __bdd copy constructor works, then we can use
+      // it to peek into the 'bdd' class
+      __bdd t2 = __bdd(bdd(__bdd(x0_and_x1)));
+      AssertThat(t2.has<node_file>(), Is().True());
+      AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_and_x1_nf._file_ptr));
+      AssertThat(t2.negate, Is().False());
+    });
+
+    describe("operators", [&]() {
+      it("should check sink_F != sink_T", [&]() {
+        AssertThat(sink_F, Is().Not().EqualTo(sink_T));
+      });
+
+      it("should check sink_F != ~sink_F", [&]() {
+        AssertThat(sink_F, Is().Not().EqualTo(~sink_F));
+      });
+
+      it("should check sink_F == ~sink_T", [&]() {
+        AssertThat(sink_F, Is().EqualTo(~sink_T));
+      });
+
+      it("should check ~(x0 & x1) != (x0 & x1)", [&]() {
+        AssertThat(x0_and_x1, Is().Not().EqualTo(x0_nand_x1));
+      });
+
+      node_file x0_and_x1_nf2;
+
+      {
+        node_writer nw_01(x0_and_x1_nf2);
+
+        nw_01 << create_node(1, MAX_ID,
+                             create_sink_ptr(false),
+                             create_sink_ptr(true));
+
+        nw_01 << create_node(0, MAX_ID,
+                             create_sink_ptr(false),
+                             create_node_ptr(1, MAX_ID));
+      }
+
+      it("should check (x0 & x1) == (x0 & x1)", [&]() {
+        bdd other(x0_and_x1_nf2);
+        AssertThat(x0_and_x1, Is().EqualTo(other));
+      });
+
+      it("should compute x0 & x1", [&]() {
+        AssertThat(x0_and_x1 == (x0 & x1), Is().True());
+      });
+
+      it("should compute bdd& in x0 ?= x1", [&]() {
+        bdd out1 = x0; out1 &= x1;
+        AssertThat(out1 == (x0 & x1), Is().True());
+        AssertThat(out1 != (x0 & x1), Is().False());
+
+        bdd out2 = x0; out2 |= x1;
+        AssertThat(out2 == (x0 | x1), Is().True());
+        AssertThat(out2 != (x0 | x1), Is().False());
+        AssertThat(out2 != (x0 & x1), Is().True());
+
+        bdd out3 = x0; out3 ^= x1;
+        AssertThat(out3 == (x0 ^ x1), Is().True());
+        AssertThat(out3 != (x0 ^ x1), Is().False());
+        AssertThat(out3 != (x0 | x1), Is().True());
+      });
+
+      it("should negate __bdd&& in ~(x0 & x1)", [&]() {
+        AssertThat(x0_nand_x1 == ~(x0 & x1), Is().True());
+        AssertThat(x0_nand_x1 != ~(x0 & x1), Is().False());
+      });
+
+      it("should compute with __bdd&& operators", [&]() {
+        bdd out = ((x0 & ~x1) | (~x0 & x1)) ^ ((x1 ^ x0) & (~x0 & x1));
+        AssertThat((x0 & ~x1) == out, Is().True());
+        AssertThat((x0 & ~x1) != out, Is().False());
+      });
+
+      it("should compute with __bdd&& and bdd& in operators [1]", [&]() {
+        // Notice, that the two expressions with sink_T and sink_F
+        // shortcut with the operator for a bdd with the negation flag
+        // set correctly.
+        bdd out = ((x0 & x1) | (~x0 & x1)) ^ ((sink_T ^ x0) & (sink_F | x1));
+        AssertThat((x0 & x1) == out, Is().True());
+        AssertThat((x0 & x1) != out, Is().False());
+      });
+
+      it("should compute with __bdd&& and bdd& in operators [2]", [&]() {
+        // The right-hand-side will evaluate to a bdd, since sink_F negates.
+        bdd out = ((~x0 | (x0 & x1)) ^ (sink_T ^ (x1 ^ x0)));
+        AssertThat((~x0 & x1) == out, Is().True());
+        AssertThat((~x0 & x1) != out, Is().False());
+      });
+
+      it("should x0 ?= __bdd&&", [&]() {
+        bdd out = x0;
+        out &= x0 & x1;
+        AssertThat((x0 & x1) == out, Is().True());
+        AssertThat((x0 & x1) != out, Is().False());
+      });
+
+      it("should check two derivations of same __bdd&&", [&]() {
+        AssertThat((x0 ^ x1) == ((x0 & ~x1) | (~x0 & x1)), Is().True());
+        AssertThat((x0 ^ x1) != ((x0 & ~x1) | (~x0 & x1)), Is().False());
+      });
+
+      it("should check two derivations of different __bdd&&", [&]() {
+        AssertThat((x0 | x1) == ((x0 & x1) | (~x0 & x1)), Is().False());
+        AssertThat((x0 | x1) != ((x0 & x1) | (~x0 & x1)), Is().True());
+      });
+    });
+
+    describe("is_sink predicate", [&]() {
+      it("should reject x0 as a sink file", [&]() {
+        AssertThat(is_sink(x0, is_true), Is().False());
+        AssertThat(is_sink(x0, is_false), Is().False());
+        AssertThat(is_sink(x0), Is().False());
+      });
+
+      it("should reject x0 & x1 as a sink file", [&]() {
+        AssertThat(is_sink(x0_and_x1, is_true), Is().False());
+        AssertThat(is_sink(x0_and_x1, is_false), Is().False());
+        AssertThat(is_sink(x0_and_x1), Is().False());
+      });
+
+      it("should recognise a true sink", [&]() {
+        AssertThat(is_sink(sink_T, is_true), Is().True());
+      });
+
+      it("should recognise a false sink", [&]() {
+        AssertThat(is_sink(sink_F, is_false), Is().True());
+      });
+
+      it("should not recognise sink file as the other sink", [&]() {
+        AssertThat(is_sink(sink_T, is_false), Is().False());
+        AssertThat(is_sink(sink_F, is_true), Is().False());
+      });
+
+      it("should have any sink as default", [&]() {
+        AssertThat(is_sink(sink_T), Is().True());
+        AssertThat(is_sink(sink_F), Is().True());
+      });
+    });
+  });
+ });

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -1,548 +1,548 @@
 go_bandit([]() {
-    describe("BDD: Build", [&]() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
-
-        describe("bdd_sink", [&]() {
-            it("can create true sink [bdd_sink]", [&]() {
-                bdd res = bdd_sink(true);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create true sink [bdd_true]", [&]() {
-                bdd res = bdd_true();
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create false sink [bdd_sink]", [&]() {
-                bdd res = bdd_sink(false);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create false sink [bdd_false]", [&]() {
-                bdd res = bdd_false();
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("bdd_ithvar", [&]() {
-            it("can create x0", [&]() {
-                bdd res = bdd_ithvar(0);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create x42", [&]() {
-                bdd res = bdd_ithvar(42);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(42, 0, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("bdd_nithvar", [&]() {
-            it("can create !x1", [&]() {
-                bdd res = bdd_nithvar(1);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0, sink_T, sink_F)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create !x3", [&]() {
-                bdd res = bdd_nithvar(3);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0, sink_T, sink_F)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("bdd_and", [&]() {
-            it("can create {x1, x2, x5}", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 5;
-                }
-
-                bdd res = bdd_and(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID,
-                                                               sink_F,
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                               sink_F,
-                                                               create_node_ptr(5,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                               sink_F,
-                                                               create_node_ptr(2,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create {} as trivially true", [&]() {
-                label_file labels;
-
-                bdd res = bdd_and(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("bdd_or", [&]() {
-            it("can create {x1, x2, x5}", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 5;
-                }
-
-                bdd res = bdd_or(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      create_node_ptr(5,MAX_ID),
-                                                                      sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      sink_T)));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create {} as trivially false", [&]() {
-                label_file labels;
-
-                bdd res = bdd_or(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("bdd_counter", [&]() {
-            it("creates trivially do counting to 10 in [0,8]", [&]() {
-                bdd res = bdd_counter(0, 8, 10);
-
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("creates trivially do counting to 10 in [10,18]", [&]() {
-                bdd res = bdd_counter(10, 18, 10);
-
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("creates counting to 0 in [1,5]", [&]() {
-                bdd res = bdd_counter(1, 5, 0);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
-                                                               sink_T,
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(5,0),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               create_node_ptr(4,0),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("creates counting to 2 in [2,5]", [&]() {
-                bdd res = bdd_counter(2, 5, 2);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
-                                                               sink_T,
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
-                                                               sink_F,
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
-                                                               create_node_ptr(5,2),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(5,1),
-                                                               create_node_ptr(5,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               sink_F,
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,3u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("creates counting to 3 in [0,8]", [&]() {
-                bdd res = bdd_counter(0, 8, 3);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 3,
-                                                               sink_T,
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2,
-                                                               sink_F,
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 3,
-                                                               create_node_ptr(8,3),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 2,
-                                                               create_node_ptr(8,2),
-                                                               create_node_ptr(8,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 1,
-                                                               sink_F,
-                                                               create_node_ptr(8,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 3,
-                                                               create_node_ptr(7,3),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
-                                                               create_node_ptr(7,2),
-                                                               create_node_ptr(7,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
-                                                               create_node_ptr(7,1),
-                                                               create_node_ptr(7,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
-                                                               sink_F,
-                                                               create_node_ptr(7,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 3,
-                                                               create_node_ptr(6,3),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
-                                                               create_node_ptr(6,2),
-                                                               create_node_ptr(6,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
-                                                               create_node_ptr(6,1),
-                                                               create_node_ptr(6,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
-                                                               create_node_ptr(6,0),
-                                                               create_node_ptr(6,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 3,
-                                                               create_node_ptr(5,3),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
-                                                               create_node_ptr(5,2),
-                                                               create_node_ptr(5,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(5,1),
-                                                               create_node_ptr(5,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(5,0),
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 3,
-                                                               create_node_ptr(4,3),
-                                                               sink_F)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
-                                                               create_node_ptr(4,2),
-                                                               create_node_ptr(4,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 2,
-                                                               create_node_ptr(3,2),
-                                                               create_node_ptr(3,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(3,1),
-                                                               create_node_ptr(3,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
-                                                               create_node_ptr(2,1),
-                                                               create_node_ptr(2,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(1,0),
-                                                               create_node_ptr(1,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,3u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,4u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,4u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,4u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,4u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
+  describe("BDD: Build", [&]() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
+
+    describe("bdd_sink", [&]() {
+      it("can create true sink [bdd_sink]", [&]() {
+        bdd res = bdd_sink(true);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
       });
+
+      it("can create true sink [bdd_true]", [&]() {
+        bdd res = bdd_true();
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create false sink [bdd_sink]", [&]() {
+        bdd res = bdd_sink(false);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create false sink [bdd_false]", [&]() {
+        bdd res = bdd_false();
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("bdd_ithvar", [&]() {
+      it("can create x0", [&]() {
+        bdd res = bdd_ithvar(0);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create x42", [&]() {
+        bdd res = bdd_ithvar(42);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(42, 0, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("bdd_nithvar", [&]() {
+      it("can create !x1", [&]() {
+        bdd res = bdd_nithvar(1);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0, sink_T, sink_F)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create !x3", [&]() {
+        bdd res = bdd_nithvar(3);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0, sink_T, sink_F)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("bdd_and", [&]() {
+      it("can create {x1, x2, x5}", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 5;
+        }
+
+        bdd res = bdd_and(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID,
+                                                       sink_F,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                       sink_F,
+                                                       create_node_ptr(5,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                       sink_F,
+                                                       create_node_ptr(2,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create {} as trivially true", [&]() {
+        label_file labels;
+
+        bdd res = bdd_and(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("bdd_or", [&]() {
+      it("can create {x1, x2, x5}", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 5;
+        }
+
+        bdd res = bdd_or(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID,
+                                                       sink_F,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                       create_node_ptr(5,MAX_ID),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                       create_node_ptr(2,MAX_ID),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create {} as trivially false", [&]() {
+        label_file labels;
+
+        bdd res = bdd_or(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("bdd_counter", [&]() {
+      it("creates trivially do counting to 10 in [0,8]", [&]() {
+        bdd res = bdd_counter(0, 8, 10);
+
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("creates trivially do counting to 10 in [10,18]", [&]() {
+        bdd res = bdd_counter(10, 18, 10);
+
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("creates counting to 0 in [1,5]", [&]() {
+        bdd res = bdd_counter(1, 5, 0);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
+                                                       sink_T,
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(5,0),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       create_node_ptr(4,0),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("creates counting to 2 in [2,5]", [&]() {
+        bdd res = bdd_counter(2, 5, 2);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
+                                                       sink_T,
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
+                                                       sink_F,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
+                                                       create_node_ptr(5,2),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(5,1),
+                                                       create_node_ptr(5,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       sink_F,
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,3u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("creates counting to 3 in [0,8]", [&]() {
+        bdd res = bdd_counter(0, 8, 3);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 3,
+                                                       sink_T,
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2,
+                                                       sink_F,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 3,
+                                                       create_node_ptr(8,3),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 2,
+                                                       create_node_ptr(8,2),
+                                                       create_node_ptr(8,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 1,
+                                                       sink_F,
+                                                       create_node_ptr(8,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 3,
+                                                       create_node_ptr(7,3),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
+                                                       create_node_ptr(7,2),
+                                                       create_node_ptr(7,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
+                                                       create_node_ptr(7,1),
+                                                       create_node_ptr(7,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
+                                                       sink_F,
+                                                       create_node_ptr(7,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 3,
+                                                       create_node_ptr(6,3),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
+                                                       create_node_ptr(6,2),
+                                                       create_node_ptr(6,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
+                                                       create_node_ptr(6,1),
+                                                       create_node_ptr(6,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
+                                                       create_node_ptr(6,0),
+                                                       create_node_ptr(6,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 3,
+                                                       create_node_ptr(5,3),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
+                                                       create_node_ptr(5,2),
+                                                       create_node_ptr(5,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(5,1),
+                                                       create_node_ptr(5,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(5,0),
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 3,
+                                                       create_node_ptr(4,3),
+                                                       sink_F)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
+                                                       create_node_ptr(4,2),
+                                                       create_node_ptr(4,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 2,
+                                                       create_node_ptr(3,2),
+                                                       create_node_ptr(3,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(3,1),
+                                                       create_node_ptr(3,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
+                                                       create_node_ptr(2,1),
+                                                       create_node_ptr(2,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(1,0),
+                                                       create_node_ptr(1,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,3u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,4u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,4u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,4u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,4u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
   });
+ });

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -65,7 +65,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -80,7 +80,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(42,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -97,7 +97,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -112,7 +112,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -149,13 +149,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -207,13 +207,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -294,19 +294,19 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -357,16 +357,16 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,3u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -515,31 +515,31 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(7,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,3u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,4u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });

--- a/test/adiar/bdd/test_count.cpp
+++ b/test/adiar/bdd/test_count.cpp
@@ -1,10 +1,10 @@
 go_bandit([]() {
-    describe("BDD: Count", [&]() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+  describe("BDD: Count", [&]() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        node_file bdd_1;
-        /*
+    node_file bdd_1;
+    /*
              1       ---- x0
             / \
             | 2      ---- x1
@@ -14,20 +14,20 @@ go_bandit([]() {
            F  4      ---- x3
              / \
              F T
-        */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_t n4 = create_node(3,0, sink_F, sink_T);
-          node_t n3 = create_node(2,0, sink_F, n4.uid);
-          node_t n2 = create_node(1,0, n3.uid, n4.uid);
-          node_t n1 = create_node(0,0, n3.uid, n2.uid);
+    { // Garbage collect writer to free write-lock
+      node_t n4 = create_node(3,0, sink_F, sink_T);
+      node_t n3 = create_node(2,0, sink_F, n4.uid);
+      node_t n2 = create_node(1,0, n3.uid, n4.uid);
+      node_t n1 = create_node(0,0, n3.uid, n2.uid);
 
-          node_writer nw_1(bdd_1);
-          nw_1 << n4 << n3 << n2 << n1;
-        }
+      node_writer nw_1(bdd_1);
+      nw_1 << n4 << n3 << n2 << n1;
+    }
 
-        node_file bdd_2;
-        /*
+    node_file bdd_2;
+    /*
                      ---- x0
 
               1      ---- x1
@@ -35,18 +35,18 @@ go_bandit([]() {
             2  |     ---- x2
            / \ /
            F  T
-        */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_t n2 = create_node(2,0, sink_F, sink_T);
-          node_t n1 = create_node(1,0, n2.uid, sink_T);
+    { // Garbage collect writer to free write-lock
+      node_t n2 = create_node(2,0, sink_F, sink_T);
+      node_t n1 = create_node(1,0, n2.uid, sink_T);
 
-          node_writer nw_2(bdd_2);
-          nw_2 << n2 << n1;
-        }
+      node_writer nw_2(bdd_2);
+      nw_2 << n2 << n1;
+    }
 
-        node_file bdd_3;
-        /*
+    node_file bdd_3;
+    /*
                     ---- x0
 
              1      ---- x1
@@ -54,19 +54,19 @@ go_bandit([]() {
            2  3     ---- x2
           / \/ \
           F T  F
-        */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_t n3 = create_node(2,1, sink_T, sink_F);
-          node_t n2 = create_node(2,0, sink_F, sink_T);
-          node_t n1 = create_node(1,0, n2.uid, n3.uid);
+    { // Garbage collect writer to free write-lock
+      node_t n3 = create_node(2,1, sink_T, sink_F);
+      node_t n2 = create_node(2,0, sink_F, sink_T);
+      node_t n1 = create_node(1,0, n2.uid, n3.uid);
 
-          node_writer nw_3(bdd_3);
-          nw_3 << n3 << n2 << n1;
-        }
+      node_writer nw_3(bdd_3);
+      nw_3 << n3 << n2 << n1;
+    }
 
-        node_file bdd_4;
-        /*
+    node_file bdd_4;
+    /*
                     __1__      ---- x0
                    /     \
                   _2_   _3_    ---- x2
@@ -77,198 +77,198 @@ go_bandit([]() {
                    5    6      ---- x6
                   / \  / \
                   T F  F T
-         */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_t n6 = create_node(6,1, sink_F, sink_T);
-          node_t n5 = create_node(6,0, sink_T, sink_F);
-          node_t n4 = create_node(4,0, n5.uid, n6.uid);
-          node_t n3 = create_node(2,1, n5.uid, n4.uid);
-          node_t n2 = create_node(2,0, n4.uid, n6.uid);
-          node_t n1 = create_node(0,0, n2.uid, n3.uid);
+    { // Garbage collect writer to free write-lock
+      node_t n6 = create_node(6,1, sink_F, sink_T);
+      node_t n5 = create_node(6,0, sink_T, sink_F);
+      node_t n4 = create_node(4,0, n5.uid, n6.uid);
+      node_t n3 = create_node(2,1, n5.uid, n4.uid);
+      node_t n2 = create_node(2,0, n4.uid, n6.uid);
+      node_t n1 = create_node(0,0, n2.uid, n3.uid);
 
-          node_writer nw_4(bdd_4);
-          nw_4 << n6 << n5 << n4 << n3 << n2 << n1;
-        }
+      node_writer nw_4(bdd_4);
+      nw_4 << n6 << n5 << n4 << n3 << n2 << n1;
+    }
 
-        node_file bdd_T;
-        /*
+    node_file bdd_T;
+    /*
               T
-         */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw_T(bdd_T);
-          nw_T << create_sink(true);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw_T(bdd_T);
+      nw_T << create_sink(true);
+    }
 
-        node_file bdd_F;
-        /*
+    node_file bdd_F;
+    /*
               F
-        */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw_F(bdd_F);
-          nw_F << create_sink(false);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw_F(bdd_F);
+      nw_F << create_sink(false);
+    }
 
-        node_file bdd_root_1;
-        /*
+    node_file bdd_root_1;
+    /*
                  1    ---- x1
                 / \
                 F T
-         */
+    */
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw_root_1(bdd_root_1);
-          nw_root_1 << create_node(1,0, sink_F, sink_T);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw_root_1(bdd_root_1);
+      nw_root_1 << create_node(1,0, sink_F, sink_T);
+    }
 
-        describe("nodecount", [&]() {
-            it("can count number of nodes", [&]() {
-                AssertThat(bdd_nodecount(bdd_1), Is().EqualTo(4u));
-                AssertThat(bdd_nodecount(bdd_2), Is().EqualTo(2u));
-                AssertThat(bdd_nodecount(bdd_3), Is().EqualTo(3u));
-                AssertThat(bdd_nodecount(bdd_4), Is().EqualTo(6u));
-                AssertThat(bdd_nodecount(bdd_T), Is().EqualTo(0u));
-                AssertThat(bdd_nodecount(bdd_F), Is().EqualTo(0u));
-                AssertThat(bdd_nodecount(bdd_root_1), Is().EqualTo(1u));
-              });
-          });
-
-        describe("varcount", [&]() {
-            it("can count number of variables", [&]() {
-                AssertThat(bdd_varcount(bdd_1), Is().EqualTo(4u));
-                AssertThat(bdd_varcount(bdd_2), Is().EqualTo(2u));
-                AssertThat(bdd_varcount(bdd_3), Is().EqualTo(2u));
-                AssertThat(bdd_varcount(bdd_4), Is().EqualTo(4u));
-                AssertThat(bdd_varcount(bdd_T), Is().EqualTo(0u));
-                AssertThat(bdd_varcount(bdd_F), Is().EqualTo(0u));
-                AssertThat(bdd_varcount(bdd_root_1), Is().EqualTo(1u));
-              });
-          });
-
-        describe("pathcount", [&]() {
-            it("can count paths leading to T sinks [1]", [&]() {
-                AssertThat(bdd_pathcount(bdd_1), Is().EqualTo(3u));
-              });
-
-            it("can count paths leading to T sinks [2]", [&]() {
-                AssertThat(bdd_pathcount(bdd_2), Is().EqualTo(2u));
-              });
-
-            it("can count paths leading to T sinks [3]", [&]() {
-                AssertThat(bdd_pathcount(bdd_3), Is().EqualTo(2u));
-              });
-
-            it("can count paths leading to T sinks [4]", [&]() {
-                AssertThat(bdd_pathcount(bdd_4), Is().EqualTo(6u));
-              });
-
-            it("can count paths leading to F sinks [1]", [&]() {
-                AssertThat(bdd_pathcount(bdd_not(bdd_1)), Is().EqualTo(5u));
-              });
-
-            it("can count paths leading to F sinks [2]", [&]() {
-                AssertThat(bdd_pathcount(bdd_not(bdd_2)), Is().EqualTo(1u));
-              });
-
-            it("should count no paths in a true sink-only BDD", [&]() {
-                AssertThat(bdd_pathcount(bdd_T), Is().EqualTo(0u));
-              });
-
-            it("should count no paths in a false sink-only BDD", [&]() {
-                AssertThat(bdd_pathcount(bdd_F), Is().EqualTo(0u));
-              });
-
-            it("should count paths of a root-only BDD [1]", [&]() {
-                AssertThat(bdd_pathcount(bdd_root_1), Is().EqualTo(1u));
-              });
-          });
-
-        describe("satcount", [&]() {
-            describe("with varcount", [&]() {
-                it("can count assignments leading to T sinks [1]", [&]() {
-                    AssertThat(bdd_satcount(bdd_1, 4), Is().EqualTo(5u));
-                    AssertThat(bdd_satcount(bdd_1, 5), Is().EqualTo(2 * 5u));
-                    AssertThat(bdd_satcount(bdd_1, 6), Is().EqualTo(2 * 2 * 5u));
-                  });
-
-                it("can count assignments leading to T sinks [2]", [&]() {
-                    AssertThat(bdd_satcount(bdd_2, 2), Is().EqualTo(3u));
-                    AssertThat(bdd_satcount(bdd_2, 3), Is().EqualTo(2 * 3u));
-                    AssertThat(bdd_satcount(bdd_2, 5), Is().EqualTo(2 * 2 * 2 * 3u));
-                  });
-
-                it("can count assignments leading to T sinks [3]", [&]() {
-                    AssertThat(bdd_satcount(bdd_3, 2), Is().EqualTo(2u));
-                    AssertThat(bdd_satcount(bdd_3, 3), Is().EqualTo(2 * 2u));
-                    AssertThat(bdd_satcount(bdd_3, 5), Is().EqualTo(2 * 2 * 2 * 2u));
-                  });
-
-                it("can count assignments leading to T sinks [4]", [&]() {
-                    AssertThat(bdd_satcount(bdd_4, 4), Is().EqualTo(8u));
-                    AssertThat(bdd_satcount(bdd_4, 5), Is().EqualTo(2 * 8u));
-                    AssertThat(bdd_satcount(bdd_4, 8), Is().EqualTo(2 * 2 * 2 * 2 * 8u));
-                  });
-
-                it("can count assignments leading to F sinks [1]", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_1), 4), Is().EqualTo(11u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_1), 5), Is().EqualTo(2 * 11u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_1), 6), Is().EqualTo(2 * 2 * 11u));
-                  });
-
-                it("can count assignments leading to F sinks [2]", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_2), 2), Is().EqualTo(1u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_2), 3), Is().EqualTo(2 * 1u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_2), 5), Is().EqualTo(2 * 2 * 2 * 1u));
-                  });
-
-                it("should count no assignments to the wrong sink-only BDD", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_T), 5), Is().EqualTo(0u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_T), 4), Is().EqualTo(0u));
-                    AssertThat(bdd_satcount(bdd_F, 3), Is().EqualTo(0u));
-                    AssertThat(bdd_satcount(bdd_F, 2), Is().EqualTo(0u));
-                  });
-
-                it("should count all assignments to the desired sink-only BDD", [&]() {
-                    AssertThat(bdd_satcount(bdd_T, 5), Is().EqualTo(32u));
-                    AssertThat(bdd_satcount(bdd_T, 4), Is().EqualTo(16u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_F), 3), Is().EqualTo(8u));
-                    AssertThat(bdd_satcount(bdd_not(bdd_F), 2), Is().EqualTo(4u));
-                  });
-              });
-
-            describe("without varcount", [&]() {
-                it("can count assignments leading to T sinks [1]", [&]() {
-                    AssertThat(bdd_satcount(bdd_1), Is().EqualTo(5u));
-                  });
-
-                it("can count assignments leading to T sinks [2]", [&]() {
-                    AssertThat(bdd_satcount(bdd_2), Is().EqualTo(3u));
-                  });
-
-                it("can count assignments leading to F sinks [1]", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_1)), Is().EqualTo(11u));
-                  });
-
-                it("can count assignments leading to F sinks [2]", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_2)), Is().EqualTo(1u));
-                  });
-
-                it("should count no assignments to the true sink-only BDD", [&]() {
-                    AssertThat(bdd_satcount(bdd_T), Is().EqualTo(0u));
-                  });
-
-                it("should count no assignments in a false sink-only BDD", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_F)), Is().EqualTo(0u));
-                    AssertThat(bdd_satcount(bdd_F), Is().EqualTo(0u));
-                  });
-
-                it("should count assignments of a root-only BDD [1]", [&]() {
-                    AssertThat(bdd_satcount(bdd_not(bdd_root_1)), Is().EqualTo(1u));
-                    AssertThat(bdd_satcount(bdd_root_1), Is().EqualTo(1u));
-                  });
-              });
-          });
+    describe("nodecount", [&]() {
+      it("can count number of nodes", [&]() {
+        AssertThat(bdd_nodecount(bdd_1), Is().EqualTo(4u));
+        AssertThat(bdd_nodecount(bdd_2), Is().EqualTo(2u));
+        AssertThat(bdd_nodecount(bdd_3), Is().EqualTo(3u));
+        AssertThat(bdd_nodecount(bdd_4), Is().EqualTo(6u));
+        AssertThat(bdd_nodecount(bdd_T), Is().EqualTo(0u));
+        AssertThat(bdd_nodecount(bdd_F), Is().EqualTo(0u));
+        AssertThat(bdd_nodecount(bdd_root_1), Is().EqualTo(1u));
       });
+    });
+
+    describe("varcount", [&]() {
+      it("can count number of variables", [&]() {
+        AssertThat(bdd_varcount(bdd_1), Is().EqualTo(4u));
+        AssertThat(bdd_varcount(bdd_2), Is().EqualTo(2u));
+        AssertThat(bdd_varcount(bdd_3), Is().EqualTo(2u));
+        AssertThat(bdd_varcount(bdd_4), Is().EqualTo(4u));
+        AssertThat(bdd_varcount(bdd_T), Is().EqualTo(0u));
+        AssertThat(bdd_varcount(bdd_F), Is().EqualTo(0u));
+        AssertThat(bdd_varcount(bdd_root_1), Is().EqualTo(1u));
+      });
+    });
+
+    describe("pathcount", [&]() {
+      it("can count paths leading to T sinks [1]", [&]() {
+        AssertThat(bdd_pathcount(bdd_1), Is().EqualTo(3u));
+      });
+
+      it("can count paths leading to T sinks [2]", [&]() {
+        AssertThat(bdd_pathcount(bdd_2), Is().EqualTo(2u));
+      });
+
+      it("can count paths leading to T sinks [3]", [&]() {
+        AssertThat(bdd_pathcount(bdd_3), Is().EqualTo(2u));
+      });
+
+      it("can count paths leading to T sinks [4]", [&]() {
+        AssertThat(bdd_pathcount(bdd_4), Is().EqualTo(6u));
+      });
+
+      it("can count paths leading to F sinks [1]", [&]() {
+        AssertThat(bdd_pathcount(bdd_not(bdd_1)), Is().EqualTo(5u));
+      });
+
+      it("can count paths leading to F sinks [2]", [&]() {
+        AssertThat(bdd_pathcount(bdd_not(bdd_2)), Is().EqualTo(1u));
+      });
+
+      it("should count no paths in a true sink-only BDD", [&]() {
+        AssertThat(bdd_pathcount(bdd_T), Is().EqualTo(0u));
+      });
+
+      it("should count no paths in a false sink-only BDD", [&]() {
+        AssertThat(bdd_pathcount(bdd_F), Is().EqualTo(0u));
+      });
+
+      it("should count paths of a root-only BDD [1]", [&]() {
+        AssertThat(bdd_pathcount(bdd_root_1), Is().EqualTo(1u));
+      });
+    });
+
+    describe("satcount", [&]() {
+      describe("with varcount", [&]() {
+        it("can count assignments leading to T sinks [1]", [&]() {
+          AssertThat(bdd_satcount(bdd_1, 4), Is().EqualTo(5u));
+          AssertThat(bdd_satcount(bdd_1, 5), Is().EqualTo(2 * 5u));
+          AssertThat(bdd_satcount(bdd_1, 6), Is().EqualTo(2 * 2 * 5u));
+        });
+
+        it("can count assignments leading to T sinks [2]", [&]() {
+          AssertThat(bdd_satcount(bdd_2, 2), Is().EqualTo(3u));
+          AssertThat(bdd_satcount(bdd_2, 3), Is().EqualTo(2 * 3u));
+          AssertThat(bdd_satcount(bdd_2, 5), Is().EqualTo(2 * 2 * 2 * 3u));
+        });
+
+        it("can count assignments leading to T sinks [3]", [&]() {
+          AssertThat(bdd_satcount(bdd_3, 2), Is().EqualTo(2u));
+          AssertThat(bdd_satcount(bdd_3, 3), Is().EqualTo(2 * 2u));
+          AssertThat(bdd_satcount(bdd_3, 5), Is().EqualTo(2 * 2 * 2 * 2u));
+        });
+
+        it("can count assignments leading to T sinks [4]", [&]() {
+          AssertThat(bdd_satcount(bdd_4, 4), Is().EqualTo(8u));
+          AssertThat(bdd_satcount(bdd_4, 5), Is().EqualTo(2 * 8u));
+          AssertThat(bdd_satcount(bdd_4, 8), Is().EqualTo(2 * 2 * 2 * 2 * 8u));
+        });
+
+        it("can count assignments leading to F sinks [1]", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_1), 4), Is().EqualTo(11u));
+          AssertThat(bdd_satcount(bdd_not(bdd_1), 5), Is().EqualTo(2 * 11u));
+          AssertThat(bdd_satcount(bdd_not(bdd_1), 6), Is().EqualTo(2 * 2 * 11u));
+        });
+
+        it("can count assignments leading to F sinks [2]", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_2), 2), Is().EqualTo(1u));
+          AssertThat(bdd_satcount(bdd_not(bdd_2), 3), Is().EqualTo(2 * 1u));
+          AssertThat(bdd_satcount(bdd_not(bdd_2), 5), Is().EqualTo(2 * 2 * 2 * 1u));
+        });
+
+        it("should count no assignments to the wrong sink-only BDD", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_T), 5), Is().EqualTo(0u));
+          AssertThat(bdd_satcount(bdd_not(bdd_T), 4), Is().EqualTo(0u));
+          AssertThat(bdd_satcount(bdd_F, 3), Is().EqualTo(0u));
+          AssertThat(bdd_satcount(bdd_F, 2), Is().EqualTo(0u));
+        });
+
+        it("should count all assignments to the desired sink-only BDD", [&]() {
+          AssertThat(bdd_satcount(bdd_T, 5), Is().EqualTo(32u));
+          AssertThat(bdd_satcount(bdd_T, 4), Is().EqualTo(16u));
+          AssertThat(bdd_satcount(bdd_not(bdd_F), 3), Is().EqualTo(8u));
+          AssertThat(bdd_satcount(bdd_not(bdd_F), 2), Is().EqualTo(4u));
+        });
+      });
+
+      describe("without varcount", [&]() {
+        it("can count assignments leading to T sinks [1]", [&]() {
+          AssertThat(bdd_satcount(bdd_1), Is().EqualTo(5u));
+        });
+
+        it("can count assignments leading to T sinks [2]", [&]() {
+          AssertThat(bdd_satcount(bdd_2), Is().EqualTo(3u));
+        });
+
+        it("can count assignments leading to F sinks [1]", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_1)), Is().EqualTo(11u));
+        });
+
+        it("can count assignments leading to F sinks [2]", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_2)), Is().EqualTo(1u));
+        });
+
+        it("should count no assignments to the true sink-only BDD", [&]() {
+          AssertThat(bdd_satcount(bdd_T), Is().EqualTo(0u));
+        });
+
+        it("should count no assignments in a false sink-only BDD", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_F)), Is().EqualTo(0u));
+          AssertThat(bdd_satcount(bdd_F), Is().EqualTo(0u));
+        });
+
+        it("should count assignments of a root-only BDD [1]", [&]() {
+          AssertThat(bdd_satcount(bdd_not(bdd_root_1)), Is().EqualTo(1u));
+          AssertThat(bdd_satcount(bdd_root_1), Is().EqualTo(1u));
+        });
+      });
+    });
   });
+ });

--- a/test/adiar/bdd/test_evaluate.cpp
+++ b/test/adiar/bdd/test_evaluate.cpp
@@ -1,9 +1,9 @@
 go_bandit([]() {
-    describe("BDD: Evaluate", [&]() {
-        // == CREATE BDD FOR UNIT TESTS ==
-        //               START
+  describe("BDD: Evaluate", [&]() {
+    // == CREATE BDD FOR UNIT TESTS ==
+    //               START
 
-        /*
+    /*
                1           ---- x0
               / \
               | 2          ---- x1
@@ -13,149 +13,149 @@ go_bandit([]() {
              F T T 5       ---- x3
                   / \
                   F T
-        */
+    */
 
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        node_file bdd;
+    node_file bdd;
 
-        node_t n5 = create_node(3,0, sink_F, sink_T);
-        node_t n4 = create_node(2,1, sink_T, n5.uid);
-        node_t n3 = create_node(2,0, sink_F, sink_T);
-        node_t n2 = create_node(1,0, n3.uid, n4.uid);
-        node_t n1 = create_node(0,0, n3.uid, n2.uid);
+    node_t n5 = create_node(3,0, sink_F, sink_T);
+    node_t n4 = create_node(2,1, sink_T, n5.uid);
+    node_t n3 = create_node(2,0, sink_F, sink_T);
+    node_t n2 = create_node(1,0, n3.uid, n4.uid);
+    node_t n1 = create_node(0,0, n3.uid, n2.uid);
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw(bdd);
-          nw << n5 << n4 << n3 << n2 << n1;
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw(bdd);
+      nw << n5 << n4 << n3 << n2 << n1;
+    }
 
-        //                END
-        // == CREATE BDD FOR UNIT TESTS ==
+    //                END
+    // == CREATE BDD FOR UNIT TESTS ==
 
-        it("should return F on test BDD with assignment (F,F,F,T)", [&bdd]() {
-            assignment_file assignment;
+    it("should return F on test BDD with assignment (F,F,F,T)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, false)
-                 << create_assignment(1, false)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, false)
+           << create_assignment(1, false)
+           << create_assignment(2, false)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().False());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().False());
+    });
 
-        it("should return F on test BDD with assignment (F,_,F,T)", [&bdd]() {
-            assignment_file assignment;
+    it("should return F on test BDD with assignment (F,_,F,T)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, false)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, false)
+           << create_assignment(2, false)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().False());
-           });
+      AssertThat(bdd_eval(bdd, assignment), Is().False());
+    });
 
-        it("should return T on test BDD with assignment (F,T,T,T)", [&bdd]() {
-            assignment_file assignment;
+    it("should return T on test BDD with assignment (F,T,T,T)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, false)
-                 << create_assignment(1, true)
-                 << create_assignment(2, true)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, false)
+           << create_assignment(1, true)
+           << create_assignment(2, true)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().True());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().True());
+    });
 
-        it("should return F on test BDD with assignment (T,F,F,T)", [&bdd]() {
-            assignment_file assignment;
+    it("should return F on test BDD with assignment (T,F,F,T)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, false)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, false)
+           << create_assignment(2, false)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().False());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().False());
+    });
 
-        it("should return T on test BDD with assignment (T,F,T,F)", [&bdd]() {
-            assignment_file assignment;
+    it("should return T on test BDD with assignment (T,F,T,F)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, false)
-                 << create_assignment(2, true)
-                 << create_assignment(3, false);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, false)
+           << create_assignment(2, true)
+           << create_assignment(3, false);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().True());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().True());
+    });
 
-        it("should return T on test BDD with assignment (T,T,F,T)", [&bdd]() {
-            assignment_file assignment;
+    it("should return T on test BDD with assignment (T,T,F,T)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, true)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, true)
+           << create_assignment(2, false)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().True());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().True());
+    });
 
-        it("should return T on test BDD with assignment (T,T,T,F)", [&bdd]() {
-            assignment_file assignment;
+    it("should return T on test BDD with assignment (T,T,T,F)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, true)
-                 << create_assignment(2, true)
-                 << create_assignment(3, false);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, true)
+           << create_assignment(2, true)
+           << create_assignment(3, false);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().False());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().False());
+    });
 
-        it("should return T on test BDD with assignment (T,T,T,T)", [&bdd]() {
-            assignment_file assignment;
+    it("should return T on test BDD with assignment (T,T,T,T)", [&bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, true)
-                 << create_assignment(2, true)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, true)
+           << create_assignment(2, true)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd, assignment), Is().True());
-          });
+      AssertThat(bdd_eval(bdd, assignment), Is().True());
+    });
 
-        // == CREATE 'SKIPPING' BDD ==
-        //             START
-        /*
+    // == CREATE 'SKIPPING' BDD ==
+    //             START
+    /*
              1      ---- x0
             / \
            /   \    ---- x1
@@ -167,125 +167,125 @@ go_bandit([]() {
                 4   ---- x4
                / \
                F T
-        */
+    */
 
-        node_file skip_bdd;
+    node_file skip_bdd;
 
-        node_t skip_n4 = create_node(4,0, sink_F, sink_T);
-        node_t skip_n3 = create_node(2,1, sink_T, skip_n4.uid);
-        node_t skip_n2 = create_node(2,0, sink_F, sink_T);
-        node_t skip_n1 = create_node(0,0, skip_n2.uid, skip_n3.uid);
+    node_t skip_n4 = create_node(4,0, sink_F, sink_T);
+    node_t skip_n3 = create_node(2,1, sink_T, skip_n4.uid);
+    node_t skip_n2 = create_node(2,0, sink_F, sink_T);
+    node_t skip_n1 = create_node(0,0, skip_n2.uid, skip_n3.uid);
 
-        { // Garbage collect writer to free write-lock
-          node_writer skip_nw(skip_bdd);
-          skip_nw << skip_n4 << skip_n3 << skip_n2 << skip_n1;
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer skip_nw(skip_bdd);
+      skip_nw << skip_n4 << skip_n3 << skip_n2 << skip_n1;
+    }
 
-        //              END
-        // == CREATE 'SKIPPING' BDD ==
+    //              END
+    // == CREATE 'SKIPPING' BDD ==
 
-        it("should be able to evaluate BDD that skips level [1]", [&skip_bdd]() {
-            assignment_file assignment;
+    it("should be able to evaluate BDD that skips level [1]", [&skip_bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, false)
-                 << create_assignment(1, true)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true)
-                 << create_assignment(4, true);
-            }
+        aw << create_assignment(0, false)
+           << create_assignment(1, true)
+           << create_assignment(2, false)
+           << create_assignment(3, true)
+           << create_assignment(4, true);
+      }
 
-            AssertThat(bdd_eval(skip_bdd, assignment), Is().False());
-          });
+      AssertThat(bdd_eval(skip_bdd, assignment), Is().False());
+    });
 
-        it("should be able to evaluate BDD that skips level [2]", [&skip_bdd]() {
-            assignment_file assignment;
+    it("should be able to evaluate BDD that skips level [2]", [&skip_bdd]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, false)
-                 << create_assignment(2, true)
-                 << create_assignment(3, true)
-                 << create_assignment(4, false);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, false)
+           << create_assignment(2, true)
+           << create_assignment(3, true)
+           << create_assignment(4, false);
+      }
 
-            AssertThat(bdd_eval(skip_bdd, assignment), Is().False());
-          });
+      AssertThat(bdd_eval(skip_bdd, assignment), Is().False());
+    });
 
-        it("should return T on BDD with non-zero root with assignment (F,T)", [&]() {
-            /*
+    it("should return T on BDD with non-zero root with assignment (F,T)", [&]() {
+      /*
                                  ---- x0
 
                      1           ---- x1
                     / \
                     F T
-             */
+      */
 
-            node_file non_zero_bdd;
+      node_file non_zero_bdd;
 
-            { // Garbage collect writer to free write-lock
-              node_writer nw(non_zero_bdd);
-              nw << create_node(1,0, sink_F, sink_T);
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer nw(non_zero_bdd);
+        nw << create_node(1,0, sink_F, sink_T);
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, false)
-                 << create_assignment(1, true);
-            }
+        aw << create_assignment(0, false)
+           << create_assignment(1, true);
+      }
 
-            AssertThat(bdd_eval(non_zero_bdd, assignment), Is().True());
-          });
+      AssertThat(bdd_eval(non_zero_bdd, assignment), Is().True());
+    });
 
-        it("should return F on F sink-only BDD", [&]() {
-            node_file bdd2;
+    it("should return F on F sink-only BDD", [&]() {
+      node_file bdd2;
 
-            { // Garbage collect writer to free write-lock
-              node_writer nw2(bdd2);
-              nw2 << create_sink(false);
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer nw2(bdd2);
+        nw2 << create_sink(false);
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, false)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, false)
+           << create_assignment(2, false)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd2, assignment), Is().False());
-          });
+      AssertThat(bdd_eval(bdd2, assignment), Is().False());
+    });
 
-        it("should return T on T sink-only BDD", [&]() {
-            node_file bdd2;
+    it("should return T on T sink-only BDD", [&]() {
+      node_file bdd2;
 
-            { // Garbage collect writer to free write-lock
-              node_writer nw2(bdd2);
-              nw2 << create_sink(true);
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer nw2(bdd2);
+        nw2 << create_sink(true);
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
 
-              aw << create_assignment(0, true)
-                 << create_assignment(1, true)
-                 << create_assignment(2, false)
-                 << create_assignment(3, true);
-            }
+        aw << create_assignment(0, true)
+           << create_assignment(1, true)
+           << create_assignment(2, false)
+           << create_assignment(3, true);
+      }
 
-            AssertThat(bdd_eval(bdd2, assignment), Is().True());
-          });
-      });
+      AssertThat(bdd_eval(bdd2, assignment), Is().True());
+    });
   });
+ });

--- a/test/adiar/bdd/test_if_then_else.cpp
+++ b/test/adiar/bdd/test_if_then_else.cpp
@@ -132,10 +132,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -172,10 +172,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -206,10 +206,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -240,10 +240,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -274,10 +274,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -308,10 +308,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -342,10 +342,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -376,10 +376,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
         });
@@ -410,10 +410,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -444,10 +444,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -494,10 +494,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -543,10 +543,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -592,10 +592,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -663,13 +663,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1004,16 +1004,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,4u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1099,16 +1099,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1171,13 +1171,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1241,13 +1241,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1349,16 +1349,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,4u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1458,16 +1458,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,4u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1564,16 +1564,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,3u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1655,16 +1655,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1744,16 +1744,16 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,4u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1804,16 +1804,16 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });
@@ -1929,28 +1929,28 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(8,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(8,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(6,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(6,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(5,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(5,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(4,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(4,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(level_info.can_pull(), Is().False());
           });

--- a/test/adiar/bdd/test_if_then_else.cpp
+++ b/test/adiar/bdd/test_if_then_else.cpp
@@ -1,460 +1,460 @@
 go_bandit([]() {
-    describe("BDD: If-Then-Else", [&]() {
-        // == CREATE BDDs FOR UNIT TESTS ==
-        //             START
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
-
-        node_file bdd_F;
-        node_file bdd_T;
-        node_file bdd_x0;
-        node_file bdd_not_x0;
-        node_file bdd_x1;
-        node_file bdd_not_x1;
-        node_file bdd_x2;
-        node_file bdd_x0_xor_x1;
-        node_file bdd_x0_xor_x2;
+  describe("BDD: If-Then-Else", [&]() {
+    // == CREATE BDDs FOR UNIT TESTS ==
+    //             START
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
+
+    node_file bdd_F;
+    node_file bdd_T;
+    node_file bdd_x0;
+    node_file bdd_not_x0;
+    node_file bdd_x1;
+    node_file bdd_not_x1;
+    node_file bdd_x2;
+    node_file bdd_x0_xor_x1;
+    node_file bdd_x0_xor_x2;
 
-        { // Garbage collect writers to free write-lock
-          node_writer nw_F(bdd_F);
-          nw_F << create_sink(false);
+    { // Garbage collect writers to free write-lock
+      node_writer nw_F(bdd_F);
+      nw_F << create_sink(false);
 
-          node_writer nw_T(bdd_T);
-          nw_T << create_sink(true);
+      node_writer nw_T(bdd_T);
+      nw_T << create_sink(true);
 
-          node_writer nw_x0(bdd_x0);
-          nw_x0 << create_node(0,0,sink_F,sink_T);
+      node_writer nw_x0(bdd_x0);
+      nw_x0 << create_node(0,0,sink_F,sink_T);
 
-          node_writer nw_not_x0(bdd_not_x0);
-          nw_not_x0 << create_node(0,0,sink_T,sink_F);
+      node_writer nw_not_x0(bdd_not_x0);
+      nw_not_x0 << create_node(0,0,sink_T,sink_F);
 
-          node_writer nw_x1(bdd_x1);
-          nw_x1 << create_node(1,0,sink_F,sink_T);
+      node_writer nw_x1(bdd_x1);
+      nw_x1 << create_node(1,0,sink_F,sink_T);
 
-          node_writer nw_not_x1(bdd_not_x1);
-          nw_not_x1 << create_node(1,0,sink_T,sink_F);
+      node_writer nw_not_x1(bdd_not_x1);
+      nw_not_x1 << create_node(1,0,sink_T,sink_F);
 
-          node_writer nw_x2(bdd_x2);
-          nw_x2 << create_node(2,0,sink_F,sink_T);
+      node_writer nw_x2(bdd_x2);
+      nw_x2 << create_node(2,0,sink_F,sink_T);
 
-          node_writer nw_x0_xor_x1(bdd_x0_xor_x1);
-          nw_x0_xor_x1 << create_node(1,1,sink_T,sink_F)
-                       << create_node(1,0,sink_F,sink_T)
-                       << create_node(0,0,create_node_uid(1,0),create_node_uid(1,1));
+      node_writer nw_x0_xor_x1(bdd_x0_xor_x1);
+      nw_x0_xor_x1 << create_node(1,1,sink_T,sink_F)
+                   << create_node(1,0,sink_F,sink_T)
+                   << create_node(0,0,create_node_uid(1,0),create_node_uid(1,1));
 
-          node_writer nw_x0_xor_x2(bdd_x0_xor_x2);
-          nw_x0_xor_x2 << create_node(2,1,sink_T,sink_F)
-                       << create_node(2,0,sink_F,sink_T)
-                       << create_node(0,0,create_node_uid(2,0),create_node_uid(2,1));
-        }
+      node_writer nw_x0_xor_x2(bdd_x0_xor_x2);
+      nw_x0_xor_x2 << create_node(2,1,sink_T,sink_F)
+                   << create_node(2,0,sink_F,sink_T)
+                   << create_node(0,0,create_node_uid(2,0),create_node_uid(2,1));
+    }
 
-        //              END
-        // == CREATE BDD FOR UNIT TESTS ==
+    //              END
+    // == CREATE BDD FOR UNIT TESTS ==
 
-        // Trivial evaluation by given a sink
-        it("should give back first file on if-true (true ? x0 : x1)", [&]() {
-            __bdd out = bdd_ite(bdd_T, bdd_x0, bdd_x1);
+    // Trivial evaluation by given a sink
+    it("should give back first file on if-true (true ? x0 : x1)", [&]() {
+      __bdd out = bdd_ite(bdd_T, bdd_x0, bdd_x1);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should give back first file with negation flag on if-true (true ? ~x0 : (~x0))", [&]() {
-            // Notice, they are equivalent then-and-else cases, but in two
-            // different files.
-            __bdd out = bdd_ite(bdd_T, bdd_not(bdd_x0), bdd_not_x0);
+    it("should give back first file with negation flag on if-true (true ? ~x0 : (~x0))", [&]() {
+      // Notice, they are equivalent then-and-else cases, but in two
+      // different files.
+      __bdd out = bdd_ite(bdd_T, bdd_not(bdd_x0), bdd_not_x0);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
-            AssertThat(out.negate, Is().True());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x0._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        it("should give back second file on if-false (false ? x0 : x1)", [&]() {
-            __bdd out = bdd_ite(bdd_F, bdd_x0, bdd_x1);
+    it("should give back second file on if-false (false ? x0 : x1)", [&]() {
+      __bdd out = bdd_ite(bdd_F, bdd_x0, bdd_x1);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should give back second file on if-false (false ? (~x1) : ~x1)", [&]() {
-            // Notice, they are equivalent then-and-else cases, but in two
-            // different files.
-            __bdd out = bdd_ite(bdd_F, bdd_not_x1, bdd_not(bdd_x1));
+    it("should give back second file on if-false (false ? (~x1) : ~x1)", [&]() {
+      // Notice, they are equivalent then-and-else cases, but in two
+      // different files.
+      __bdd out = bdd_ite(bdd_F, bdd_not_x1, bdd_not(bdd_x1));
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
-            AssertThat(out.negate, Is().True());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        // Trivial inputs with duplicate file inputs
-        it("should return 'then' file if 'else' file is the same [1]", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_x1);
+    // Trivial inputs with duplicate file inputs
+    it("should return 'then' file if 'else' file is the same [1]", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_x1);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should return 'then' file if 'else' file is the same [2]", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x1), bdd_not(bdd_x1));
+    it("should return 'then' file if 'else' file is the same [2]", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x1), bdd_not(bdd_x1));
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
-            AssertThat(out.negate, Is().True());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_x1._file_ptr));
+      AssertThat(out.negate, Is().True());
+    });
 
-        // Inputs boiling down to an apply
-        it("should create XNOR of x0 and x1 (x0 ? x1 : ~x1) due to same file", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_not(bdd_x1));
+    // Inputs boiling down to an apply
+    it("should create XNOR of x0 and x1 (x0 ? x1 : ~x1) due to same file", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_not(bdd_x1));
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create XNOR of x0 and ~x1 (x0 ? ~x1 : x1) due to same file", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x1), bdd_x1);
+    it("should create XNOR of x0 and ~x1 (x0 ? ~x1 : x1) due to same file", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x1), bdd_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create OR of x0 and x1 (x0 ? x0 : x1) due to same file", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x0, bdd_x1);
+    it("should create OR of x0 and x1 (x0 ? x0 : x1) due to same file", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x0, bdd_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create AND of x0 (negated) and x1 (x0 ? ~x0 : x1) due to same file", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x0), bdd_x1);
+    it("should create AND of x0 (negated) and x1 (x0 ? ~x0 : x1) due to same file", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_not(bdd_x0), bdd_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create AND of x0 and x1 (x0 ? x1 : x0) due to same file", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_x0);
+    it("should create AND of x0 and x1 (x0 ? x1 : x0) due to same file", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_x0);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create IMPLIES of x0 and x1 (x0 ? x1 : ~x0) due to same file", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_not(bdd_x0));
+    it("should create IMPLIES of x0 and x1 (x0 ? x1 : ~x0) due to same file", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_not(bdd_x0));
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create OR of x0 and x1 (x0 ? T : x1)", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_T, bdd_x1);
+    it("should create OR of x0 and x1 (x0 ? T : x1)", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_T, bdd_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create AND of x0 (negated) and x1 (x0 ? F : x1)", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_F, bdd_x1);
+    it("should create AND of x0 (negated) and x1 (x0 ? F : x1)", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_F, bdd_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-        });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create IMPLIES of x0 and x1 (x0 ? x1 : T)", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_T);
+    it("should create IMPLIES of x0 and x1 (x0 ? x1 : T)", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_T);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should create AND of x0 and x1 (x0 ? x1 : F)", [&]() {
-            __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_F);
+    it("should create AND of x0 and x1 (x0 ? x1 : F)", [&]() {
+      __bdd out = bdd_ite(bdd_x0, bdd_x1, bdd_F);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        // Inputs that require the cross-product of all three BDDs
-        it("should compute x0 ? ~x1 : x1", [&]() {
-            /*
+    // Inputs that require the cross-product of all three BDDs
+    it("should compute x0 ? ~x1 : x1", [&]() {
+      /*
                      (x0, ~x1, x1)             ---- x0
                       /         \
                (F, Nil, x1)  (T, ~x1, Nil)     ---- x1
@@ -462,48 +462,48 @@ go_bandit([]() {
                 F        T    T         F
 
                 The low arc is resolved first, since F < T
-             */
-            __bdd out = bdd_ite(bdd_x0, bdd_not_x1, bdd_x1);
+      */
+      __bdd out = bdd_ite(bdd_x0, bdd_not_x1, bdd_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute x1 ? ~x0 : x0", [&]() {
-            /*
+    it("should compute x1 ? ~x0 : x0", [&]() {
+      /*
                      (x1, ~x0, x0)          ---- x0
                       /         \
                 (x1, T, F)  (x1, F, T)      ---- x1
@@ -511,48 +511,48 @@ go_bandit([]() {
                  F      T    T      F
 
                 The high arc is resolved first, since T > F on the second coordinate
-             */
-            __bdd out = bdd_ite(bdd_x1, bdd_not_x0, bdd_x0);
+      */
+      __bdd out = bdd_ite(bdd_x1, bdd_not_x0, bdd_x0);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute x1 ? x0 : ~x0", [&]() {
-            /*
+    it("should compute x1 ? x0 : ~x0", [&]() {
+      /*
                      (x1, x0, ~x0)         ---- x0
                       /         \
                (x1, F, T)  (x1, T, F)      ---- x1
@@ -560,58 +560,58 @@ go_bandit([]() {
                 T      F    F       T
 
                 The low arc is resolved first, since F < T on the second coordinate.
-             */
-            __bdd out = bdd_ite(bdd_x1, bdd_x0, bdd_not_x0);
+      */
+      __bdd out = bdd_ite(bdd_x1, bdd_x0, bdd_not_x0);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute ~x2 ? (x0^x1) : ~(x0^x1)", [&]() {
-            // Create an XNOR input where one needs to forward data across the
-            // level once to resolve the request
-            node_file bdd_x0_xnor_x1;
-            {
-              node_writer nw_x0_xnor_x1(bdd_x0_xnor_x1);
-              nw_x0_xnor_x1 << create_node(1,1,sink_T,sink_F)
-                            << create_node(1,0,sink_F,sink_T)
-                            << create_node(0,0,create_node_uid(1,1),create_node_uid(1,0));
-            }
+    it("should compute ~x2 ? (x0^x1) : ~(x0^x1)", [&]() {
+      // Create an XNOR input where one needs to forward data across the
+      // level once to resolve the request
+      node_file bdd_x0_xnor_x1;
+      {
+        node_writer nw_x0_xnor_x1(bdd_x0_xnor_x1);
+        nw_x0_xnor_x1 << create_node(1,1,sink_T,sink_F)
+                      << create_node(1,0,sink_F,sink_T)
+                      << create_node(0,0,create_node_uid(1,1),create_node_uid(1,0));
+      }
 
-            /*
+      /*
                                 ((2,0),(0,0),(0,0))                 ---- x0
                                  /               \
                       ((2,0),(1,0),(1,1))  ((2,0),(1,1),(1,0))      ---- x1
@@ -623,62 +623,63 @@ go_bandit([]() {
                            ((2,0),F,T)      ((2,0),T,F)             ---- x2
                               / \               / \
                               F T               T F
-             */
-            __bdd out = bdd_ite(bdd_not(bdd_x2), bdd_x0_xor_x1, bdd_x0_xnor_x1);
+      */
+      __bdd out = bdd_ite(bdd_not(bdd_x2), bdd_x0_xor_x1, bdd_x0_xnor_x1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),(1,0),(1,1))
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),(1,0),(1,1))
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),(1,1),(1,0))
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),(1,1),(1,0))
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),F,T)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),F,T)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),T,F)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // ((2,0),T,F)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // ((2,0),F,T)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // ((2,0),F,T)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // ((2,0),T,F)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // ((2,0),T,F)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        // == CREATE BIG OBDDs FOR UNIT TESTS ==
-        //                START
+    // == CREATE BIG OBDDs FOR UNIT TESTS ==
+    //                START
 
-        node_file bdd_1;
-        /*                  _1_              ---- x0
+    node_file bdd_1;
+    /*
+                            _1_              ---- x0
                            /   \
                            2   3             ---- x1
                           / \ / \
@@ -687,22 +688,23 @@ go_bandit([]() {
                          F T  7  T           ---- x3
                              / \
                              F T
-         */
+    */
 
-        { // Garbage collect writers to free write-lock
-          node_writer nw_1(bdd_1);
-          nw_1 << create_node(3,0,sink_F,sink_T)                             // 7
-               << create_node(2,2,sink_F,sink_T)                             // 6
-               << create_node(2,1,sink_T,create_node_ptr(3,0))               // 5
-               << create_node(2,0,create_node_ptr(3,0),sink_T)               // 4
-               << create_node(1,1,create_node_ptr(2,1),create_node_ptr(2,0)) // 3
-               << create_node(1,0,create_node_ptr(2,2),create_node_ptr(2,1)) // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(1,1)) // 1
-            ;
-        }
+    { // Garbage collect writers to free write-lock
+      node_writer nw_1(bdd_1);
+      nw_1 << create_node(3,0,sink_F,sink_T)                             // 7
+           << create_node(2,2,sink_F,sink_T)                             // 6
+           << create_node(2,1,sink_T,create_node_ptr(3,0))               // 5
+           << create_node(2,0,create_node_ptr(3,0),sink_T)               // 4
+           << create_node(1,1,create_node_ptr(2,1),create_node_ptr(2,0)) // 3
+           << create_node(1,0,create_node_ptr(2,2),create_node_ptr(2,1)) // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(1,1)) // 1
+        ;
+    }
 
-        node_file bdd_2;
-        /*                     __1__         ---- x0
+    node_file bdd_2;
+    /*
+                               __1__         ---- x0
                               /     \
                             _2_     _3_      ---- x1
                            /   \   /   \
@@ -711,24 +713,25 @@ go_bandit([]() {
                           F 8 F 9 T F F T    ---- x3
                            / \ / \
                            T F F T
-         */
+    */
 
-        { // Garbage collect writers to free write-lock
-          node_writer nw_2(bdd_2);
-          nw_2 << create_node(3,1,sink_F,sink_T)                              // 9
-               << create_node(3,0,sink_T,sink_F)                              // 8
-               << create_node(2,3,sink_F,sink_T)                              // 7
-               << create_node(2,2,sink_T,sink_F)                              // 6
-               << create_node(2,1,sink_F,create_node_ptr(3,1))                // 5
-               << create_node(2,0,sink_F,create_node_ptr(3,0))                // 4
-               << create_node(1,1,create_node_ptr(2,2),create_node_ptr(2,3))  // 3
-               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))  // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(1,1))  // 1
-            ;
-        }
+    { // Garbage collect writers to free write-lock
+      node_writer nw_2(bdd_2);
+      nw_2 << create_node(3,1,sink_F,sink_T)                              // 9
+           << create_node(3,0,sink_T,sink_F)                              // 8
+           << create_node(2,3,sink_F,sink_T)                              // 7
+           << create_node(2,2,sink_T,sink_F)                              // 6
+           << create_node(2,1,sink_F,create_node_ptr(3,1))                // 5
+           << create_node(2,0,sink_F,create_node_ptr(3,0))                // 4
+           << create_node(1,1,create_node_ptr(2,2),create_node_ptr(2,3))  // 3
+           << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))  // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(1,1))  // 1
+        ;
+    }
 
-        node_file bdd_3;
-       /*                     __1__         ---- x0
+    node_file bdd_3;
+    /*
+                              __1__         ---- x0
                              /     \
                            _2_      \       ---- x1
                           /   \      \
@@ -737,21 +740,22 @@ go_bandit([]() {
                          T F F 6    F T     ---- x3
                               / \
                               F T
-        */
+    */
 
-        { // Garbage collect writers to free write-lock
-          node_writer nw_3(bdd_3);
-          nw_3 << create_node(3,0,sink_F,sink_T)                             // 6
-               << create_node(2,2,sink_F,sink_T)                             // 5
-               << create_node(2,1,sink_F,create_node_ptr(3,0))               // 4
-               << create_node(2,0,sink_T,sink_F)                             // 3
-               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1)) // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,2)) // 1
-            ;
-        }
+    { // Garbage collect writers to free write-lock
+      node_writer nw_3(bdd_3);
+      nw_3 << create_node(3,0,sink_F,sink_T)                             // 6
+           << create_node(2,2,sink_F,sink_T)                             // 5
+           << create_node(2,1,sink_F,create_node_ptr(3,0))               // 4
+           << create_node(2,0,sink_T,sink_F)                             // 3
+           << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1)) // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,2)) // 1
+        ;
+    }
 
-        node_file bdd_4;
-        /*                     __1__         ---- x0
+    node_file bdd_4;
+    /*
+                               __1__         ---- x0
                               /     \
                             _2_      \       ---- x1
                            /   \      \
@@ -760,21 +764,22 @@ go_bandit([]() {
                           6 T F 7    T F     ---- x3
                          / \   / \
                          T F   F T
-        */
-        { // Garbage collect writers to free write-lock
-          node_writer nw_4(bdd_4);
-          nw_4 << create_node(3,1,sink_F,sink_T)                             // 7
-               << create_node(3,0,sink_T,sink_F)                             // 6
-               << create_node(2,2,sink_F,create_node_ptr(3,1))               // 5
-               << create_node(2,1,create_node_ptr(3,0),sink_T)               // 4
-               << create_node(2,0,sink_T,sink_F)                             // 3
-               << create_node(1,0,create_node_ptr(2,1),create_node_ptr(2,2)) // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,0)) // 1
-            ;
-        }
+    */
+    { // Garbage collect writers to free write-lock
+      node_writer nw_4(bdd_4);
+      nw_4 << create_node(3,1,sink_F,sink_T)                             // 7
+           << create_node(3,0,sink_T,sink_F)                             // 6
+           << create_node(2,2,sink_F,create_node_ptr(3,1))               // 5
+           << create_node(2,1,create_node_ptr(3,0),sink_T)               // 4
+           << create_node(2,0,sink_T,sink_F)                             // 3
+           << create_node(1,0,create_node_ptr(2,1),create_node_ptr(2,2)) // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,0)) // 1
+        ;
+    }
 
-        node_file bdd_5;
-        /*                     __1__         ---- x0
+    node_file bdd_5;
+    /*
+                               __1__         ---- x0
                               /     \
                             _2_      \       ---- x1
                            /   \      \
@@ -783,20 +788,21 @@ go_bandit([]() {
                           F 6 T F    F T     ---- x3
                            / \
                            T F
-        */
-        { // Garbage collect writers to free write-lock
-          node_writer nw_5(bdd_5);
-          nw_5 << create_node(3,0,sink_T,sink_F)                             // 6
-               << create_node(2,2,sink_F,create_node_ptr(3,0))               // 5
-               << create_node(2,1,sink_F,sink_T)                             // 4
-               << create_node(2,0,sink_T,sink_F)                             // 3
-               << create_node(1,0,create_node_ptr(2,2),create_node_ptr(2,0)) // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,1)) // 1
-            ;
-        }
+    */
+    { // Garbage collect writers to free write-lock
+      node_writer nw_5(bdd_5);
+      nw_5 << create_node(3,0,sink_T,sink_F)                             // 6
+           << create_node(2,2,sink_F,create_node_ptr(3,0))               // 5
+           << create_node(2,1,sink_F,sink_T)                             // 4
+           << create_node(2,0,sink_T,sink_F)                             // 3
+           << create_node(1,0,create_node_ptr(2,2),create_node_ptr(2,0)) // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,1)) // 1
+        ;
+    }
 
-        node_file bdd_6;
-        /*                          1         ---- x0
+    node_file bdd_6;
+    /*
+                                    1         ---- x0
                                    / \
                                    F _2_      ---- x1
                                     /   \
@@ -804,18 +810,19 @@ go_bandit([]() {
                                    / \ / \
                                    F T T F
 
-        */
-        { // Garbage collect writers to free write-lock
-          node_writer nw_6(bdd_6);
-          nw_6 << create_node(2,1,sink_T,sink_F)
-               << create_node(2,0,sink_F,sink_T)
-               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))
-               << create_node(0,0,sink_F,create_node_ptr(1,0))
-            ;
-        }
+    */
+    { // Garbage collect writers to free write-lock
+      node_writer nw_6(bdd_6);
+      nw_6 << create_node(2,1,sink_T,sink_F)
+           << create_node(2,0,sink_F,sink_T)
+           << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))
+           << create_node(0,0,sink_F,create_node_ptr(1,0))
+        ;
+    }
 
-        node_file bdd_not_6;
-         /*                         1         ---- x0
+    node_file bdd_not_6;
+    /*
+                                    1         ---- x0
                                    / \
                                    T _2_      ---- x1
                                     /   \
@@ -823,18 +830,18 @@ go_bandit([]() {
                                    / \ / \
                                    T F F T
 
-        */
-        { // Garbage collect writers to free write-lock
-          node_writer nw_not_6(bdd_not_6);
-          nw_not_6 << create_node(2,1,sink_F,sink_T)
-                   << create_node(2,0,sink_T,sink_F)
-                   << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))
-                   << create_node(0,0,sink_T,create_node_ptr(1,0))
-            ;
-        }
+    */
+    { // Garbage collect writers to free write-lock
+      node_writer nw_not_6(bdd_not_6);
+      nw_not_6 << create_node(2,1,sink_F,sink_T)
+               << create_node(2,0,sink_T,sink_F)
+               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1))
+               << create_node(0,0,sink_T,create_node_ptr(1,0))
+        ;
+    }
 
-        node_file bdd_7;
-        /*
+    node_file bdd_7;
+    /*
                                      1         ---- x0
                                     / \
                                     2__\       ---- x1
@@ -844,20 +851,20 @@ go_bandit([]() {
                                   F  5  T      ---- x3
                                     / \
                                     F T
-        */
+    */
 
-        {
-          node_writer nw_7(bdd_7);
-          nw_7 << create_node(3,0,sink_F,sink_T)                             // 5
-               << create_node(2,1,create_node_ptr(3,0),sink_T)               // 4
-               << create_node(2,0,sink_F,create_node_ptr(3,0))               // 3
-               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1)) // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,1)) // 1
-            ;
-        }
+    {
+      node_writer nw_7(bdd_7);
+      nw_7 << create_node(3,0,sink_F,sink_T)                             // 5
+           << create_node(2,1,create_node_ptr(3,0),sink_T)               // 4
+           << create_node(2,0,sink_F,create_node_ptr(3,0))               // 3
+           << create_node(1,0,create_node_ptr(2,0),create_node_ptr(2,1)) // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(2,1)) // 1
+        ;
+    }
 
-        node_file bdd_8;
-        /*
+    node_file bdd_8;
+    /*
                                    1         ---- x0
                                   / \
                                   2 |        ---- x1
@@ -867,46 +874,46 @@ go_bandit([]() {
                                 T 4          ---- x3
                                  / \
                                  T F
-        */
-        {
-          node_writer nw_8(bdd_8);
-          nw_8 << create_node(3,0,sink_T,sink_F)                             // 4
-               << create_node(2,0,sink_T,create_node_ptr(3,0))               // 3
-               << create_node(1,0,create_node_ptr(2,0),create_node_ptr(3,0)) // 2
-               << create_node(0,0,create_node_ptr(1,0),create_node_ptr(3,0)) // 1
-            ;
-        }
+    */
+    {
+      node_writer nw_8(bdd_8);
+      nw_8 << create_node(3,0,sink_T,sink_F)                             // 4
+           << create_node(2,0,sink_T,create_node_ptr(3,0))               // 3
+           << create_node(1,0,create_node_ptr(2,0),create_node_ptr(3,0)) // 2
+           << create_node(0,0,create_node_ptr(1,0),create_node_ptr(3,0)) // 1
+        ;
+    }
 
-        //                 END
-        // == CREATE BIG OBDDs FOR UNIT TESTS ==
+    //                 END
+    // == CREATE BIG OBDDs FOR UNIT TESTS ==
 
-        it("should compute x3 ? (x1 & x2) : bdd_1", [&]() {
-            node_file bdd_x3;
-            /*
+    it("should compute x3 ? (x1 & x2) : bdd_1", [&]() {
+      node_file bdd_x3;
+      /*
                      1     ---- x3
                     / \
                     F T
-             */
-            {
-              node_writer nw_x3(bdd_x3);
-              nw_x3 << create_node(3,0,sink_F,sink_T);
-            }
+      */
+      {
+        node_writer nw_x3(bdd_x3);
+        nw_x3 << create_node(3,0,sink_F,sink_T);
+      }
 
-            node_file bdd_x1_and_x2;
-            /*
+      node_file bdd_x1_and_x2;
+      /*
                      1     ---- x1
                     / \
                     F 2    ---- x2
                      / \
                      F T
-             */
-            {
-              node_writer nw_x1_and_x2(bdd_x1_and_x2);
-              nw_x1_and_x2 << create_node(2,1,sink_F,sink_T)
-                           << create_node(1,0,sink_F,create_node_ptr(2,1));
-            }
+      */
+      {
+        node_writer nw_x1_and_x2(bdd_x1_and_x2);
+        nw_x1_and_x2 << create_node(2,1,sink_F,sink_T)
+                     << create_node(1,0,sink_F,create_node_ptr(2,1));
+      }
 
-            /*
+      /*
                                         (1,1,1)                          ---- x0
                              ____________/   \___________
                             /                            \
@@ -936,90 +943,90 @@ go_bandit([]() {
               'then' and the 'else' case agree, so we don't recurse to obtain
               the value of the 'if' conditional. The same goes for T sink of
               (1,2,4).
-             */
-            __bdd out = bdd_ite(bdd_x3, bdd_x1_and_x2, bdd_1);
+      */
+      __bdd out = bdd_ite(bdd_x3, bdd_x1_and_x2, bdd_1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,1,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,1,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,1,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,1,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,6)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,3) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,6)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,3) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,7)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,7)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,T)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,1) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), create_node_ptr(3,1) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,F,T)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,T,7)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,T,7)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,2,4)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,2,4)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,6)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,6)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,7)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,7)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,T)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,F,T)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,T,7)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,T,7)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute bdd_3 ? bdd_4 : bdd_5", [&]() {
-            /*
+    it("should compute bdd_3 ? bdd_4 : bdd_5", [&]() {
+      /*
                                      (1,1,1)               ---- x0
                                  ______/ \______
                                 /               \
@@ -1040,89 +1047,89 @@ go_bandit([]() {
                 one at a time.
 
                 The level for x3 equires to forward (6) in (6,7,F) once.
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_3, bdd_4, bdd_5);
+      __bdd out = bdd_ite(bdd_3, bdd_4, bdd_5);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (4,5,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (4,5,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (5,3,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (5,3,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,6)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,6)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (T,6,_)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (T,6,_)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (6,7,F)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (6,7,F)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (5,3,4)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (5,3,4)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,6)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,6)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (T,6,_)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (T,6,_)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (6,7,F)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (6,7,F)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute bdd_6 ? x0^x2 : bdd_not_6", [&]() {
-            /*                bdd_x0_xor_x2
+    it("should compute bdd_6 ? x0^x2 : bdd_not_6", [&]() {
+      /*                      bdd_x0_xor_x2
                     _1_       ---- x1
                    /   \
                    2   3      ---- x2
                   / \ / \
                   F T T F
-            */
+      */
 
-            /*
+      /*
                                  (1,1,1)               ---- x0
                                   /   \
                                   T  (2,2,3)           ---- x1
@@ -1134,65 +1141,65 @@ go_bandit([]() {
                  On level x2 forwarding happens for (3,3,3) with the two nodes
                  3, 3 from the if-case and else-case. Both of these are
                  encountered simultaneously, so they are in one-go forwarded.
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_6, bdd_x0_xor_x2, bdd_not_6);
+      __bdd out = bdd_ite(bdd_6, bdd_x0_xor_x2, bdd_not_6);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (4,4,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (4,4,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,1,1)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,1,1)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,4,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (4,4,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
 
-        it("should compute bdd_not_6 ? bdd_6 : x0^x2", [&]() {
-            /*                bdd_x0_xor_x2
+    it("should compute bdd_not_6 ? bdd_6 : x0^x2", [&]() {
+      /*                      bdd_x0_xor_x2
                     _1_       ---- x1
                    /   \
                    2   3      ---- x2
                   / \ / \
                   F T T F
-            */
+      */
 
-            /*
+      /*
                                  (1,1,1)               ---- x0
                                   /   \
                                   F  (2,3,2)           ---- x1
@@ -1204,71 +1211,71 @@ go_bandit([]() {
                  On level x2 forwarding happens for (3,3,3) with the two nodes
                  3, 3 from the if-case and then-case. Both of these are
                  encountered simultaneously, so they are in one-go forwarded.
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_not_6, bdd_6, bdd_x0_xor_x2);
+      __bdd out = bdd_ite(bdd_not_6, bdd_6, bdd_x0_xor_x2);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,3,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,3,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (4,3,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (4,3,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (1,1,1)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (1,1,1)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,4,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (4,4,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute ~(x0^x2) ? ~x2 : bdd_1", [&]() {
-            node_file bdd_x0_xnor_x2;
-            /*
+    it("should compute ~(x0^x2) ? ~x2 : bdd_1", [&]() {
+      node_file bdd_x0_xnor_x2;
+      /*
                                 _1_
                                /   \
                                3   2
                               / \ / \
                               T F F T
-             */
-            {
-              node_writer nw_x0_xnor_x2(bdd_x0_xnor_x2);
-              nw_x0_xnor_x2 << create_node(2,1,sink_T,sink_F)                              // 3
-                            << create_node(2,0,sink_F,sink_T)                              // 2
-                            << create_node(0,0,create_node_uid(2,1),create_node_uid(2,0)); // 1
-            }
+      */
+      {
+        node_writer nw_x0_xnor_x2(bdd_x0_xnor_x2);
+        nw_x0_xnor_x2 << create_node(2,1,sink_T,sink_F)                              // 3
+                      << create_node(2,0,sink_F,sink_T)                              // 2
+                      << create_node(0,0,create_node_uid(2,1),create_node_uid(2,0)); // 1
+      }
 
-            /*
+      /*
                                  (1,1,1)                   ---- x0
                            _______/   \________
                           /                    \
@@ -1290,97 +1297,97 @@ go_bandit([]() {
                and (2,1,4) is resolved without forwarding, (2,1,5) forwards two
                elements (2 and 1) at once, and finally (3,1,5) and (3,1,6)
                require forwarding two elements one at a time.
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_x0_xnor_x2, bdd_not(bdd_x2), bdd_1);
+      __bdd out = bdd_ite(bdd_x0_xnor_x2, bdd_not(bdd_x2), bdd_1);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,1,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,6)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,3) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,1,6)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,3) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,7)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,7)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,1,4)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (2,1,4)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,1,5)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (2,1,5)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,1,5)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,1,5)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,1,6)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,1,6)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,7)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,7)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute (x1^x2) ? bdd_1 : bdd_2", [&]() {
-            node_file bdd_x1_xor_x2_2;
-            /*
+    it("should compute (x1^x2) ? bdd_1 : bdd_2", [&]() {
+      node_file bdd_x1_xor_x2_2;
+      /*
                             _1_      ---- x1
                            /   \
                            3   2     ---- x2
                           / \ / \
                           F T T F
-             */
+      */
 
-            {
-              node_writer nw_x1_xor_x2(bdd_x1_xor_x2_2);
-              nw_x1_xor_x2 << create_node(2,1,sink_F,sink_T)                              // 3
-                           << create_node(2,0,sink_T,sink_F)                              // 2
-                           << create_node(1,0,create_node_uid(2,1),create_node_uid(2,0)); // 1
-            }
+      {
+        node_writer nw_x1_xor_x2(bdd_x1_xor_x2_2);
+        nw_x1_xor_x2 << create_node(2,1,sink_F,sink_T)                              // 3
+                     << create_node(2,0,sink_T,sink_F)                              // 2
+                     << create_node(1,0,create_node_uid(2,1),create_node_uid(2,0)); // 1
+      }
 
-            /*
+      /*
                                  (1,1,1)                   ---- x0
                             ______/   \_____
                            /                \
@@ -1394,87 +1401,87 @@ go_bandit([]() {
                             (F,_,9)       (T,7,_)          ---- x3
                              /   \         /   \                    (To reproduce: look at actual ids and sorting)
                              F   T         F   T
-             */
-            __bdd out = bdd_ite(bdd_x1_xor_x2_2, bdd_1, bdd_2);
+      */
+      __bdd out = bdd_ite(bdd_x1_xor_x2_2, bdd_1, bdd_2);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,2,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (1,3,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (1,3,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,5,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,5,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,5,6)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,5,6)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,6,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,6,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,4,7)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,3) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,4,7)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,3) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (T,7,_)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (T,7,_)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,9)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,9)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,5,5)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (2,5,5)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,5,6)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,5,6)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,6,4)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,6,4)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (2,4,7)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (2,4,7)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (T,7,_)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (T,7,_)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,9)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,9)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute (~x0 & ~x1 & x2) ? bdd_2 : bdd_4", [&]() {
-            node_file bdd_if;
-            /*
+    it("should compute (~x0 & ~x1 & x2) ? bdd_2 : bdd_4", [&]() {
+      node_file bdd_if;
+      /*
                               1       ---- x0
                              / \
                              2 F      ---- x1
@@ -1482,16 +1489,16 @@ go_bandit([]() {
                             3 F       ---- x2
                            / \
                            F T
-             */
+      */
 
-            {
-              node_writer nw_if(bdd_if);
-              nw_if << create_node(2,0,sink_F,sink_T)                // 3
-                    << create_node(1,0,create_node_uid(2,0),sink_F)  // 2
-                    << create_node(0,0,create_node_uid(1,0),sink_F); // 1
-            }
+      {
+        node_writer nw_if(bdd_if);
+        nw_if << create_node(2,0,sink_F,sink_T)                // 3
+              << create_node(1,0,create_node_uid(2,0),sink_F)  // 2
+              << create_node(0,0,create_node_uid(1,0),sink_F); // 1
+      }
 
-            /*
+      /*
                                        (1,1,1)                  ---- x0
                                 ________/   \
                                /             \
@@ -1505,82 +1512,82 @@ go_bandit([]() {
 
                 Where the order for x2 is (F,_,3), (3,4,4), (F,_,5) because the
                 (3,4,4) node needs to forward (3,4,_) information once.
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_if, bdd_2, bdd_4);
+      __bdd out = bdd_ite(bdd_if, bdd_2, bdd_4);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,6)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,6)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (T,8,_)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (T,8,_)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,7)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,7)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), create_node_ptr(3,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,5)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,5)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,6)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,6)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (T,8,_)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (T,8,_)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,7)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,7)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,3u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute (x0 | (x1 & x2)) ? bdd_8 : bdd_7", [&]() {
-            node_file bdd_if;
-            /*
+    it("should compute (x0 | (x1 & x2)) ? bdd_8 : bdd_7", [&]() {
+      node_file bdd_if;
+      /*
                                1        ---- x0
                               / \
                               2 T       ---- x1
@@ -1588,16 +1595,16 @@ go_bandit([]() {
                              F 3        ---- x2
                               / \
                               F T
-             */
-            {
-              node_writer nw_if(bdd_if);
-              nw_if << create_node(2,0,sink_F,sink_T)               // 3
-                    << create_node(1,0,sink_F,create_node_ptr(2,0)) // 2
-                    << create_node(0,0,create_node_ptr(1,0),sink_T) // 1
-                ;
-            }
+      */
+      {
+        node_writer nw_if(bdd_if);
+        nw_if << create_node(2,0,sink_F,sink_T)               // 3
+              << create_node(1,0,sink_F,create_node_ptr(2,0)) // 2
+              << create_node(0,0,create_node_ptr(1,0),sink_T) // 1
+          ;
+      }
 
-            /*
+      /*
                                      (1,1,1)        ---- x0
                              _________/   \
                             /             |
@@ -1608,69 +1615,69 @@ go_bandit([]() {
                      F  (F,_,5)        (T,4,_)      ---- x3
                          /   \          /   \
                          F   T          T   F
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_if, bdd_8, bdd_7);
+      __bdd out = bdd_ite(bdd_if, bdd_8, bdd_7);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,2,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,4,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (T,4,_)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,1) }));
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (T,4,_)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,3)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,3)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,5)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,5)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (T,4,_)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (T,4,_)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should compute bdd_6 ? bdd_4 : bdd_2", [&]() {
-            /*
+    it("should compute bdd_6 ? bdd_4 : bdd_2", [&]() {
+      /*
                                        (1,1,1)                           ---- x0
                               __________/   \___________
                              /                          \
@@ -1681,146 +1688,146 @@ go_bandit([]() {
                       F (F,_,8) F (F,_,9)         T   F   T   T          ---- x3
                          /   \     /   \
                          T   F     F   T
-             */
+      */
 
-            __bdd out = bdd_ite(bdd_6, bdd_4, bdd_2);
+      __bdd out = bdd_ite(bdd_6, bdd_4, bdd_2);
 
-            node_arc_test_stream node_arcs(out);
+      node_arc_test_stream node_arcs(out);
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,2)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,2)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (2,3,3)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (2,3,3)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,4)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,4)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,5)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,5)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,6)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,2) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (3,3,6)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), create_node_ptr(2,2) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (4,3,7)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,3) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (4,3,7)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), create_node_ptr(2,3) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,8)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,8)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
 
-            AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,9)
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,1) }));
+      AssertThat(node_arcs.can_pull(), Is().True()); // (F,_,9)
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), create_node_ptr(3,1) }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(out);
+      sink_arc_test_stream sink_arcs(out);
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,4)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,4)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,5)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,5)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,6)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (3,3,6)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,2), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,2)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (4,3,7)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (4,3,7)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,3), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,3)), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,8)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,8)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,9)
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True()); // (F,_,9)
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,4u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should merely zip disjunct levels if possible [1]", [&]() {
-            node_file bdd_x1_and_x3;
-            /*
+    it("should merely zip disjunct levels if possible [1]", [&]() {
+      node_file bdd_x1_and_x3;
+      /*
                          1      ---- x1
                         / \
                         F 2     ---- x3
                          / \
                          T F
-             */
+      */
 
-            {
-              node_writer nw_x1_and_x3(bdd_x1_and_x3);
-              nw_x1_and_x3 << create_node(3,42,sink_F,sink_T)                // 2
-                           << create_node(1,0,sink_F,create_node_uid(3,42)); // 1
-            }
+      {
+        node_writer nw_x1_and_x3(bdd_x1_and_x3);
+        nw_x1_and_x3 << create_node(3,42,sink_F,sink_T)                // 2
+                     << create_node(1,0,sink_F,create_node_uid(3,42)); // 1
+      }
 
-            bdd out = bdd_ite(bdd_x0, bdd_x2, bdd_x1_and_x3);
-            AssertThat(is_canonical(out), Is().False());
+      bdd out = bdd_ite(bdd_x0, bdd_x2, bdd_x1_and_x3);
+      AssertThat(is_canonical(out), Is().False());
 
-            node_test_stream ns(out);
+      node_test_stream ns(out);
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(3,42,
-                                                           sink_F,
-                                                           sink_T)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(3,42,
+                                                     sink_F,
+                                                     sink_T)));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(2,0,
-                                                           sink_F,
-                                                           sink_T)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2,0,
+                                                     sink_F,
+                                                     sink_T)));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(1,0,
-                                                           sink_F,
-                                                           create_node_ptr(3,42))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1,0,
+                                                     sink_F,
+                                                     create_node_ptr(3,42))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(0,0,
-                                                           create_node_ptr(1,0),
-                                                           create_node_ptr(2,0))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0,0,
+                                                     create_node_ptr(1,0),
+                                                     create_node_ptr(2,0))));
 
-            AssertThat(ns.can_pull(), Is().False());
+      AssertThat(ns.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("should merely zip disjunct levels if possible [2]", [&]() {
-            node_file bdd_then;
-            /*
+    it("should merely zip disjunct levels if possible [2]", [&]() {
+      node_file bdd_then;
+      /*
                          _1_      ---- x2
                         /   \
                         2   3     ---- x3
@@ -1830,237 +1837,237 @@ go_bandit([]() {
                         F T T 6   ---- x6
                              / \
                              T F
-             */
+      */
 
-            {
-              node_writer nw_then(bdd_then);
-              nw_then << create_node(6,1,sink_T,sink_F)                              // 6
-                      << create_node(4,1,sink_T,create_node_ptr(6,1))                // 5
-                      << create_node(4,0,sink_F,sink_T)                              // 4
-                      << create_node(3,2,sink_T,create_node_ptr(4,1))                // 3
-                      << create_node(3,0,sink_T,create_node_ptr(4,0))                // 2
-                      << create_node(2,0,create_node_ptr(3,0),create_node_uid(3,2)); // 1
-            }
+      {
+        node_writer nw_then(bdd_then);
+        nw_then << create_node(6,1,sink_T,sink_F)                              // 6
+                << create_node(4,1,sink_T,create_node_ptr(6,1))                // 5
+                << create_node(4,0,sink_F,sink_T)                              // 4
+                << create_node(3,2,sink_T,create_node_ptr(4,1))                // 3
+                << create_node(3,0,sink_T,create_node_ptr(4,0))                // 2
+                << create_node(2,0,create_node_ptr(3,0),create_node_uid(3,2)); // 1
+      }
 
-            node_file bdd_else;
-            /*
+      node_file bdd_else;
+      /*
                          _1_      ---- x5
                         /   \
                         2   3     ---- x8
                        / \ / \
                        T F F T
-            */
+      */
 
-            {
-              node_writer nw_else(bdd_else);
-              nw_else << create_node(8,1,sink_T,sink_F)                             // 3
-                      << create_node(8,0,sink_F,sink_T)                             // 2
-                      << create_node(5,0,create_node_ptr(8,0),create_node_ptr(8,1)) // 1
-                ;
-            }
+      {
+        node_writer nw_else(bdd_else);
+        nw_else << create_node(8,1,sink_T,sink_F)                             // 3
+                << create_node(8,0,sink_F,sink_T)                             // 2
+                << create_node(5,0,create_node_ptr(8,0),create_node_ptr(8,1)) // 1
+          ;
+      }
 
-            bdd out = bdd_ite(bdd_not(bdd_x0_xor_x1), bdd_then, bdd_else);
-            AssertThat(is_canonical(out), Is().False());
+      bdd out = bdd_ite(bdd_not(bdd_x0_xor_x1), bdd_then, bdd_else);
+      AssertThat(is_canonical(out), Is().False());
 
-            node_test_stream ns(out);
+      node_test_stream ns(out);
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(8,1,
-                                                           sink_T,
-                                                           sink_F)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(8,1,
+                                                     sink_T,
+                                                     sink_F)));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(8,0,
-                                                           sink_F,
-                                                           sink_T)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(8,0,
+                                                     sink_F,
+                                                     sink_T)));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(6,1,
-                                                           sink_T,
-                                                           sink_F)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(6,1,
+                                                     sink_T,
+                                                     sink_F)));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(5,0,
-                                                           create_node_ptr(8,0),
-                                                           create_node_ptr(8,1))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(5,0,
+                                                     create_node_ptr(8,0),
+                                                     create_node_ptr(8,1))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(4,1,
-                                                           sink_T,
-                                                           create_node_ptr(6,1))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(4,1,
+                                                     sink_T,
+                                                     create_node_ptr(6,1))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(4,0,
-                                                           sink_F,
-                                                           sink_T)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(4,0,
+                                                     sink_F,
+                                                     sink_T)));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(3,2,
-                                                           sink_T,
-                                                           create_node_ptr(4,1))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(3,2,
+                                                     sink_T,
+                                                     create_node_ptr(4,1))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(3,0,
-                                                           sink_T,
-                                                           create_node_ptr(4,0))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(3,0,
+                                                     sink_T,
+                                                     create_node_ptr(4,0))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(2,0,
-                                                           create_node_ptr(3,0),
-                                                           create_node_ptr(3,2))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2,0,
+                                                     create_node_ptr(3,0),
+                                                     create_node_ptr(3,2))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(1,1,
-                                                           create_node_ptr(5,0),
-                                                           create_node_ptr(2,0))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1,1,
+                                                     create_node_ptr(5,0),
+                                                     create_node_ptr(2,0))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(1,0,
-                                                           create_node_ptr(2,0),
-                                                           create_node_ptr(5,0))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1,0,
+                                                     create_node_ptr(2,0),
+                                                     create_node_ptr(5,0))));
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_node(0,0,
-                                                           create_node_ptr(1,0),
-                                                           create_node_ptr(1,1))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0,0,
+                                                     create_node_ptr(1,0),
+                                                     create_node_ptr(1,1))));
 
-            AssertThat(ns.can_pull(), Is().False());
+      AssertThat(ns.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(8,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(8,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(6,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(6,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(5,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(5,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(4,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(4,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(level_info.can_pull(), Is().True());
-            AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(level_info.can_pull(), Is().True());
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(level_info.can_pull(), Is().False());
-          });
+      AssertThat(level_info.can_pull(), Is().False());
+    });
 
-        it("can derive canonicity when zipping with one-node 'if'", [&]() {
-            node_file bdd_if;
-            {
-              node_writer nw_if(bdd_if);
-              nw_if << create_node(0,MAX_ID,sink_T,sink_F);
-            }
+    it("can derive canonicity when zipping with one-node 'if'", [&]() {
+      node_file bdd_if;
+      {
+        node_writer nw_if(bdd_if);
+        nw_if << create_node(0,MAX_ID,sink_T,sink_F);
+      }
 
-            node_file bdd_a;
-            {
-              node_writer nw_a(bdd_a);
-              nw_a << create_node(2,MAX_ID,sink_F,sink_T);
-            }
+      node_file bdd_a;
+      {
+        node_writer nw_a(bdd_a);
+        nw_a << create_node(2,MAX_ID,sink_F,sink_T);
+      }
 
-            node_file bdd_b;
-            {
-              node_writer nw_b(bdd_b);
-              nw_b << create_node(1,MAX_ID,sink_T,sink_F);
-            }
+      node_file bdd_b;
+      {
+        node_writer nw_b(bdd_b);
+        nw_b << create_node(1,MAX_ID,sink_T,sink_F);
+      }
 
-            bdd out_1 = bdd_ite(bdd_if, bdd_a, bdd_b);
-            AssertThat(is_canonical(out_1), Is().True());
+      bdd out_1 = bdd_ite(bdd_if, bdd_a, bdd_b);
+      AssertThat(is_canonical(out_1), Is().True());
 
-            bdd out_1n = bdd_ite(bdd_not(bdd_if), bdd_a, bdd_b);
-            AssertThat(is_canonical(out_1n), Is().True());
+      bdd out_1n = bdd_ite(bdd_not(bdd_if), bdd_a, bdd_b);
+      AssertThat(is_canonical(out_1n), Is().True());
 
-            bdd out_2 = bdd_ite(bdd_if, bdd_b, bdd_a);
-            AssertThat(is_canonical(out_2), Is().True());
+      bdd out_2 = bdd_ite(bdd_if, bdd_b, bdd_a);
+      AssertThat(is_canonical(out_2), Is().True());
 
-            bdd out_2n = bdd_ite(bdd_not(bdd_if), bdd_b, bdd_a);
-            AssertThat(is_canonical(out_2n), Is().True());
-         });
+      bdd out_2n = bdd_ite(bdd_not(bdd_if), bdd_b, bdd_a);
+      AssertThat(is_canonical(out_2n), Is().True());
+    });
 
 
-        it("can derive canonicity when zipping negated 'then' or 'else'", [&]() {
-            node_file bdd_if;
-            {
-              node_writer nw_if(bdd_if);
-              nw_if << create_node(0,MAX_ID,sink_T,sink_F);
-            }
-            AssertThat(is_canonical(bdd_if), Is().True());
+    it("can derive canonicity when zipping negated 'then' or 'else'", [&]() {
+      node_file bdd_if;
+      {
+        node_writer nw_if(bdd_if);
+        nw_if << create_node(0,MAX_ID,sink_T,sink_F);
+      }
+      AssertThat(is_canonical(bdd_if), Is().True());
 
-            node_file bdd_a;
-            {
-              node_writer nw_a(bdd_a);
-              nw_a << create_node(2,MAX_ID,sink_F,sink_T);
-            }
-            AssertThat(is_canonical(bdd_a), Is().True());
+      node_file bdd_a;
+      {
+        node_writer nw_a(bdd_a);
+        nw_a << create_node(2,MAX_ID,sink_F,sink_T);
+      }
+      AssertThat(is_canonical(bdd_a), Is().True());
 
-            node_file bdd_b;
-            {
-              node_writer nw_b(bdd_b);
-              nw_b << create_node(3,MAX_ID,   sink_F, sink_T)
-                   << create_node(3,MAX_ID-1, sink_T, sink_F)
-                   << create_node(1,MAX_ID,   create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID));
-            }
-            AssertThat(is_canonical(bdd_b), Is().True());
+      node_file bdd_b;
+      {
+        node_writer nw_b(bdd_b);
+        nw_b << create_node(3,MAX_ID,   sink_F, sink_T)
+             << create_node(3,MAX_ID-1, sink_T, sink_F)
+             << create_node(1,MAX_ID,   create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID));
+      }
+      AssertThat(is_canonical(bdd_b), Is().True());
 
-            node_file bdd_c;
-            {
-              node_writer nw_c(bdd_c);
-              nw_c << create_node(1,MAX_ID, sink_T, sink_F);
-            }
-            AssertThat(is_canonical(bdd_c), Is().True());
+      node_file bdd_c;
+      {
+        node_writer nw_c(bdd_c);
+        nw_c << create_node(1,MAX_ID, sink_T, sink_F);
+      }
+      AssertThat(is_canonical(bdd_c), Is().True());
 
-            bdd out_1 = bdd_ite(bdd_if, bdd_not(bdd_a), bdd_b);
-            AssertThat(is_canonical(out_1), Is().True());
+      bdd out_1 = bdd_ite(bdd_if, bdd_not(bdd_a), bdd_b);
+      AssertThat(is_canonical(out_1), Is().True());
 
-            bdd out_2 = bdd_ite(bdd_if, bdd_a, bdd_not(bdd_b));
-            AssertThat(is_canonical(out_2), Is().False());
+      bdd out_2 = bdd_ite(bdd_if, bdd_a, bdd_not(bdd_b));
+      AssertThat(is_canonical(out_2), Is().False());
 
-            bdd out_3 = bdd_ite(bdd_if, bdd_a, bdd_not(bdd_c));
-            AssertThat(is_canonical(out_3), Is().True());
+      bdd out_3 = bdd_ite(bdd_if, bdd_a, bdd_not(bdd_c));
+      AssertThat(is_canonical(out_3), Is().True());
 
-            bdd out_4 = bdd_ite(bdd_if, bdd_not(bdd_b), bdd_not(bdd_a));
-            AssertThat(is_canonical(out_4), Is().False());
-         });
+      bdd out_4 = bdd_ite(bdd_if, bdd_not(bdd_b), bdd_not(bdd_a));
+      AssertThat(is_canonical(out_4), Is().False());
+    });
 
-        it("can derive canonicity when zipping 'if' with multiple nodes on a level", [&]() {
-            node_file bdd_if;
-            {
-              node_writer nw_if(bdd_if);
-              nw_if << create_node(1,MAX_ID,   sink_T,                      sink_T)
-                    << create_node(1,MAX_ID-1, sink_F,                      sink_F)
-                    << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
-            }
+    it("can derive canonicity when zipping 'if' with multiple nodes on a level", [&]() {
+      node_file bdd_if;
+      {
+        node_writer nw_if(bdd_if);
+        nw_if << create_node(1,MAX_ID,   sink_T,                      sink_T)
+              << create_node(1,MAX_ID-1, sink_F,                      sink_F)
+              << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
+      }
 
-            node_file bdd_a;
-            {
-              node_writer nw_a(bdd_a);
-              nw_a << create_node(3,MAX_ID,sink_F,sink_T);
-            }
+      node_file bdd_a;
+      {
+        node_writer nw_a(bdd_a);
+        nw_a << create_node(3,MAX_ID,sink_F,sink_T);
+      }
 
-            node_file bdd_b;
-            {
-              node_writer nw_b(bdd_b);
-              nw_b << create_node(2,MAX_ID,sink_T,sink_F);
-            }
+      node_file bdd_b;
+      {
+        node_writer nw_b(bdd_b);
+        nw_b << create_node(2,MAX_ID,sink_T,sink_F);
+      }
 
-            bdd out_1 = bdd_ite(bdd_if, bdd_a, bdd_b);
-            AssertThat(is_canonical(out_1), Is().True());
+      bdd out_1 = bdd_ite(bdd_if, bdd_a, bdd_b);
+      AssertThat(is_canonical(out_1), Is().True());
 
-            bdd out_2 = bdd_ite(bdd_not(bdd_if), bdd_a, bdd_b);
-            AssertThat(is_canonical(out_2), Is().False());
+      bdd out_2 = bdd_ite(bdd_not(bdd_if), bdd_a, bdd_b);
+      AssertThat(is_canonical(out_2), Is().False());
 
-            bdd out_3 = bdd_ite(bdd_not(bdd_if), bdd_b, bdd_a);
-            AssertThat(is_canonical(out_3), Is().True());
-          });
-      });
+      bdd out_3 = bdd_ite(bdd_not(bdd_if), bdd_b, bdd_a);
+      AssertThat(is_canonical(out_3), Is().True());
+    });
   });
+ });

--- a/test/adiar/bdd/test_negate.cpp
+++ b/test/adiar/bdd/test_negate.cpp
@@ -1,90 +1,90 @@
 go_bandit([]() {
-    describe("BDD: Negate", [&]() {
-        node_file sink_T_nf;
+  describe("BDD: Negate", [&]() {
+    node_file sink_T_nf;
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw(sink_T_nf);
-          nw << create_sink(true);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw(sink_T_nf);
+      nw << create_sink(true);
+    }
 
-        bdd sink_T(sink_T_nf);
+    bdd sink_T(sink_T_nf);
 
-        it("should negate a T sink-only BDD into an F sink-only BDD [const&]", [&]() {
-            bdd out = bdd_not(sink_T);
+    it("should negate a T sink-only BDD into an F sink-only BDD [const&]", [&]() {
+      bdd out = bdd_not(sink_T);
 
-            // Check if it is correct
-            node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-            AssertThat(ns.can_pull(), Is().False());
-          });
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should negate a T sink-only BDD into an F sink-only BDD [&&]", [&]() {
-          bdd out = bdd_not(sink_T_nf);
+    it("should negate a T sink-only BDD into an F sink-only BDD [&&]", [&]() {
+      bdd out = bdd_not(sink_T_nf);
 
-          // Check if it is correct
-          node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should doube-negate a T sink-only BDD back into a T sink-only BDD", [&]() {
-            bdd out = bdd_not(bdd_not(sink_T));
+    it("should doube-negate a T sink-only BDD back into a T sink-only BDD", [&]() {
+      bdd out = bdd_not(bdd_not(sink_T));
 
-            // Check if it is correct
-            node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-            AssertThat(ns.can_pull(), Is().False());
-          });
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        node_file sink_F_nf;
+    node_file sink_F_nf;
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw(sink_F_nf);
-          nw << create_sink(false);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw(sink_F_nf);
+      nw << create_sink(false);
+    }
 
-        bdd sink_F(sink_F_nf);
+    bdd sink_F(sink_F_nf);
 
-        it("should negate a F sink-only BDD into an T sink-only BDD [const&]", [&]() {
-            bdd out = bdd_not(sink_F);
+    it("should negate a F sink-only BDD into an T sink-only BDD [const&]", [&]() {
+      bdd out = bdd_not(sink_F);
 
-            // Check if it is correct
-            node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-            AssertThat(ns.can_pull(), Is().False());
-          });
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should negate a F sink-only BDD into an T sink-only BDD [&&]", [&]() {
-          bdd out = bdd_not(sink_F);
+    it("should negate a F sink-only BDD into an T sink-only BDD [&&]", [&]() {
+      bdd out = bdd_not(sink_F);
 
-          // Check if it is correct
-          node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should doube-negate an F sink-only BDD back into an F sink-only BDD", [&]() {
-            bdd out = bdd_not(bdd_not(sink_T));
+    it("should doube-negate an F sink-only BDD back into an F sink-only BDD", [&]() {
+      bdd out = bdd_not(bdd_not(sink_T));
 
-            // Check if it is correct
-            node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-            AssertThat(ns.can_pull(), Is().True());
-            AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-            AssertThat(ns.can_pull(), Is().False());
-          });
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        /*
+    /*
              1
             / \
             | 2
@@ -92,123 +92,123 @@ go_bandit([]() {
             3  |
             |\ /
             F T
-        */
+    */
 
-        node_file bdd_1_nf;
+    node_file bdd_1_nf;
 
-        ptr_t sink_T_ptr = create_sink_ptr(true);
-        ptr_t sink_F_ptr = create_sink_ptr(false);
+    ptr_t sink_T_ptr = create_sink_ptr(true);
+    ptr_t sink_F_ptr = create_sink_ptr(false);
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw(bdd_1_nf);
+    { // Garbage collect writer to free write-lock
+      node_writer nw(bdd_1_nf);
 
-          nw << create_node(2, MAX_ID, sink_F_ptr, sink_T_ptr)
-             << create_node(1, MAX_ID, create_node_ptr(2, MAX_ID), sink_T_ptr)
-             << create_node(0, MAX_ID, create_node_ptr(2, MAX_ID), create_node_ptr(1, MAX_ID));
-        }
+      nw << create_node(2, MAX_ID, sink_F_ptr, sink_T_ptr)
+         << create_node(1, MAX_ID, create_node_ptr(2, MAX_ID), sink_T_ptr)
+         << create_node(0, MAX_ID, create_node_ptr(2, MAX_ID), create_node_ptr(1, MAX_ID));
+    }
 
-        bdd bdd_1(bdd_1_nf);
+    bdd bdd_1(bdd_1_nf);
 
-        it("should negate sink-children in BDD 1 [const&]", [&]() {
-          bdd out = bdd_not(bdd_1);
+    it("should negate sink-children in BDD 1 [const&]", [&]() {
+      bdd out = bdd_not(bdd_1);
 
-          // Check if it is correct
-          node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                         sink_T_ptr,
-                                                         sink_F_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                     sink_T_ptr,
+                                                     sink_F_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         sink_F_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     sink_F_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         create_node_ptr(1, MAX_ID))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     create_node_ptr(1, MAX_ID))));
 
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should negate sink-children in BDD 1 [&&]", [&]() {
-          bdd out = bdd_not(bdd_1_nf);
+    it("should negate sink-children in BDD 1 [&&]", [&]() {
+      bdd out = bdd_not(bdd_1_nf);
 
-          // Check if it is correct
-          node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                         sink_T_ptr,
-                                                         sink_F_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                     sink_T_ptr,
+                                                     sink_F_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         sink_F_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     sink_F_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         create_node_ptr(1, MAX_ID))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     create_node_ptr(1, MAX_ID))));
 
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should double-negate sink-children in BDD 1 back to the original [const&, &&]", [&]() {
-          // Checkmate, constructivists...
+    it("should double-negate sink-children in BDD 1 back to the original [const&, &&]", [&]() {
+      // Checkmate, constructivists...
 
-          bdd out = bdd_not(bdd_not(bdd_1));
+      bdd out = bdd_not(bdd_not(bdd_1));
 
-          // Check if it is correct
-          node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                         sink_F_ptr,
-                                                         sink_T_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                     sink_F_ptr,
+                                                     sink_T_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         sink_T_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     sink_T_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         create_node_ptr(1, MAX_ID))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     create_node_ptr(1, MAX_ID))));
 
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        it("should double-negate sink-children in BDD 1 back to the original [const&, const&]", [&]() {
-          bdd temp = bdd_not(bdd_1);
-          bdd out = bdd_not(temp);
+    it("should double-negate sink-children in BDD 1 back to the original [const&, const&]", [&]() {
+      bdd temp = bdd_not(bdd_1);
+      bdd out = bdd_not(temp);
 
-          // Check if it is correct
-          node_test_stream ns(out);
+      // Check if it is correct
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                         sink_F_ptr,
-                                                         sink_T_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                     sink_F_ptr,
+                                                     sink_T_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         sink_T_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     sink_T_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         create_node_ptr(1, MAX_ID))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     create_node_ptr(1, MAX_ID))));
 
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().False());
+    });
 
-        /*
+    /*
               1
              / \
             2   3
@@ -217,77 +217,77 @@ go_bandit([]() {
               6
              / \
              F T
-        */
+    */
 
-        node_file bdd_2_nf;
+    node_file bdd_2_nf;
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw(bdd_2_nf);
+    { // Garbage collect writer to free write-lock
+      node_writer nw(bdd_2_nf);
 
-          nw << create_node(2, MAX_ID, sink_F_ptr, sink_T_ptr)
-             << create_node(1, MAX_ID, create_node_ptr(2, MAX_ID), sink_T_ptr)
-             << create_node(1, MAX_ID-1, sink_T_ptr, create_node_ptr(2, MAX_ID))
-             << create_node(0, MAX_ID, create_node_ptr(1, MAX_ID-1), create_node_ptr(1, MAX_ID));
-        }
+      nw << create_node(2, MAX_ID, sink_F_ptr, sink_T_ptr)
+         << create_node(1, MAX_ID, create_node_ptr(2, MAX_ID), sink_T_ptr)
+         << create_node(1, MAX_ID-1, sink_T_ptr, create_node_ptr(2, MAX_ID))
+         << create_node(0, MAX_ID, create_node_ptr(1, MAX_ID-1), create_node_ptr(1, MAX_ID));
+    }
 
-        bdd bdd_2(bdd_2_nf);
+    bdd bdd_2(bdd_2_nf);
 
-        it("should negate sink-children in BDD 2 [const&]", [&]() {
-          bdd out = bdd_not(bdd_2_nf);
+    it("should negate sink-children in BDD 2 [const&]", [&]() {
+      bdd out = bdd_not(bdd_2_nf);
 
-          node_test_stream ns(out);
+      node_test_stream ns(out);
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                         sink_T_ptr,
-                                                         sink_F_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                     sink_T_ptr,
+                                                     sink_F_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         sink_F_ptr)));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     sink_F_ptr)));
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID-1,
-                                                         sink_F_ptr,
-                                                         create_node_ptr(2, MAX_ID))));
-
-
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                         create_node_ptr(1, MAX_ID-1),
-                                                         create_node_ptr(1, MAX_ID))));
-
-          AssertThat(ns.can_pull(), Is().False());
-        });
-
-        it("should negate sink-children in BDD 2 [&&]", [&]() {
-          bdd out = bdd_not(bdd_2_nf);
-
-          node_test_stream ns(out);
-
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                         sink_T_ptr,
-                                                         sink_F_ptr)));
-
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                         create_node_ptr(2, MAX_ID),
-                                                         sink_F_ptr)));
-
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID-1,
-                                                         sink_F_ptr,
-                                                         create_node_ptr(2, MAX_ID))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID-1,
+                                                     sink_F_ptr,
+                                                     create_node_ptr(2, MAX_ID))));
 
 
-          AssertThat(ns.can_pull(), Is().True());
-          AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                         create_node_ptr(1, MAX_ID-1),
-                                                         create_node_ptr(1, MAX_ID))));
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                     create_node_ptr(1, MAX_ID-1),
+                                                     create_node_ptr(1, MAX_ID))));
 
-          AssertThat(ns.can_pull(), Is().False());
-        });
+      AssertThat(ns.can_pull(), Is().False());
     });
-});
+
+    it("should negate sink-children in BDD 2 [&&]", [&]() {
+      bdd out = bdd_not(bdd_2_nf);
+
+      node_test_stream ns(out);
+
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                     sink_T_ptr,
+                                                     sink_F_ptr)));
+
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                     create_node_ptr(2, MAX_ID),
+                                                     sink_F_ptr)));
+
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID-1,
+                                                     sink_F_ptr,
+                                                     create_node_ptr(2, MAX_ID))));
+
+
+      AssertThat(ns.can_pull(), Is().True());
+      AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                     create_node_ptr(1, MAX_ID-1),
+                                                     create_node_ptr(1, MAX_ID))));
+
+      AssertThat(ns.can_pull(), Is().False());
+    });
+  });
+ });

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -1,1561 +1,1561 @@
 go_bandit([]() {
-    describe("BDD: Quantify", [&]() {
-        ////////////////////////////////////////////////////////////////////////
-        // Sink only BDDs
-        node_file sink_F;
-
-        { // Garbage collect writer to free write-lock}
-          node_writer nw_F(sink_F);
-          nw_F << create_sink(false);
-        }
-
-        node_file sink_T;
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_T(sink_T);
-          nw_T << create_sink(true);
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        // BDD 1
-        /*
-        //   1     ---- x0
-        //  / \
-        //  T 2    ---- x1
-        //   / \
-        //   F T
-        */
-        node_file bdd_1;
-
-        node_t n1_2 = create_node(1,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-        node_t n1_1 = create_node(0,MAX_ID, create_sink_ptr(true), n1_2.uid);
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_1(bdd_1);
-          nw_1 << n1_2 << n1_1;
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        // BDD 2
-        /*
-        //       1       ---- x0
-        //      / \
-        //     2   3     ---- x1
-        //    / \ / \
-        //   4   5  F    ---- x2
-        //  / \ / \
-        //  T F F T
-        */
-        node_file bdd_2;
-
-        node_t n2_5 = create_node(2,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-        node_t n2_4 = create_node(2,MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false));
-        node_t n2_3 = create_node(1,MAX_ID, n2_5.uid, create_sink_ptr(false));
-        node_t n2_2 = create_node(1,MAX_ID-1, n2_4.uid, n2_5.uid);
-        node_t n2_1 = create_node(0,MAX_ID, n2_2.uid, n2_3.uid);
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_2(bdd_2);
-          nw_2 << n2_5 << n2_4 << n2_3 <<n2_2 << n2_1;
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        // BDD 3
-        /*
-        //       1       ---- x0
-        //      / \
-        //      |  2     ---- x1
-        //      \ / \
-        //       3   4   ---- x2
-        //      / \ / \
-        //      T F F T
-        */
-        node_file bdd_3;
-
-        node_t n3_4 = create_node(2,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-        node_t n3_3 = create_node(2,MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false));
-        node_t n3_2 = create_node(1,MAX_ID, n3_3.uid, n3_4.uid);
-        node_t n3_1 = create_node(0,MAX_ID, n3_3.uid, n3_2.uid);
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_3(bdd_3);
-          nw_3 << n3_4 << n3_3 << n3_2 << n3_1;
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        // BDD 4
-        /*
-        //       1       ---- x0
-        //      / \
-        //      |  2     ---- x1
-        //      \ / \
-        //       3   4   ---- x2
-        //      / \ / \
-        //      F  5  T  ---- x3
-        //        / \
-        //        F T
-        */
-        node_file bdd_4;
-
-        node_t n4_5 = create_node(3,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-        node_t n4_4 = create_node(2,MAX_ID, n4_5.uid, create_sink_ptr(true));
-        node_t n4_3 = create_node(2,MAX_ID-1, create_sink_ptr(false), n4_5.uid);
-        node_t n4_2 = create_node(1,MAX_ID, n4_3.uid, n4_4.uid);
-        node_t n4_1 = create_node(0,MAX_ID, n4_3.uid, n4_2.uid);
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_4(bdd_4);
-          nw_4 << n4_5 << n4_4 << n4_3 << n4_2 << n4_1;
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        // BDD 5
-        /*
-        //    1      ---- x0
-        //   / \
-        //   F 2     ---- x1
-        //    / \
-        //   3   4   ---- x2
-        //  / \ / \
-        //  F T T F
-        */
-        node_file bdd_5;
-
-        node_t n5_4 = create_node(2,MAX_ID, create_sink_ptr(true), create_sink_ptr(false));
-        node_t n5_3 = create_node(2,MAX_ID-1, create_sink_ptr(false), create_sink_ptr(true));
-        node_t n5_2 = create_node(1,MAX_ID, n5_3.uid, n5_4.uid);
-        node_t n5_1 = create_node(0,MAX_ID, create_sink_ptr(false), n5_2.uid);
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_5(bdd_5);
-          nw_5 << n5_4 << n5_3 << n5_2 << n5_1;
-        }
-
-        ////////////////////////////////////////////////////////////////////////////
-        // x2 variable BDD
-        node_file bdd_x2;
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_x2(bdd_x2);
-          nw_x2 << create_node(2,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-        }
-
-        ////////////////////////////////////////////////////////////////////////////
-        // BDD 6
-        /*
-        //         ___1__        ---- x0
-        //        /      \
-        //      _3__   __2__     ---- x1
-        //     /    \ /     \
-        //     4     6      5    ---- x2
-        //    / \   / \    / \
-        //    F  \ /  T   /  F
-        //        8       7      ---- x3
-        //       / \     / \
-        //       F T     T F
-        */
-        node_file bdd_6;
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_6(bdd_6);
-          nw_6 << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 8
-               << create_node(3,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))      // 7
-               << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID),   create_sink_ptr(true))       // 6
-               << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID-1), create_sink_ptr(false))      // 5
-               << create_node(2,MAX_ID-2, create_sink_ptr(false),      create_node_ptr(3,MAX_ID))   // 4
-               << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-2), create_node_ptr(2,MAX_ID))   // 3
-               << create_node(1,MAX_ID-1, create_node_ptr(2,MAX_ID),   create_node_ptr(2,MAX_ID-1)) // 2
-               << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(1,MAX_ID-1)) // 1
-            ;
-        }
-
-        ////////////////////////////////////////////////////////////////////////////
-        // BDD 7
-        /*
-        //          _1_        ---- x0
-        //         /   \
-        //         3   2       ---- x1
-        //        / \ / \
-        //        \_ | __\
-        //           |    \
-        //           4    5    ---- x2
-        //          / \  / \
-        //          T F  F T
-        */
-        node_file bdd_7;
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_7(bdd_7);
-          nw_7 << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 5
-               << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))      // 4
-               << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_node_ptr(2,MAX_ID-1)) // 3
-               << create_node(1,MAX_ID-1, create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))   // 2
-               << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(1,MAX_ID-1)) // 1
-            ;
-        }
-
-        ////////////////////////////////////////////////////////////////////////////
-        // BDD 8 (b is mirrored on the nodes for x2)
-        /*
-        //           __1__         ---- x0
-        //          /     \
-        //         _2_     \       ---- x1
-        //        /   \     \
-        //        3    4    |      ---- x2
-        //       / \  / \   |
-        //       T  \ F  \  |
-        //           \____\ |
-        //                 \|
-        //                  5      ---- x3
-        //                 / \
-        //                 F T
-        */
-        node_file bdd_8a, bdd_8b;
-
-        { // Garbage collect writer to free write-lock
-          node_writer nw_8a(bdd_8a);
-          nw_8a << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 5
-                << create_node(2,MAX_ID,   create_sink_ptr(false),      create_node_ptr(3,MAX_ID))   // 4
-                << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_node_ptr(3,MAX_ID))   // 3
-                << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))   // 2
-                << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(3,MAX_ID))   // 1
-            ;
-
-          node_writer nw_8b(bdd_8b);
-          nw_8b << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 5
-                << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID),   create_sink_ptr(false))      // 4
-                << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID),   create_sink_ptr(true))       // 3
-                << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))   // 2
-                << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(3,MAX_ID))   // 1
-            ;
-        }
-
-        ////////////////////////////////////////////////////////////////////////////
-        describe("Exists", [&]() {
-            it("should quantify T sink-only BDD as itself", [&]() {
-                __bdd out = bdd_exists(sink_T, 42);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
-
-            it("should quantify F sink-only BDD as itself", [&]() {
-                __bdd out = bdd_exists(sink_F, 21);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
-
-            it("should shortcut quantification of root into T sink [BDD 1]", [&]() {
-                __bdd out = bdd_exists(bdd_1, 0);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
-
-            it("should shortcut quantification of root into T sink [x2]", [&]() {
-                __bdd out = bdd_exists(bdd_x2, 2);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
-
-            it("should shortcut quantification on non-existent label in input [BDD 1]", [&]() {
-                __bdd out = bdd_exists(bdd_1, 42);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(n1_2));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(n1_1));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("should quantify bottom-most nodes [BDD 1]", [&]() {
-                tpie::file_stream<arc_t> reduce_node_arcs;
-                __bdd out = bdd_exists(bdd_1, 1);
-
-                node_arc_test_stream node_arcs(out);
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should quantify root without sink arcs [BDD 2]", [&]() {
-                __bdd out = bdd_exists(bdd_2, 0);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // (4,5)
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // (5,_)
-                           Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should quantify nodes with sink or nodes as children [BDD 2]", [&]() {
-                __bdd out = bdd_exists(bdd_2, 1);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // (4,5)
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // (5,_)
-                           Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should output sink arcs in order, despite the order of resolvement [BDD 2]", [&]() {
-                __bdd out = bdd_exists(bdd_2, 2);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_node_ptr(1,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 4.low
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 5.high
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 5.high
-                           Is().EqualTo(arc_t { create_node_ptr(1,1), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // false due to its own leaf
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,1)), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,2u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should keep nodes as is when skipping quantified level [BDD 3]", [&]() {
-                __bdd out = bdd_exists(bdd_3, 1);
-
-                node_arc_test_stream node_arcs(out);
-
-                // Note, that node (2,0) reflects (3,NIL) since while n4 < NIL we process this
-                // request without forwarding n3 through the secondary priority queue
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // n3
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // n3
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 3.low
-                           Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 4.high
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should output sink arcs in order, despite the order of resolvement [BDD 3]", [&]() {
-                __bdd out = bdd_exists(bdd_3, 2);
-
-                node_arc_test_stream node_arcs(out);
-
-                // Note, that node (2,0) reflects (3,NIL) while n4 < NIL since we process this
-                // request without forwarding n3 through the secondary priority queue
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 3.low
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 3.low
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 4.high
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should resolve sink-sink requests in [BDD 5]", [&]() {
-                __bdd out = bdd_exists(bdd_5, 1);
-
-                node_arc_test_stream node_arcs(out);
-
-                // Note, that node (2,0) reflects (3,NIL) while n4 < NIL since we process this
-                // request without forwarding n3 through the secondary priority queue
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 4.low
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 3.high
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("can shortcut/prune irrelevant subtrees [OR-chain]", [&]() {
-                node_file bdd_chain;
-
-                node_t n4 = create_node(3,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-                node_t n3 = create_node(2,MAX_ID, n4.uid, create_sink_ptr(true));
-                node_t n2 = create_node(1,MAX_ID, n3.uid, create_sink_ptr(true));
-                node_t n1 = create_node(0,MAX_ID, n2.uid, create_sink_ptr(true));
-
-                { // Garbage collect writer to free write-lock
-                  node_writer bdd_chain_w(bdd_chain);
-                  bdd_chain_w << n4 << n3 << n2 << n1;
-                }
-
-                __bdd out = bdd_exists(bdd_chain, 2);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to quantification of x2
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("can forward information across a level [BDD 6]", [&]() {
-                 __bdd out = bdd_exists(bdd_6, 1);
-
-                 node_arc_test_stream node_arcs(out);
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (4,6)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (5,6)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (7,8)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (8,F)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().False());
-
-                 sink_arc_test_stream sink_arcs(out);
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (4,6)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
-
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (5,6)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
-
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (7,8)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(true) }));
-                 AssertThat(sink_arcs.can_pull(), Is().True());
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
-
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (8,F)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { create_node_ptr(3,1), create_sink_ptr(false) }));
-                 AssertThat(sink_arcs.can_pull(), Is().True());
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(3,1)), create_sink_ptr(true) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().False());
-
-                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,2u)));
-
-                 AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("can forward multiple arcs to the same node across a level [BDD 7]", [&]() {
-                 __bdd out = bdd_exists(bdd_7, 1);
-
-                 node_arc_test_stream node_arcs(out);
-
-                 // The high arc is forwarded first, since (2) was resolved before (3)
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (4,5)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
-                 AssertThat(node_arcs.can_pull(), Is().True());
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().False());
-
-                 sink_arc_test_stream sink_arcs(out);
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().False());
-
-                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                 AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should collapse tuple requests of the same node back into request on a single node [BDD 8a]", [&]() {
-                __bdd out = bdd_exists(bdd_8a, 1);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True()); // (5,_)
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,0) }));
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True()); // (3,4)
-                AssertThat(sink_arcs.pull(), // true due to 3.low
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True()); // (5,_)
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
-
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should collapse tuple requests of the same node back into request on a single node [BDD 8b]", [&]() {
-                __bdd out = bdd_exists(bdd_8b, 1);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True()); // (5,_)
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,0) }));
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True()); // (3,4)
-                AssertThat(sink_arcs.pull(), // true due to 3.low
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True()); // (5,_)
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
-
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("can quantify list [x1, x2] in sink-only BDD [&&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2;
-                }
-
-                __bdd out = bdd_exists(sink_T, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can quantify list [x1, x2] in sink-only BDD [const &bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2;
-                }
-
-                bdd in_bdd = sink_T;
-                __bdd out = bdd_exists(in_bdd, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can quantify list [x1, x2] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2;
-                }
-
-                bdd out = bdd_exists(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("can quantify list [x2, x1] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 2 << 1;
-                }
-
-                bdd out = bdd_exists(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("should quantify singleton list [x2] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 2;
-                }
-
-                bdd out = bdd_exists(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1,MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x1, x3] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 3;
-                }
-
-                bdd out = bdd_exists(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x0, x2] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2;
-                }
-
-                bdd out = bdd_exists(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1,MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x0, x2] [BDD 4 : const &bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2;
-                }
-
-                bdd in_bdd = bdd_4;
-                bdd out = bdd_exists(in_bdd, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1,MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x3, x1, x0, x2] where it is sink-only already before x2 [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 3 << 1 << 0 << 2;
-                }
-
-                bdd out = bdd_exists(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x2, x1] into T sink [x2 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 2 << 1;
-                }
-
-                bdd out = bdd_exists(bdd_x2, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify list [] into the original file [BDD 3 : &&bdd]", [&]() {
-                label_file labels;
-
-                // __bdd is used to access the node_file
-                __bdd out = bdd_exists(bdd_3, labels);
-                AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
-              });
-
-            it("should quantify list [] into the original file [BDD 3 : const &bdd]", [&]() {
-                label_file labels;
-
-                bdd in_bdd = bdd_3;
-                __bdd out = bdd_exists(in_bdd, labels);
-                AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
-              });
-          });
-
-        ////////////////////////////////////////////////////////////////////////////
-        // We will not test the Forall operator as much, since it is the same
-        // underlying algorithm, but just with the AND operator.
-        describe("Forall", [&]() {
-            it("should quantify T sink-only BDD as itself", [&]() {
-                __bdd out = bdd_forall(sink_T, 42);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify F sink-only BDD as itself", [&]() {
-                __bdd out = bdd_forall(sink_F, 21);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify root with non-shortcutting sink [BDD 1]", [&]() {
-                __bdd out = bdd_forall(bdd_1, 0);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
-
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should quantify root of [BDD 3]", [&]() {
-                __bdd out = bdd_forall(bdd_3, 0);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should prune shortcuttable requests [BDD 4]", [&]() {
-                __bdd out = bdd_forall(bdd_4, 2);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_node_ptr(3,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // false due to 3.low
-                           Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // false due to 3.low
-                           Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // false due to 5.low
-                           Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), // true due to 5.high and 4.high
-                           Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("can forward information across a level [BDD 6]", [&]() {
-                 __bdd out = bdd_forall(bdd_6, 1);
-
-                 node_arc_test_stream node_arcs(out);
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (4,6)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (5,6)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (7,8)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().True()); // (8,T)
-                 AssertThat(node_arcs.pull(),
-                            Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().False());
-
-                 sink_arc_test_stream sink_arcs(out);
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (4,6)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(false) }));
-
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (5,6)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(false) }));
-
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (7,8)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
-                 AssertThat(sink_arcs.can_pull(), Is().True());
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(false) }));
-
-                 AssertThat(sink_arcs.can_pull(), Is().True()); // (8,T)
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { create_node_ptr(3,1), create_sink_ptr(false) }));
-                 AssertThat(sink_arcs.can_pull(), Is().True());
-                 AssertThat(sink_arcs.pull(),
-                            Is().EqualTo(arc_t { flag(create_node_ptr(3,1)), create_sink_ptr(true) }));
-
-                 AssertThat(node_arcs.can_pull(), Is().False());
-
-                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
-
-                 AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,2u)));
-
-                 AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should collapse tuple requests of the same node back into request on a single node [BDD 8a]", [&]() {
-                __bdd out = bdd_forall(bdd_8a, 1);
-
-                node_arc_test_stream node_arcs(out);
-
-                AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().True()); // (5,_)
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,0) }));
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(),
-                           Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
-
-                AssertThat(node_arcs.can_pull(), Is().False());
-
-                sink_arc_test_stream sink_arcs(out);
-
-                AssertThat(sink_arcs.can_pull(), Is().True()); // (3,4)
-                AssertThat(sink_arcs.pull(), // false due to 4.low
-                           Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(false) }));
-
-                AssertThat(sink_arcs.can_pull(), Is().True()); // (5,_)
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(),
-                           Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
-
-
-                AssertThat(sink_arcs.can_pull(), Is().False());
-
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x0, x2, x1] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 1;
-                }
-
-                bdd out = bdd_forall(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x0, x2, x1] [BDD 4 : const &bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 1;
-                }
-
-                bdd in_bdd = bdd_4;
-                bdd out = bdd_forall(in_bdd, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x1] [BDD 4 : &&bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1;
-                }
-
-                bdd out = bdd_forall(bdd_4, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True()); // (5,_) / (5,T)
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True()); // (3,_) / (3,4)
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_node_ptr(3,MAX_ID))));
-
-                // The node (1,_) is reduced away due to its low child is (3,_)
-                // and its high child is (3,4)
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify list [x1] [BDD 4 : const &bdd]", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1;
-                }
-
-                bdd in_bdd = bdd_4;
-                bdd out = bdd_forall(in_bdd, labels);
-
-                node_test_stream out_nodes(out);
-
-                AssertThat(out_nodes.can_pull(), Is().True()); // (5,_) / (5,T)
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_sink_ptr(true))));
-
-                AssertThat(out_nodes.can_pull(), Is().True()); // (3,_) / (3,4)
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2,MAX_ID,
-                                                                      create_sink_ptr(false),
-                                                                      create_node_ptr(3,MAX_ID))));
-
-                // The node (1,_) is reduced away due to its low child is (3,_)
-                // and its high child is (3,4)
-
-                AssertThat(out_nodes.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3u,1u)));
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2u,1u)));
-
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("should quantify list [] into the original file [BDD 3 : &&bdd]", [&]() {
-                label_file labels;
-
-                // __bdd is used to access the node_file
-                __bdd out = bdd_forall(bdd_3, labels);
-                AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
-              });
-
-            it("should quantify list [] into the original file [BDD 3 : const &bdd]", [&]() {
-                label_file labels;
-
-                bdd in_bdd = bdd_3;
-                __bdd out = bdd_forall(in_bdd, labels);
-                AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
-              });
-          });
+  describe("BDD: Quantify", [&]() {
+    ////////////////////////////////////////////////////////////////////////
+    // Sink only BDDs
+    node_file sink_F;
+
+    { // Garbage collect writer to free write-lock}
+      node_writer nw_F(sink_F);
+      nw_F << create_sink(false);
+    }
+
+    node_file sink_T;
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_T(sink_T);
+      nw_T << create_sink(true);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // BDD 1
+    /*
+    //   1     ---- x0
+    //  / \
+    //  T 2    ---- x1
+    //   / \
+    //   F T
+    */
+    node_file bdd_1;
+
+    node_t n1_2 = create_node(1,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+    node_t n1_1 = create_node(0,MAX_ID, create_sink_ptr(true), n1_2.uid);
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_1(bdd_1);
+      nw_1 << n1_2 << n1_1;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // BDD 2
+    /*
+    //       1       ---- x0
+    //      / \
+    //     2   3     ---- x1
+    //    / \ / \
+    //   4   5  F    ---- x2
+    //  / \ / \
+    //  T F F T
+    */
+    node_file bdd_2;
+
+    node_t n2_5 = create_node(2,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+    node_t n2_4 = create_node(2,MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false));
+    node_t n2_3 = create_node(1,MAX_ID, n2_5.uid, create_sink_ptr(false));
+    node_t n2_2 = create_node(1,MAX_ID-1, n2_4.uid, n2_5.uid);
+    node_t n2_1 = create_node(0,MAX_ID, n2_2.uid, n2_3.uid);
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_2(bdd_2);
+      nw_2 << n2_5 << n2_4 << n2_3 <<n2_2 << n2_1;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // BDD 3
+    /*
+    //       1       ---- x0
+    //      / \
+    //      |  2     ---- x1
+    //      \ / \
+    //       3   4   ---- x2
+    //      / \ / \
+    //      T F F T
+    */
+    node_file bdd_3;
+
+    node_t n3_4 = create_node(2,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+    node_t n3_3 = create_node(2,MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false));
+    node_t n3_2 = create_node(1,MAX_ID, n3_3.uid, n3_4.uid);
+    node_t n3_1 = create_node(0,MAX_ID, n3_3.uid, n3_2.uid);
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_3(bdd_3);
+      nw_3 << n3_4 << n3_3 << n3_2 << n3_1;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // BDD 4
+    /*
+    //       1       ---- x0
+    //      / \
+    //      |  2     ---- x1
+    //      \ / \
+    //       3   4   ---- x2
+    //      / \ / \
+    //      F  5  T  ---- x3
+    //        / \
+    //        F T
+    */
+    node_file bdd_4;
+
+    node_t n4_5 = create_node(3,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+    node_t n4_4 = create_node(2,MAX_ID, n4_5.uid, create_sink_ptr(true));
+    node_t n4_3 = create_node(2,MAX_ID-1, create_sink_ptr(false), n4_5.uid);
+    node_t n4_2 = create_node(1,MAX_ID, n4_3.uid, n4_4.uid);
+    node_t n4_1 = create_node(0,MAX_ID, n4_3.uid, n4_2.uid);
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_4(bdd_4);
+      nw_4 << n4_5 << n4_4 << n4_3 << n4_2 << n4_1;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // BDD 5
+    /*
+    //    1      ---- x0
+    //   / \
+    //   F 2     ---- x1
+    //    / \
+    //   3   4   ---- x2
+    //  / \ / \
+    //  F T T F
+    */
+    node_file bdd_5;
+
+    node_t n5_4 = create_node(2,MAX_ID, create_sink_ptr(true), create_sink_ptr(false));
+    node_t n5_3 = create_node(2,MAX_ID-1, create_sink_ptr(false), create_sink_ptr(true));
+    node_t n5_2 = create_node(1,MAX_ID, n5_3.uid, n5_4.uid);
+    node_t n5_1 = create_node(0,MAX_ID, create_sink_ptr(false), n5_2.uid);
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_5(bdd_5);
+      nw_5 << n5_4 << n5_3 << n5_2 << n5_1;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // x2 variable BDD
+    node_file bdd_x2;
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_x2(bdd_x2);
+      nw_x2 << create_node(2,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // BDD 6
+    /*
+    //         ___1__        ---- x0
+    //        /      \
+    //      _3__   __2__     ---- x1
+    //     /    \ /     \
+    //     4     6      5    ---- x2
+    //    / \   / \    / \
+    //    F  \ /  T   /  F
+    //        8       7      ---- x3
+    //       / \     / \
+    //       F T     T F
+    */
+    node_file bdd_6;
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_6(bdd_6);
+      nw_6 << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 8
+           << create_node(3,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))      // 7
+           << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID),   create_sink_ptr(true))       // 6
+           << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID-1), create_sink_ptr(false))      // 5
+           << create_node(2,MAX_ID-2, create_sink_ptr(false),      create_node_ptr(3,MAX_ID))   // 4
+           << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-2), create_node_ptr(2,MAX_ID))   // 3
+           << create_node(1,MAX_ID-1, create_node_ptr(2,MAX_ID),   create_node_ptr(2,MAX_ID-1)) // 2
+           << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(1,MAX_ID-1)) // 1
+        ;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // BDD 7
+    /*
+    //          _1_        ---- x0
+    //         /   \
+    //         3   2       ---- x1
+    //        / \ / \
+    //        \_ | __\
+    //           |    \
+    //           4    5    ---- x2
+    //          / \  / \
+    //          T F  F T
+    */
+    node_file bdd_7;
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_7(bdd_7);
+      nw_7 << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 5
+           << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))      // 4
+           << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_node_ptr(2,MAX_ID-1)) // 3
+           << create_node(1,MAX_ID-1, create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))   // 2
+           << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(1,MAX_ID-1)) // 1
+        ;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // BDD 8 (b is mirrored on the nodes for x2)
+    /*
+    //           __1__         ---- x0
+    //          /     \
+    //         _2_     \       ---- x1
+    //        /   \     \
+    //        3    4    |      ---- x2
+    //       / \  / \   |
+    //       T  \ F  \  |
+    //           \____\ |
+    //                 \|
+    //                  5      ---- x3
+    //                 / \
+    //                 F T
+    */
+    node_file bdd_8a, bdd_8b;
+
+    { // Garbage collect writer to free write-lock
+      node_writer nw_8a(bdd_8a);
+      nw_8a << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 5
+            << create_node(2,MAX_ID,   create_sink_ptr(false),      create_node_ptr(3,MAX_ID))   // 4
+            << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_node_ptr(3,MAX_ID))   // 3
+            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))   // 2
+            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(3,MAX_ID))   // 1
+        ;
+
+      node_writer nw_8b(bdd_8b);
+      nw_8b << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))       // 5
+            << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID),   create_sink_ptr(false))      // 4
+            << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID),   create_sink_ptr(true))       // 3
+            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))   // 2
+            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(3,MAX_ID))   // 1
+        ;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    describe("Exists", [&]() {
+      it("should quantify T sink-only BDD as itself", [&]() {
+        __bdd out = bdd_exists(sink_T, 42);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
       });
+
+      it("should quantify F sink-only BDD as itself", [&]() {
+        __bdd out = bdd_exists(sink_F, 21);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
+
+      it("should shortcut quantification of root into T sink [BDD 1]", [&]() {
+        __bdd out = bdd_exists(bdd_1, 0);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
+
+      it("should shortcut quantification of root into T sink [x2]", [&]() {
+        __bdd out = bdd_exists(bdd_x2, 2);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
+
+      it("should shortcut quantification on non-existent label in input [BDD 1]", [&]() {
+        __bdd out = bdd_exists(bdd_1, 42);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(n1_2));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(n1_1));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("should quantify bottom-most nodes [BDD 1]", [&]() {
+        tpie::file_stream<arc_t> reduce_node_arcs;
+        __bdd out = bdd_exists(bdd_1, 1);
+
+        node_arc_test_stream node_arcs(out);
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should quantify root without sink arcs [BDD 2]", [&]() {
+        __bdd out = bdd_exists(bdd_2, 0);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // (4,5)
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // (5,_)
+                   Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should quantify nodes with sink or nodes as children [BDD 2]", [&]() {
+        __bdd out = bdd_exists(bdd_2, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // (4,5)
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // (5,_)
+                   Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should output sink arcs in order, despite the order of resolvement [BDD 2]", [&]() {
+        __bdd out = bdd_exists(bdd_2, 2);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 4.low
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 5.high
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 5.high
+                   Is().EqualTo(arc_t { create_node_ptr(1,1), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // false due to its own leaf
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,1)), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should keep nodes as is when skipping quantified level [BDD 3]", [&]() {
+        __bdd out = bdd_exists(bdd_3, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        // Note, that node (2,0) reflects (3,NIL) since while n4 < NIL we process this
+        // request without forwarding n3 through the secondary priority queue
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // n3
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // n3
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 3.low
+                   Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 4.high
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should output sink arcs in order, despite the order of resolvement [BDD 3]", [&]() {
+        __bdd out = bdd_exists(bdd_3, 2);
+
+        node_arc_test_stream node_arcs(out);
+
+        // Note, that node (2,0) reflects (3,NIL) while n4 < NIL since we process this
+        // request without forwarding n3 through the secondary priority queue
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 3.low
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 3.low
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 4.high
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should resolve sink-sink requests in [BDD 5]", [&]() {
+        __bdd out = bdd_exists(bdd_5, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        // Note, that node (2,0) reflects (3,NIL) while n4 < NIL since we process this
+        // request without forwarding n3 through the secondary priority queue
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 4.low
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 3.high
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("can shortcut/prune irrelevant subtrees [OR-chain]", [&]() {
+        node_file bdd_chain;
+
+        node_t n4 = create_node(3,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+        node_t n3 = create_node(2,MAX_ID, n4.uid, create_sink_ptr(true));
+        node_t n2 = create_node(1,MAX_ID, n3.uid, create_sink_ptr(true));
+        node_t n1 = create_node(0,MAX_ID, n2.uid, create_sink_ptr(true));
+
+        { // Garbage collect writer to free write-lock
+          node_writer bdd_chain_w(bdd_chain);
+          bdd_chain_w << n4 << n3 << n2 << n1;
+        }
+
+        __bdd out = bdd_exists(bdd_chain, 2);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to quantification of x2
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("can forward information across a level [BDD 6]", [&]() {
+        __bdd out = bdd_exists(bdd_6, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (4,6)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (5,6)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (7,8)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (8,F)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (4,6)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (5,6)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (7,8)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(true) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (8,F)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,1), create_sink_ptr(false) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,1)), create_sink_ptr(true) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("can forward multiple arcs to the same node across a level [BDD 7]", [&]() {
+        __bdd out = bdd_exists(bdd_7, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        // The high arc is forwarded first, since (2) was resolved before (3)
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (4,5)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (4,5)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should collapse tuple requests of the same node back into request on a single node [BDD 8a]", [&]() {
+        __bdd out = bdd_exists(bdd_8a, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (5,_)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (3,4)
+        AssertThat(sink_arcs.pull(), // true due to 3.low
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (5,_)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
+
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should collapse tuple requests of the same node back into request on a single node [BDD 8b]", [&]() {
+        __bdd out = bdd_exists(bdd_8b, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (5,_)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (3,4)
+        AssertThat(sink_arcs.pull(), // true due to 3.low
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (5,_)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
+
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("can quantify list [x1, x2] in sink-only BDD [&&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2;
+        }
+
+        __bdd out = bdd_exists(sink_T, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can quantify list [x1, x2] in sink-only BDD [const &bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2;
+        }
+
+        bdd in_bdd = sink_T;
+        __bdd out = bdd_exists(in_bdd, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can quantify list [x1, x2] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2;
+        }
+
+        bdd out = bdd_exists(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("can quantify list [x2, x1] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 2 << 1;
+        }
+
+        bdd out = bdd_exists(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("should quantify singleton list [x2] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 2;
+        }
+
+        bdd out = bdd_exists(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1,MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x1, x3] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 3;
+        }
+
+        bdd out = bdd_exists(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0,MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x0, x2] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2;
+        }
+
+        bdd out = bdd_exists(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1,MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x0, x2] [BDD 4 : const &bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2;
+        }
+
+        bdd in_bdd = bdd_4;
+        bdd out = bdd_exists(in_bdd, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1,MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x3, x1, x0, x2] where it is sink-only already before x2 [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 3 << 1 << 0 << 2;
+        }
+
+        bdd out = bdd_exists(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x2, x1] into T sink [x2 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 2 << 1;
+        }
+
+        bdd out = bdd_exists(bdd_x2, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify list [] into the original file [BDD 3 : &&bdd]", [&]() {
+        label_file labels;
+
+        // __bdd is used to access the node_file
+        __bdd out = bdd_exists(bdd_3, labels);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
+      });
+
+      it("should quantify list [] into the original file [BDD 3 : const &bdd]", [&]() {
+        label_file labels;
+
+        bdd in_bdd = bdd_3;
+        __bdd out = bdd_exists(in_bdd, labels);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
+      });
+    });
+
+    ////////////////////////////////////////////////////////////////////////////
+    // We will not test the Forall operator as much, since it is the same
+    // underlying algorithm, but just with the AND operator.
+    describe("Forall", [&]() {
+      it("should quantify T sink-only BDD as itself", [&]() {
+        __bdd out = bdd_forall(sink_T, 42);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify F sink-only BDD as itself", [&]() {
+        __bdd out = bdd_forall(sink_F, 21);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify root with non-shortcutting sink [BDD 1]", [&]() {
+        __bdd out = bdd_forall(bdd_1, 0);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_sink_ptr(true) }));
+
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should quantify root of [BDD 3]", [&]() {
+        __bdd out = bdd_forall(bdd_3, 0);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_node_ptr(2,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,0)), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(2,1), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should prune shortcuttable requests [BDD 4]", [&]() {
+        __bdd out = bdd_forall(bdd_4, 2);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(1,0)), create_node_ptr(3,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // false due to 3.low
+                   Is().EqualTo(arc_t { create_node_ptr(0,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // false due to 3.low
+                   Is().EqualTo(arc_t { create_node_ptr(1,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // false due to 5.low
+                   Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), // true due to 5.high and 4.high
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("can forward information across a level [BDD 6]", [&]() {
+        __bdd out = bdd_forall(bdd_6, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (4,6)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (5,6)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (7,8)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(2,1), create_node_ptr(3,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (8,T)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (4,6)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (5,6)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(2,1)), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (7,8)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (8,T)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,1), create_sink_ptr(false) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,1)), create_sink_ptr(true) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,2u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should collapse tuple requests of the same node back into request on a single node [BDD 8a]", [&]() {
+        __bdd out = bdd_forall(bdd_8a, 1);
+
+        node_arc_test_stream node_arcs(out);
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (3,4)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().True()); // (5,_)
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(),
+                   Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,0) }));
+
+        AssertThat(node_arcs.can_pull(), Is().False());
+
+        sink_arc_test_stream sink_arcs(out);
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (3,4)
+        AssertThat(sink_arcs.pull(), // false due to 4.low
+                   Is().EqualTo(arc_t { create_node_ptr(2,0), create_sink_ptr(false) }));
+
+        AssertThat(sink_arcs.can_pull(), Is().True()); // (5,_)
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { create_node_ptr(3,0), create_sink_ptr(false) }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(),
+                   Is().EqualTo(arc_t { flag(create_node_ptr(3,0)), create_sink_ptr(true) }));
+
+
+        AssertThat(sink_arcs.can_pull(), Is().False());
+
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x0, x2, x1] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 1;
+        }
+
+        bdd out = bdd_forall(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x0, x2, x1] [BDD 4 : const &bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 1;
+        }
+
+        bdd in_bdd = bdd_4;
+        bdd out = bdd_forall(in_bdd, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x1] [BDD 4 : &&bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1;
+        }
+
+        bdd out = bdd_forall(bdd_4, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True()); // (5,_) / (5,T)
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True()); // (3,_) / (3,4)
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_node_ptr(3,MAX_ID))));
+
+        // The node (1,_) is reduced away due to its low child is (3,_)
+        // and its high child is (3,4)
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify list [x1] [BDD 4 : const &bdd]", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1;
+        }
+
+        bdd in_bdd = bdd_4;
+        bdd out = bdd_forall(in_bdd, labels);
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True()); // (5,_) / (5,T)
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_sink_ptr(true))));
+
+        AssertThat(out_nodes.can_pull(), Is().True()); // (3,_) / (3,4)
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2,MAX_ID,
+                                                              create_sink_ptr(false),
+                                                              create_node_ptr(3,MAX_ID))));
+
+        // The node (1,_) is reduced away due to its low child is (3,_)
+        // and its high child is (3,4)
+
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3u,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2u,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("should quantify list [] into the original file [BDD 3 : &&bdd]", [&]() {
+        label_file labels;
+
+        // __bdd is used to access the node_file
+        __bdd out = bdd_forall(bdd_3, labels);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
+      });
+
+      it("should quantify list [] into the original file [BDD 3 : const &bdd]", [&]() {
+        label_file labels;
+
+        bdd in_bdd = bdd_3;
+        __bdd out = bdd_forall(in_bdd, labels);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd_3._file_ptr));
+      });
+    });
   });
+ });

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -296,10 +296,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -326,7 +326,7 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -369,10 +369,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -415,10 +415,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -461,10 +461,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -509,10 +509,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -549,10 +549,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -589,10 +589,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -638,10 +638,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -697,13 +697,13 @@ go_bandit([]() {
                  level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,2u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(3u,2u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,2u)));
 
                  AssertThat(level_info.can_pull(), Is().False());
               });
@@ -737,10 +737,10 @@ go_bandit([]() {
                  level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,1u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                  AssertThat(level_info.can_pull(), Is().False());
               });
@@ -782,13 +782,13 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -830,13 +830,13 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -909,10 +909,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -944,10 +944,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -984,13 +984,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1022,10 +1022,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1057,10 +1057,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1093,10 +1093,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1211,7 +1211,7 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1254,10 +1254,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1300,13 +1300,13 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1362,13 +1362,13 @@ go_bandit([]() {
                  level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,2u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,2u)));
 
                  AssertThat(level_info.can_pull(), Is().True());
-                 AssertThat(level_info.pull(), Is().EqualTo(create_meta(3u,2u)));
+                 AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,2u)));
 
                  AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1410,13 +1410,13 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1493,10 +1493,10 @@ go_bandit([]() {
 
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });
@@ -1533,10 +1533,10 @@ go_bandit([]() {
 
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3u,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3u,1u)));
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2u,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2u,1u)));
 
                 AssertThat(ms.can_pull(), Is().False());
               });

--- a/test/adiar/bdd/test_restrict.cpp
+++ b/test/adiar/bdd/test_restrict.cpp
@@ -83,13 +83,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -135,10 +135,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -198,13 +198,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -256,10 +256,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -297,7 +297,7 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -479,10 +479,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -551,10 +551,10 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,2u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });
@@ -641,13 +641,13 @@ go_bandit([]() {
             level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,2u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,2u)));
+            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,2u)));
 
             AssertThat(meta_arcs.can_pull(), Is().False());
           });

--- a/test/adiar/bdd/test_restrict.cpp
+++ b/test/adiar/bdd/test_restrict.cpp
@@ -1,9 +1,9 @@
 go_bandit([]() {
-    describe("BDD: Restrict", [&]() {
-        // == CREATE BDD FOR UNIT TESTS ==
-        //               START
+  describe("BDD: Restrict", [&]() {
+    // == CREATE BDD FOR UNIT TESTS ==
+    //               START
 
-        /*
+    /*
              1         ---- x0
             / \
             | 2        ---- x1
@@ -13,29 +13,29 @@ go_bandit([]() {
            F T T 5     ---- x3
                 / \
                 F T
-        */
+    */
 
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        node_t n5 = create_node(3,0, sink_F, sink_T);
-        node_t n4 = create_node(2,1, sink_T, n5.uid);
-        node_t n3 = create_node(2,0, sink_F, sink_T);
-        node_t n2 = create_node(1,0, n3.uid, n4.uid);
-        node_t n1 = create_node(0,0, n3.uid, n2.uid);
+    node_t n5 = create_node(3,0, sink_F, sink_T);
+    node_t n4 = create_node(2,1, sink_T, n5.uid);
+    node_t n3 = create_node(2,0, sink_F, sink_T);
+    node_t n2 = create_node(1,0, n3.uid, n4.uid);
+    node_t n1 = create_node(0,0, n3.uid, n2.uid);
 
-        node_file bdd;
+    node_file bdd;
 
-        { // Garbage collect writer to free write-lock
-          node_writer bdd_w(bdd);
-          bdd_w << n5 << n4 << n3 << n2 << n1;
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer bdd_w(bdd);
+      bdd_w << n5 << n4 << n3 << n2 << n1;
+    }
 
-        //                END
-        // == CREATE BDD FOR UNIT TESTS ==
+    //                END
+    // == CREATE BDD FOR UNIT TESTS ==
 
-        it("should bridge level [1]. Assignment: (_,_,T,_)", [&]() {
-            /*
+    it("should bridge level [1]. Assignment: (_,_,T,_)", [&]() {
+      /*
                  1      ---- x0
                 / \
                 T 2     ---- x1
@@ -45,57 +45,57 @@ go_bandit([]() {
                    5    ---- x3
                   / \
                   F T
-            */
+      */
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(2, true);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(2, true);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n2.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n2.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), n5.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), n5.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n1.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n1.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n2.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n2.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n5.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n5.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n5.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n5.uid), sink_T }));
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should bridge levels. [2]. Assignment: (_,F,_,_)", [&]() {
-            /*
+    it("should bridge levels. [2]. Assignment: (_,F,_,_)", [&]() {
+      /*
                  1      ---- x0
                 / \
                 | |
@@ -103,48 +103,48 @@ go_bandit([]() {
                  3      ---- x2
                 / \
                 F T
-            */
+      */
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(1, false);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(1, false);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n3.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n3.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n3.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n3.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should bridge levels [3]. Assignment: (_,T,_,_)", [&]() {
-            /*
+    it("should bridge levels [3]. Assignment: (_,T,_,_)", [&]() {
+      /*
                   1         ---- x0
                  / \
                 /   \
@@ -154,270 +154,270 @@ go_bandit([]() {
                F T T 5      ---- x3
                     / \
                     F T
-            */
+      */
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(1, true);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(1, true);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n3.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n3.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n4.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n4.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n4.uid), n5.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n4.uid), n5.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n4.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n4.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n5.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n5.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n5.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n5.uid), sink_T }));
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should remove root. Assignment: (T,_,_,F)", [&]() {
-            /*
+    it("should remove root. Assignment: (T,_,_,F)", [&]() {
+      /*
                   2     ---- x1
                  / \
                 /   \
                 3   4   ---- x2
                / \ / \
                F T T F
-            */
+      */
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(0, true)
-                 << create_assignment(3, false);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(0, true)
+           << create_assignment(3, false);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n2.uid, n3.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n2.uid, n3.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), n4.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), n4.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n4.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n4.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n4.uid), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n4.uid), sink_F }));
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should ignore skipped variables. Assignment: (F,T,_,F)", [&]() {
-            /*
+    it("should ignore skipped variables. Assignment: (F,T,_,F)", [&]() {
+      /*
                  3      ---- x2
                 / \
                 F T
-            */
+      */
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(0, false)
-                 << create_assignment(1, true)
-                 << create_assignment(3, false);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(0, false)
+           << create_assignment(1, true)
+           << create_assignment(3, false);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_T }));
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should return F sink. Assignment: (F,_,F,_)", [&]() {
-            assignment_file assignment;
+    it("should return F sink. Assignment: (F,_,F,_)", [&]() {
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(0, false)
-                 << create_assignment(2, false);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(0, false)
+           << create_assignment(2, false);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_test_stream out_nodes(output);
+      node_test_stream out_nodes(output);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(output);
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(output);
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should return T sink. Assignment: (T,T,F,_)", [&]() {
-            assignment_file assignment;
+    it("should return T sink. Assignment: (T,T,F,_)", [&]() {
+      assignment_file assignment;
 
-            {  // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(0, true)
-                 << create_assignment(1, true)
-                 << create_assignment(2, false);
-            }
+      {  // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(0, true)
+           << create_assignment(1, true)
+           << create_assignment(2, false);
+      }
 
-            __bdd output = bdd_restrict(bdd, assignment);
+      __bdd output = bdd_restrict(bdd, assignment);
 
-            node_test_stream out_nodes(output);
+      node_test_stream out_nodes(output);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(output);
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(output);
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should return input unchanged when given a T sink", [&]() {
-            node_file T_file;
+    it("should return input unchanged when given a T sink", [&]() {
+      node_file T_file;
 
-            { // Garbage collect writer to free write-lock
-              node_writer Tw(T_file);
-              Tw << create_sink(true);
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer Tw(T_file);
+        Tw << create_sink(true);
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(0, true)
-                 << create_assignment(2, true)
-                 << create_assignment(42, false);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(0, true)
+           << create_assignment(2, true)
+           << create_assignment(42, false);
+      }
 
-            __bdd out = bdd_restrict(T_file, assignment);
+      __bdd out = bdd_restrict(T_file, assignment);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(T_file._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(T_file._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should return input unchanged when given a F sink", [&]() {
-            node_file F_file;
+    it("should return input unchanged when given a F sink", [&]() {
+      node_file F_file;
 
-            { // Garbage collect writer to free write-lock
-              node_writer Fw(F_file);
-              Fw << create_sink(false);
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer Fw(F_file);
+        Fw << create_sink(false);
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(2, true)
-                 << create_assignment(21, true)
-                 << create_assignment(28, false);
-            }
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(2, true)
+           << create_assignment(21, true)
+           << create_assignment(28, false);
+      }
 
-            __bdd out = bdd_restrict(F_file, assignment);
+      __bdd out = bdd_restrict(F_file, assignment);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(F_file._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(F_file._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should return input unchanged when given an empty assignment", [&]() {
-            assignment_file assignment;
+    it("should return input unchanged when given an empty assignment", [&]() {
+      assignment_file assignment;
 
-            __bdd out = bdd_restrict(bdd, assignment);
+      __bdd out = bdd_restrict(bdd, assignment);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should return input unchanged when assignment that is disjoint of its live variables", [&]() {
-            assignment_file assignment;
-            { // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(5, false)
-                 << create_assignment(6, true)
-                 << create_assignment(7, true)
-                ;
-            }
+    it("should return input unchanged when assignment that is disjoint of its live variables", [&]() {
+      assignment_file assignment;
+      { // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(5, false)
+           << create_assignment(6, true)
+           << create_assignment(7, true)
+          ;
+      }
 
-            __bdd out = bdd_restrict(bdd, assignment);
+      __bdd out = bdd_restrict(bdd, assignment);
 
-            AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd._file_ptr));
-            AssertThat(out.negate, Is().False());
-          });
+      AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(bdd._file_ptr));
+      AssertThat(out.negate, Is().False());
+    });
 
-        it("should have sink arcs restricted to a sink sorted [1]", []() {
-            /*
+    it("should have sink arcs restricted to a sink sorted [1]", []() {
+      /*
                     1                 1         ---- x0
                    / \              /   \
                   2   3     =>     2     3      ---- x1
@@ -425,70 +425,70 @@ go_bandit([]() {
                  4 F T F         F*  F  T F     ---- x2
                 / \
                 T F              * This arc will be resolved as the last one
-             */
-            ptr_t sink_T = create_sink_ptr(true);
-            ptr_t sink_F = create_sink_ptr(false);
+      */
+      ptr_t sink_T = create_sink_ptr(true);
+      ptr_t sink_F = create_sink_ptr(false);
 
-            node_file node_input;
+      node_file node_input;
 
-            node_t n4 = create_node(2,0, sink_T, sink_F);
-            node_t n3 = create_node(1,1, sink_T, sink_F);
-            node_t n2 = create_node(1,0, n4.uid, sink_F);
-            node_t n1 = create_node(0,0, n2.uid, n3.uid);
+      node_t n4 = create_node(2,0, sink_T, sink_F);
+      node_t n3 = create_node(1,1, sink_T, sink_F);
+      node_t n2 = create_node(1,0, n4.uid, sink_F);
+      node_t n1 = create_node(0,0, n2.uid, n3.uid);
 
-            { // Garbage collect writer to free write-lock
-              node_writer inw(node_input);
-              inw << n4 << n3 << n2 << n1;
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer inw(node_input);
+        inw << n4 << n3 << n2 << n1;
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            {  // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(2, true);
-            }
+      {  // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(2, true);
+      }
 
-            __bdd output = bdd_restrict(node_input, assignment);
+      __bdd output = bdd_restrict(node_input, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n2.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n2.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n3.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n3.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n2.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n2.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should have sink arcs restricted to a sink sorted [2]", []() {
-            /*
+    it("should have sink arcs restricted to a sink sorted [2]", []() {
+      /*
                     1                _ 1 _
                    / \              /     \
                   2   3     =>     2       3
@@ -496,71 +496,71 @@ go_bandit([]() {
                  4 F 5 F         F*  F   T*  F
                 / \ / \
                 T F F T          * Both these will be resolved out-of-order!
-             */
-            ptr_t sink_T = create_sink_ptr(true);
-            ptr_t sink_F = create_sink_ptr(false);
+      */
+      ptr_t sink_T = create_sink_ptr(true);
+      ptr_t sink_F = create_sink_ptr(false);
 
-            node_file node_input;
+      node_file node_input;
 
-            node_t n5 = create_node(2,1, sink_F, sink_T);
-            node_t n4 = create_node(2,0, sink_T, sink_F);
-            node_t n3 = create_node(1,1, n5.uid, sink_F);
-            node_t n2 = create_node(1,0, n4.uid, sink_F);
-            node_t n1 = create_node(0,0, n2.uid, n3.uid);
+      node_t n5 = create_node(2,1, sink_F, sink_T);
+      node_t n4 = create_node(2,0, sink_T, sink_F);
+      node_t n3 = create_node(1,1, n5.uid, sink_F);
+      node_t n2 = create_node(1,0, n4.uid, sink_F);
+      node_t n1 = create_node(0,0, n2.uid, n3.uid);
 
-            { // Garbage collect writer to free write-lock
-              node_writer inw(node_input);
-              inw << n5 << n4 << n3 << n2 << n1;
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer inw(node_input);
+        inw << n5 << n4 << n3 << n2 << n1;
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            {  // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(2, true);
-            }
+      {  // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(2, true);
+      }
 
-            __bdd output = bdd_restrict(node_input, assignment);
+      __bdd output = bdd_restrict(node_input, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n2.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n2.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n3.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n3.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n2.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n2.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n2.uid), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n3.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_F} ));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n3.uid), sink_F} ));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,2u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should skip 'dead' nodes", [&]() {
-            /*
+    it("should skip 'dead' nodes", [&]() {
+      /*
                         1           ---- x0
                       /   \
                      2     3        ---- x1
@@ -572,144 +572,144 @@ go_bandit([]() {
                       F T  T F
 
                  Here, node 4 and 6 are going to be dead, when x1 -> T.
-             */
+      */
 
-            node_file dead_bdd;
+      node_file dead_bdd;
 
-            node_t n9 = create_node(3,1, sink_T, sink_F);
-            node_t n8 = create_node(3,0, sink_F, sink_T);
-            node_t n7 = create_node(2,3, n9.uid, sink_T);
-            node_t n6 = create_node(2,2, sink_T, n9.uid);
-            node_t n5 = create_node(2,1, sink_F, n8.uid);
-            node_t n4 = create_node(2,0, sink_T, sink_F);
-            node_t n3 = create_node(1,1, n6.uid, n7.uid);
-            node_t n2 = create_node(1,0, n4.uid, n5.uid);
-            node_t n1 = create_node(0,0, n2.uid, n3.uid);
+      node_t n9 = create_node(3,1, sink_T, sink_F);
+      node_t n8 = create_node(3,0, sink_F, sink_T);
+      node_t n7 = create_node(2,3, n9.uid, sink_T);
+      node_t n6 = create_node(2,2, sink_T, n9.uid);
+      node_t n5 = create_node(2,1, sink_F, n8.uid);
+      node_t n4 = create_node(2,0, sink_T, sink_F);
+      node_t n3 = create_node(1,1, n6.uid, n7.uid);
+      node_t n2 = create_node(1,0, n4.uid, n5.uid);
+      node_t n1 = create_node(0,0, n2.uid, n3.uid);
 
-            { // Garbage collect writer to free write-lock
-              node_writer dead_w(dead_bdd);
-              dead_w << n9 << n8 << n7 << n6 << n5 << n4 << n3 << n2 << n1;
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer dead_w(dead_bdd);
+        dead_w << n9 << n8 << n7 << n6 << n5 << n4 << n3 << n2 << n1;
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            {  // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(1, true);
-            }
+      {  // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(1, true);
+      }
 
-            __bdd output = bdd_restrict(dead_bdd, assignment);
+      __bdd output = bdd_restrict(dead_bdd, assignment);
 
-            node_arc_test_stream node_arcs(output);
+      node_arc_test_stream node_arcs(output);
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n5.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1.uid, n5.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n7.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1.uid), n7.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n5.uid), n8.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n5.uid), n8.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().True());
-            AssertThat(node_arcs.pull(), Is().EqualTo(arc { n7.uid, n9.uid }));
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { n7.uid, n9.uid }));
 
-            AssertThat(node_arcs.can_pull(), Is().False());
+      AssertThat(node_arcs.can_pull(), Is().False());
 
-            sink_arc_test_stream sink_arcs(output);
+      sink_arc_test_stream sink_arcs(output);
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n5.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n5.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n7.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n7.uid), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n8.uid, sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n8.uid, sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n8.uid), sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n8.uid), sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n9.uid, sink_T }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { n9.uid, sink_T }));
 
-            AssertThat(sink_arcs.can_pull(), Is().True());
-            AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n9.uid), sink_F }));
+      AssertThat(sink_arcs.can_pull(), Is().True());
+      AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(n9.uid), sink_F }));
 
-            AssertThat(sink_arcs.can_pull(), Is().False());
+      AssertThat(sink_arcs.can_pull(), Is().False());
 
-            level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
+      level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(output);
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().True());
-            AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,2u)));
+      AssertThat(meta_arcs.can_pull(), Is().True());
+      AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should return sink-child of restricted root [assignment = T]", [&]() {
-            node_file sink_child_of_root_bdd;
+    it("should return sink-child of restricted root [assignment = T]", [&]() {
+      node_file sink_child_of_root_bdd;
 
-            node_t n2 = create_node(2,MAX_ID, sink_T, sink_T);
-            node_t n1 = create_node(1,MAX_ID, n2.uid, sink_F);
+      node_t n2 = create_node(2,MAX_ID, sink_T, sink_T);
+      node_t n1 = create_node(1,MAX_ID, n2.uid, sink_F);
 
-            { // Garbage collect writer to free write-lock
-              node_writer dead_w(sink_child_of_root_bdd);
-              dead_w << n2 << n1;
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer dead_w(sink_child_of_root_bdd);
+        dead_w << n2 << n1;
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            {  // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(1, true);
-            }
+      {  // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(1, true);
+      }
 
-            __bdd out = bdd_restrict(sink_child_of_root_bdd, assignment);
+      __bdd out = bdd_restrict(sink_child_of_root_bdd, assignment);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(out);
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(out);
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
 
-        it("should return sink-child of restricted root [assignment = F]", [&]() {
-            node_file sink_child_of_root_bdd;
+    it("should return sink-child of restricted root [assignment = F]", [&]() {
+      node_file sink_child_of_root_bdd;
 
-            node_t n2 = create_node(2,MAX_ID, sink_T, sink_T);
-            node_t n1 = create_node(0,MAX_ID, sink_T, n2.uid);
+      node_t n2 = create_node(2,MAX_ID, sink_T, sink_T);
+      node_t n1 = create_node(0,MAX_ID, sink_T, n2.uid);
 
-            { // Garbage collect writer to free write-lock
-              node_writer dead_w(sink_child_of_root_bdd);
-              dead_w << n2 << n1;
-            }
+      { // Garbage collect writer to free write-lock
+        node_writer dead_w(sink_child_of_root_bdd);
+        dead_w << n2 << n1;
+      }
 
-            assignment_file assignment;
+      assignment_file assignment;
 
-            {  // Garbage collect writer to free write-lock
-              assignment_writer aw(assignment);
-              aw << create_assignment(0, false);
-            }
+      {  // Garbage collect writer to free write-lock
+        assignment_writer aw(assignment);
+        aw << create_assignment(0, false);
+      }
 
-            __bdd out = bdd_restrict(sink_child_of_root_bdd, assignment);
+      __bdd out = bdd_restrict(sink_child_of_root_bdd, assignment);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(out);
-            AssertThat(meta_arcs.can_pull(), Is().False());
-          });
-      });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> meta_arcs(out);
+      AssertThat(meta_arcs.can_pull(), Is().False());
+    });
   });
+ });

--- a/test/adiar/internal/test_isomorphism.cpp
+++ b/test/adiar/internal/test_isomorphism.cpp
@@ -1,164 +1,164 @@
 #include <adiar/internal/pred.h>
 
 go_bandit([]() {
-    describe("INTERNAL: Isomorphism", [&]() {
-        describe("Trivial cases", [&]() {
-            node_file sink_F, x21, x42, x21_and_x22, x21_and_x22_and_x42, x21_and_x42, x21_xor_x42;
+  describe("INTERNAL: Isomorphism", [&]() {
+    describe("Trivial cases", [&]() {
+      node_file sink_F, x21, x42, x21_and_x22, x21_and_x22_and_x42, x21_and_x42, x21_xor_x42;
 
-            { // Garbage collect writers to free write-lock
-              node_writer w_F(sink_F);
-              w_F << create_sink(false);
+      { // Garbage collect writers to free write-lock
+        node_writer w_F(sink_F);
+        w_F << create_sink(false);
 
-              node_writer w_21(x21);
-              w_21 << create_node(21,0, create_sink_ptr(false), create_sink_ptr(true));
+        node_writer w_21(x21);
+        w_21 << create_node(21,0, create_sink_ptr(false), create_sink_ptr(true));
 
-              node_writer w_42(x42);
-              w_42 << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true));
+        node_writer w_42(x42);
+        w_42 << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true));
 
-              node_writer w_21_and_22(x21_and_x22);
-              w_21_and_22 << create_node(22,0, create_sink_ptr(false), create_sink_ptr(true))
-                          << create_node(21,0, create_sink_ptr(false), create_node_ptr(22,0));
+        node_writer w_21_and_22(x21_and_x22);
+        w_21_and_22 << create_node(22,0, create_sink_ptr(false), create_sink_ptr(true))
+                    << create_node(21,0, create_sink_ptr(false), create_node_ptr(22,0));
 
-              node_writer w_21_and_22_and_42(x21_and_x22_and_x42);
-              w_21_and_22_and_42 << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true))
-                                 << create_node(22,0, create_sink_ptr(false), create_node_ptr(42,0))
-                                 << create_node(21,0, create_sink_ptr(false), create_node_ptr(22,0));
+        node_writer w_21_and_22_and_42(x21_and_x22_and_x42);
+        w_21_and_22_and_42 << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true))
+                           << create_node(22,0, create_sink_ptr(false), create_node_ptr(42,0))
+                           << create_node(21,0, create_sink_ptr(false), create_node_ptr(22,0));
 
-              node_writer w_21_and_42(x21_and_x42);
-              w_21_and_42 << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true))
-                          << create_node(21,0, create_sink_ptr(false), create_node_ptr(42,0));
+        node_writer w_21_and_42(x21_and_x42);
+        w_21_and_42 << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true))
+                    << create_node(21,0, create_sink_ptr(false), create_node_ptr(42,0));
 
-              node_writer w_21_xor_42(x21_xor_x42);
-              w_21_xor_42 << create_node(42,1, create_sink_ptr(true), create_sink_ptr(false))
-                          << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true))
-                          << create_node(21,0, create_node_ptr(42,0), create_node_ptr(42,1));
-            }
+        node_writer w_21_xor_42(x21_xor_x42);
+        w_21_xor_42 << create_node(42,1, create_sink_ptr(true), create_sink_ptr(false))
+                    << create_node(42,0, create_sink_ptr(false), create_sink_ptr(true))
+                    << create_node(21,0, create_node_ptr(42,0), create_node_ptr(42,1));
+      }
 
-            it("accepts same file with same negation flag", [&]() {
-                AssertThat(is_isomorphic(sink_F, sink_F, false, false), Is().True());
-                AssertThat(is_isomorphic(sink_F, sink_F, true, true), Is().True());
-              });
+      it("accepts same file with same negation flag", [&]() {
+        AssertThat(is_isomorphic(sink_F, sink_F, false, false), Is().True());
+        AssertThat(is_isomorphic(sink_F, sink_F, true, true), Is().True());
+      });
 
-            it("rejects same file with differing negation falgs", [&]() {
-                AssertThat(is_isomorphic(sink_F, sink_F, false, true), Is().False());
-                AssertThat(is_isomorphic(sink_F, sink_F, true, false), Is().False());
-              });
+      it("rejects same file with differing negation falgs", [&]() {
+        AssertThat(is_isomorphic(sink_F, sink_F, false, true), Is().False());
+        AssertThat(is_isomorphic(sink_F, sink_F, true, false), Is().False());
+      });
 
-            it("rejects on different number of nodes [1]", [&]() {
-                AssertThat(is_isomorphic(x21, x21_and_x42, false, false), Is().False());
-                AssertThat(is_isomorphic(x21, x21_and_x42, false, true), Is().False());
-                AssertThat(is_isomorphic(x21_and_x42, x21, true, false), Is().False());
-                AssertThat(is_isomorphic(x21_and_x42, x21, true, true), Is().False());
-              });
+      it("rejects on different number of nodes [1]", [&]() {
+        AssertThat(is_isomorphic(x21, x21_and_x42, false, false), Is().False());
+        AssertThat(is_isomorphic(x21, x21_and_x42, false, true), Is().False());
+        AssertThat(is_isomorphic(x21_and_x42, x21, true, false), Is().False());
+        AssertThat(is_isomorphic(x21_and_x42, x21, true, true), Is().False());
+      });
 
-            it("rejects on different number of nodes [2]", [&]() {
-                AssertThat(is_isomorphic(x21_xor_x42, x21_and_x42, false, false), Is().False());
-                AssertThat(is_isomorphic(x21_xor_x42, x21_and_x42, false, true), Is().False());
-                AssertThat(is_isomorphic(x21_and_x42, x21_xor_x42, true, false), Is().False());
-                AssertThat(is_isomorphic(x21_and_x42, x21_xor_x42, true, true), Is().False());
-              });
+      it("rejects on different number of nodes [2]", [&]() {
+        AssertThat(is_isomorphic(x21_xor_x42, x21_and_x42, false, false), Is().False());
+        AssertThat(is_isomorphic(x21_xor_x42, x21_and_x42, false, true), Is().False());
+        AssertThat(is_isomorphic(x21_and_x42, x21_xor_x42, true, false), Is().False());
+        AssertThat(is_isomorphic(x21_and_x42, x21_xor_x42, true, true), Is().False());
+      });
 
-            it("rejects on different number of levels [1]", [&]() {
-                AssertThat(is_isomorphic(sink_F, x42, false, false), Is().False());
-                AssertThat(is_isomorphic(sink_F, x42, false, true), Is().False());
-                AssertThat(is_isomorphic(x42, sink_F, true, false), Is().False());
-                AssertThat(is_isomorphic(x42, sink_F, true, true), Is().False());
-              });
+      it("rejects on different number of levels [1]", [&]() {
+        AssertThat(is_isomorphic(sink_F, x42, false, false), Is().False());
+        AssertThat(is_isomorphic(sink_F, x42, false, true), Is().False());
+        AssertThat(is_isomorphic(x42, sink_F, true, false), Is().False());
+        AssertThat(is_isomorphic(x42, sink_F, true, true), Is().False());
+      });
 
-            it("rejects on different number of levels [2]", [&]() {
-                AssertThat(is_isomorphic(x21_and_x22_and_x42, x21_and_x22, false, false), Is().False());
-                AssertThat(is_isomorphic(x21_and_x22_and_x42, x21_and_x22, false, true), Is().False());
-                AssertThat(is_isomorphic(x21_and_x22, x21_and_x22_and_x42, true, false), Is().False());
-                AssertThat(is_isomorphic(x21_and_x22, x21_and_x22_and_x42, true, true), Is().False());
-              });
+      it("rejects on different number of levels [2]", [&]() {
+        AssertThat(is_isomorphic(x21_and_x22_and_x42, x21_and_x22, false, false), Is().False());
+        AssertThat(is_isomorphic(x21_and_x22_and_x42, x21_and_x22, false, true), Is().False());
+        AssertThat(is_isomorphic(x21_and_x22, x21_and_x22_and_x42, true, false), Is().False());
+        AssertThat(is_isomorphic(x21_and_x22, x21_and_x22_and_x42, true, true), Is().False());
+      });
 
-            it("rejects on different labels in level [1]", [&]() {
-                AssertThat(is_isomorphic(x21, x42, false, false), Is().False());
-                AssertThat(is_isomorphic(x21, x42, false, true), Is().False());
-                AssertThat(is_isomorphic(x42, x21, true, false), Is().False());
-                AssertThat(is_isomorphic(x42, x21, true, true), Is().False());
-              });
+      it("rejects on different labels in level [1]", [&]() {
+        AssertThat(is_isomorphic(x21, x42, false, false), Is().False());
+        AssertThat(is_isomorphic(x21, x42, false, true), Is().False());
+        AssertThat(is_isomorphic(x42, x21, true, false), Is().False());
+        AssertThat(is_isomorphic(x42, x21, true, true), Is().False());
+      });
 
-            it("rejects on different labels in level [2]", [&]() {
-                AssertThat(is_isomorphic(x21_and_x42, x21_and_x22, false, false), Is().False());
-                AssertThat(is_isomorphic(x21_and_x42, x21_and_x22, false, true), Is().False());
-                AssertThat(is_isomorphic(x21_and_x22, x21_and_x42, true, false), Is().False());
-                AssertThat(is_isomorphic(x21_and_x22, x21_and_x42, true, true), Is().False());
-              });
+      it("rejects on different labels in level [2]", [&]() {
+        AssertThat(is_isomorphic(x21_and_x42, x21_and_x22, false, false), Is().False());
+        AssertThat(is_isomorphic(x21_and_x42, x21_and_x22, false, true), Is().False());
+        AssertThat(is_isomorphic(x21_and_x22, x21_and_x42, true, false), Is().False());
+        AssertThat(is_isomorphic(x21_and_x22, x21_and_x42, true, true), Is().False());
+      });
 
-            it("rejects on different size of level", [&]() {
-                // Create two BDDs with 6 nodes each on variables x0, x1, x2,
-                // and x3 (i.e. the same number of nodes and levels). One with 2
-                // nodes for x1 and x2 and one with 3 nodes for x2.
+      it("rejects on different size of level", [&]() {
+        // Create two BDDs with 6 nodes each on variables x0, x1, x2,
+        // and x3 (i.e. the same number of nodes and levels). One with 2
+        // nodes for x1 and x2 and one with 3 nodes for x2.
 
-                node_file six_a, six_b;
-
-                { // Garbage collect writers to free write-lock
-                  node_writer w_six_a(six_a);
-                  w_six_a << create_node(3,0, create_sink_ptr(false), create_sink_ptr(true))
-                          << create_node(2,1, create_node_ptr(3,0), create_sink_ptr(true))
-                          << create_node(2,0, create_node_ptr(3,0), create_sink_ptr(false))
-                          << create_node(1,1, create_node_ptr(2,1), create_node_ptr(2,0))
-                          << create_node(1,0, create_node_ptr(2,0), create_node_ptr(2,1))
-                          << create_node(0,0, create_node_ptr(1,0), create_node_ptr(2,0));
-
-                  node_writer w_six_b(six_b);
-                  w_six_b << create_node(3,0, create_sink_ptr(false), create_sink_ptr(true))
-                          << create_node(2,2, create_sink_ptr(false), create_sink_ptr(true))
-                          << create_node(2,1, create_node_ptr(3,0), create_sink_ptr(true))
-                          << create_node(2,0, create_node_ptr(3,0), create_sink_ptr(false))
-                          << create_node(1,0, create_node_ptr(2,1), create_node_ptr(2,2))
-                          << create_node(0,0, create_node_ptr(1,0), create_node_ptr(2,0));
-                }
-
-                AssertThat(is_isomorphic(six_a, six_b, false, false), Is().False());
-                AssertThat(is_isomorphic(six_a, six_b, false, true), Is().False());
-                AssertThat(is_isomorphic(six_b, six_a, true, false), Is().False());
-                AssertThat(is_isomorphic(six_b, six_a, true, true), Is().False());
-              });
-          });
-
-
-        //////////////////////
-        // Sink-only cases
-        node_file F_a, F_b, T_a;
+        node_file six_a, six_b;
 
         { // Garbage collect writers to free write-lock
-          node_writer nw_F_a(F_a);
-          nw_F_a << create_sink(false);
+          node_writer w_six_a(six_a);
+          w_six_a << create_node(3,0, create_sink_ptr(false), create_sink_ptr(true))
+                  << create_node(2,1, create_node_ptr(3,0), create_sink_ptr(true))
+                  << create_node(2,0, create_node_ptr(3,0), create_sink_ptr(false))
+                  << create_node(1,1, create_node_ptr(2,1), create_node_ptr(2,0))
+                  << create_node(1,0, create_node_ptr(2,0), create_node_ptr(2,1))
+                  << create_node(0,0, create_node_ptr(1,0), create_node_ptr(2,0));
 
-          node_writer nw_F_b(F_b);
-          nw_F_b << create_sink(false);
-
-          node_writer nw_T_a(T_a);
-          nw_T_a << create_sink(true);
+          node_writer w_six_b(six_b);
+          w_six_b << create_node(3,0, create_sink_ptr(false), create_sink_ptr(true))
+                  << create_node(2,2, create_sink_ptr(false), create_sink_ptr(true))
+                  << create_node(2,1, create_node_ptr(3,0), create_sink_ptr(true))
+                  << create_node(2,0, create_node_ptr(3,0), create_sink_ptr(false))
+                  << create_node(1,0, create_node_ptr(2,1), create_node_ptr(2,2))
+                  << create_node(0,0, create_node_ptr(1,0), create_node_ptr(2,0));
         }
 
-        //////////////////////
-        // One-node cases
-        /*
+        AssertThat(is_isomorphic(six_a, six_b, false, false), Is().False());
+        AssertThat(is_isomorphic(six_a, six_b, false, true), Is().False());
+        AssertThat(is_isomorphic(six_b, six_a, true, false), Is().False());
+        AssertThat(is_isomorphic(six_b, six_a, true, true), Is().False());
+      });
+    });
+
+
+    //////////////////////
+    // Sink-only cases
+    node_file F_a, F_b, T_a;
+
+    { // Garbage collect writers to free write-lock
+      node_writer nw_F_a(F_a);
+      nw_F_a << create_sink(false);
+
+      node_writer nw_F_b(F_b);
+      nw_F_b << create_sink(false);
+
+      node_writer nw_T_a(T_a);
+      nw_T_a << create_sink(true);
+    }
+
+    //////////////////////
+    // One-node cases
+    /*
            1     ---- x42
           / \
           F T
-        */
-        node_file x42_a, x42_b, not_x42;
+    */
+    node_file x42_a, x42_b, not_x42;
 
-        { // Garbage collect writers to free write-lock
-          node_writer wa(x42_a);
-          wa << create_node(42,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+    { // Garbage collect writers to free write-lock
+      node_writer wa(x42_a);
+      wa << create_node(42,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
 
-          node_writer wb(x42_b);
-          wb << create_node(42,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+      node_writer wb(x42_b);
+      wb << create_node(42,MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
 
-          node_writer wn(not_x42);
-          wn << create_node(42,MAX_ID, create_sink_ptr(true), create_sink_ptr(false));
-        }
+      node_writer wn(not_x42);
+      wn << create_node(42,MAX_ID, create_sink_ptr(true), create_sink_ptr(false));
+    }
 
 
-        //////////////////////
-        // Traversal cases
-        node_file bdd_1;
-        /*
+    //////////////////////
+    // Traversal cases
+    node_file bdd_1;
+    /*
             _1_     ---- x0
            /   \
            2   3    ---- x1
@@ -166,43 +166,43 @@ go_bandit([]() {
           T  4  F   ---- x2
             / \
             F T
-        */
-        { node_writer w(bdd_1);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(false))
-            << create_node(1,MAX_ID-1, create_sink_ptr(true),       create_node_ptr(2,MAX_ID))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
-        }
+    */
+    { node_writer w(bdd_1);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(false))
+        << create_node(1,MAX_ID-1, create_sink_ptr(true),       create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
+    }
 
-        node_file bdd_1n;
-        /* bdd_1 negated */
-        { node_writer w(bdd_1n);
-          w << create_node(2,MAX_ID,   create_sink_ptr(true),       create_sink_ptr(false))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(true))
-            << create_node(1,MAX_ID-1, create_sink_ptr(false),      create_node_ptr(2,MAX_ID))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
-        }
+    node_file bdd_1n;
+    /* bdd_1 negated */
+    { node_writer w(bdd_1n);
+      w << create_node(2,MAX_ID,   create_sink_ptr(true),       create_sink_ptr(false))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(true))
+        << create_node(1,MAX_ID-1, create_sink_ptr(false),      create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
+    }
 
-        // bdd_1 with child of (2) flipped in truth value
-        node_file bdd_1_low_leaf;
-        { node_writer w(bdd_1_low_leaf);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),       create_sink_ptr(true))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(false))
-            << create_node(1,MAX_ID-1, create_sink_ptr(false),      create_node_ptr(2,MAX_ID))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
-        }
+    // bdd_1 with child of (2) flipped in truth value
+    node_file bdd_1_low_leaf;
+    { node_writer w(bdd_1_low_leaf);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),       create_sink_ptr(true))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(false))
+        << create_node(1,MAX_ID-1, create_sink_ptr(false),      create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
+    }
 
-        // bdd_1 with child of (3) flipped in truth value
-        node_file bdd_1_high_leaf;
-        { node_writer w(bdd_1_high_leaf);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(true))
-            << create_node(1,MAX_ID-1, create_sink_ptr(true),       create_node_ptr(2,MAX_ID))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
-        }
+    // bdd_1 with child of (3) flipped in truth value
+    node_file bdd_1_high_leaf;
+    { node_writer w(bdd_1_high_leaf);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_sink_ptr(true))
+        << create_node(1,MAX_ID-1, create_sink_ptr(true),       create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID));
+    }
 
-        node_file bdd_2;
-        /*
+    node_file bdd_2;
+    /*
              1    ---- x0
             / \
             2 |   ---- x1
@@ -210,25 +210,25 @@ go_bandit([]() {
            3  4   ---- x2
           / \/ \
           T  F T
-        */
-        { node_writer w(bdd_2);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
-            << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(2,MAX_ID));
-        }
+    */
+    { node_writer w(bdd_2);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
+        << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(2,MAX_ID));
+    }
 
-        node_file bdd_2n;
-        /* bdd_2 negated */
-        { node_writer w(bdd_2n);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),    create_sink_ptr(true))
-            << create_node(2,MAX_ID-1, create_sink_ptr(true),     create_sink_ptr(false))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID-1));
-        }
+    node_file bdd_2n;
+    /* bdd_2 negated */
+    { node_writer w(bdd_2n);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),    create_sink_ptr(true))
+        << create_node(2,MAX_ID-1, create_sink_ptr(true),     create_sink_ptr(false))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID-1));
+    }
 
-        node_file bdd_2_low_child;
-        /*
+    node_file bdd_2_low_child;
+    /*
             1      ---- x0
            / \
            2 /     ---- x1
@@ -239,16 +239,16 @@ go_bandit([]() {
           T  F T
 
           which in traversal look similar to bdd_2 until (2) on level x1
-        */
-        { node_writer w(bdd_2_low_child);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),    create_sink_ptr(true))
-            << create_node(2,MAX_ID-1, create_sink_ptr(true),     create_sink_ptr(false))
-            << create_node(1,MAX_ID,   create_sink_ptr(true),     create_node_ptr(2,MAX_ID))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID-1));
-        }
+    */
+    { node_writer w(bdd_2_low_child);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),    create_sink_ptr(true))
+        << create_node(2,MAX_ID-1, create_sink_ptr(true),     create_sink_ptr(false))
+        << create_node(1,MAX_ID,   create_sink_ptr(true),     create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID-1));
+    }
 
-        node_file bdd_2_high_child;
-        /*
+    node_file bdd_2_high_child;
+    /*
              1      ---- x0
             / \
             2  \    ---- x1
@@ -258,16 +258,16 @@ go_bandit([]() {
           T F  T T
 
           which in traversal look similar to bdd_2 until (2) on level x1
-        */
-        { node_writer w(bdd_2_high_child);
-          w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
-            << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))
-            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_sink_ptr(false))
-            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(2,MAX_ID));
-        }
+    */
+    { node_writer w(bdd_2_high_child);
+      w << create_node(2,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
+        << create_node(2,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))
+        << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_sink_ptr(false))
+        << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(2,MAX_ID));
+    }
 
-        node_file bdd_3;
-        /*
+    node_file bdd_3;
+    /*
            1      ---- x0
           / \
           |  2    ---- x1
@@ -277,16 +277,16 @@ go_bandit([]() {
           T 4     ---- x3
            / \
            F T
-        */
-        { node_writer w(bdd_3);
-          w << create_node(3,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
-            << create_node(2,MAX_ID, create_sink_ptr(true),     create_node_ptr(3,MAX_ID))
-            << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_sink_ptr(false))
-            << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID));
-        }
+    */
+    { node_writer w(bdd_3);
+      w << create_node(3,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
+        << create_node(2,MAX_ID, create_sink_ptr(true),     create_node_ptr(3,MAX_ID))
+        << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_sink_ptr(false))
+        << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID));
+    }
 
-        node_file bdd_4;
-        /*
+    node_file bdd_4;
+    /*
              1     ---- x0
             / \
            2  |    ---- x1
@@ -298,269 +298,269 @@ go_bandit([]() {
            F T
 
           The same as bdd_3 but mirrored horisontally
-        */
-        { node_writer w(bdd_4);
+    */
+    { node_writer w(bdd_4);
+      w << create_node(3,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
+        << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(true))
+        << create_node(1,MAX_ID, create_sink_ptr(false),    create_node_ptr(2,MAX_ID))
+        << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID));
+    }
+
+    describe("Fast 2N/B check", [&]() {
+      // The fast checks require the BDDs to be on 'canonical' form, which
+      // makes two isomorphic BDDs truly identical.
+
+      //////////////////////
+      // Sink-only cases
+      it("accepts two different F sinks ", [&]() {
+        AssertThat(is_isomorphic(F_a, F_b), Is().True());
+      });
+
+      it("rejects an F and a T sink ", [&]() {
+        AssertThat(is_isomorphic(T_a, F_a), Is().False());
+        AssertThat(is_isomorphic(F_b, T_a), Is().False());
+      });
+
+      it("rejects an F with a T sink, where both are negated", [&]() {
+        AssertThat(is_isomorphic(T_a, F_a, true, true), Is().False());
+        AssertThat(is_isomorphic(T_a, F_a, true, true), Is().False());
+      });
+
+      //////////////////////
+      // One-node cases
+      it("accepts two different x42", [&]() {
+        AssertThat(is_isomorphic(x42_a, x42_b, false, false), Is().True());
+        AssertThat(is_isomorphic(x42_a, x42_b, true, true), Is().True());
+      });
+
+      it("rejects x42 and ~x42", [&]() {
+        AssertThat(is_isomorphic(x42_a, not_x42, false, false), Is().False());
+        AssertThat(is_isomorphic(x42_a, not_x42, true, true), Is().False());
+      });
+
+      //////////////////////
+      // Traversal cases
+      it("rejects its negation [1]", [&]() {
+        AssertThat(is_isomorphic(bdd_1, bdd_1n, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_1, bdd_1n, true, true), Is().False());
+      });
+
+      it("rejects its negation [2]", [&]() {
+        AssertThat(is_isomorphic(bdd_2, bdd_2n, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_2, bdd_2n, true, true), Is().False());
+      });
+
+      it("rejects on low child mismatch (leaf value) [1]", [&]() {
+        AssertThat(is_isomorphic(bdd_1, bdd_1_low_leaf, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_1, bdd_1_low_leaf, true, true), Is().False());
+      });
+
+      it("rejects on low child mismatch (internal node vs. leaf) [2]", [&]() {
+        AssertThat(is_isomorphic(bdd_2, bdd_2_low_child, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_2, bdd_2_low_child, true, true), Is().False());
+      });
+
+
+      it("rejects on low child mismatch (internal node labels) [3]", [&]() {
+        node_file bdd_3_b;
+        /* Same as bdd_3 but with (2) directly going to (4) on the low */
+        { // Garbage collect writers to free write-lock
+          node_writer w(bdd_3_b);
+          w << create_node(3,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
+            << create_node(2,MAX_ID, create_sink_ptr(true),     create_node_ptr(3,MAX_ID))
+            << create_node(1,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(false))
+            << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID));
+        }
+
+        AssertThat(is_isomorphic(bdd_3, bdd_3_b, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_3, bdd_3_b, true, true), Is().False());
+      });
+
+      it("rejects on high child mismatch (leaf value) [1]", [&]() {
+        AssertThat(is_isomorphic(bdd_1, bdd_1_high_leaf, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_1, bdd_1_high_leaf, true, true), Is().False());
+      });
+
+      it("rejects on high child mismatch (internal node vs. leaf) [2]", [&]() {
+        AssertThat(is_isomorphic(bdd_2, bdd_2_high_child, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_2, bdd_2_high_child, true, true), Is().False());
+      });
+
+      it("rejects on high child mismatch (internal node labels) [4]", [&]() {
+        node_file bdd_4_b;
+        /* Same as bdd_4 but with (2) directly going to (4) on the high */
+        { node_writer w(bdd_4_b);
           w << create_node(3,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
             << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(true))
-            << create_node(1,MAX_ID, create_sink_ptr(false),    create_node_ptr(2,MAX_ID))
+            << create_node(1,MAX_ID, create_sink_ptr(false),    create_node_ptr(3,MAX_ID))
             << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID));
         }
 
-        describe("Fast 2N/B check", [&]() {
-            // The fast checks require the BDDs to be on 'canonical' form, which
-            // makes two isomorphic BDDs truly identical.
+        AssertThat(is_isomorphic(bdd_4, bdd_4_b, false, false), Is().False());
+        AssertThat(is_isomorphic(bdd_4, bdd_4_b, true, true), Is().False());
+      });
+    });
 
-            //////////////////////
-            // Sink-only cases
-            it("accepts two different F sinks ", [&]() {
-                AssertThat(is_isomorphic(F_a, F_b), Is().True());
-              });
+    describe("Slow O(sort(N)) check", [&]() {
+      //////////////////////
+      // Sink-only cases
+      it("accepts two F sinks, where one is negated", [&]() {
+        AssertThat(is_isomorphic(F_a, F_b, true, false), Is().False());
+        AssertThat(is_isomorphic(F_a, F_b, false, true), Is().False());
+      });
 
-            it("rejects an F and a T sink ", [&]() {
-                AssertThat(is_isomorphic(T_a, F_a), Is().False());
-                AssertThat(is_isomorphic(F_b, T_a), Is().False());
-              });
+      it("accepts an F with a T sink, where one is negated", [&]() {
+        AssertThat(is_isomorphic(T_a, F_a, true, false), Is().True());
+        AssertThat(is_isomorphic(T_a, F_a, false, true), Is().True());
+        AssertThat(is_isomorphic(F_b, T_a, true, false), Is().True());
+        AssertThat(is_isomorphic(F_b, T_a, false, true), Is().True());
+      });
 
-            it("rejects an F with a T sink, where both are negated", [&]() {
-                AssertThat(is_isomorphic(T_a, F_a, true, true), Is().False());
-                AssertThat(is_isomorphic(T_a, F_a, true, true), Is().False());
-              });
+      //////////////////////
+      // One-node cases
+      it("rejects two x42, where one is negated", [&]() {
+        AssertThat(is_isomorphic(x42_a, x42_b, false, true), Is().False());
+        AssertThat(is_isomorphic(x42_a, x42_b, true, false), Is().False());
+      });
 
-            //////////////////////
-            // One-node cases
-            it("accepts two different x42", [&]() {
-                AssertThat(is_isomorphic(x42_a, x42_b, false, false), Is().True());
-                AssertThat(is_isomorphic(x42_a, x42_b, true, true), Is().True());
-              });
+      it("accepts x42 with negated ~x42", [&]() {
+        AssertThat(is_isomorphic(x42_a, not_x42, false, true), Is().True());
+        AssertThat(is_isomorphic(x42_a, not_x42, true, false), Is().True());
+      });
 
-            it("rejects x42 and ~x42", [&]() {
-                AssertThat(is_isomorphic(x42_a, not_x42, false, false), Is().False());
-                AssertThat(is_isomorphic(x42_a, not_x42, true, true), Is().False());
-              });
+      //////////////////////
+      // Traversal cases
+      it("accepts with negation of negated [1]", [&]() {
+        AssertThat(is_isomorphic(bdd_1, bdd_1n, false, true), Is().True());
+        AssertThat(is_isomorphic(bdd_1, bdd_1n, true, false), Is().True());
+      });
 
-            //////////////////////
-            // Traversal cases
-            it("rejects its negation [1]", [&]() {
-                AssertThat(is_isomorphic(bdd_1, bdd_1n, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_1, bdd_1n, true, true), Is().False());
-              });
+      it("accepts with negation of negated [2]", [&]() {
+        AssertThat(is_isomorphic(bdd_2, bdd_2n, false, true), Is().True());
+        AssertThat(is_isomorphic(bdd_2, bdd_2n, true, false), Is().True());
+      });
 
-            it("rejects its negation [2]", [&]() {
-                AssertThat(is_isomorphic(bdd_2, bdd_2n, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_2, bdd_2n, true, true), Is().False());
-              });
+      it("accepts with nodes swapped [1]", [&]() {
+        // bdd_1 with nodes (2) and (3) swapped (and hence non-canonical)
+        node_file bdd_1b;
+        { // Garbage collect writers to free write-lock
+          node_writer w(bdd_1b);
+          w << create_node(2,MAX_ID,   create_sink_ptr(false),    create_sink_ptr(true))
+            << create_node(1,MAX_ID,   create_sink_ptr(true),     create_node_ptr(2,MAX_ID))
+            << create_node(1,MAX_ID-1, create_node_ptr(2,MAX_ID), create_sink_ptr(false))
+            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID-1));
+        }
 
-            it("rejects on low child mismatch (leaf value) [1]", [&]() {
-                AssertThat(is_isomorphic(bdd_1, bdd_1_low_leaf, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_1, bdd_1_low_leaf, true, true), Is().False());
-              });
+        AssertThat(is_isomorphic(bdd_1, bdd_1b, false, false), Is().True());
+        AssertThat(is_isomorphic(bdd_1n, bdd_1b, true, false), Is().True());
+        AssertThat(is_isomorphic(bdd_1n, bdd_1b, false, true), Is().True());
+        AssertThat(is_isomorphic(bdd_1, bdd_1b, true, true), Is().True());
+      });
 
-            it("rejects on low child mismatch (internal node vs. leaf) [2]", [&]() {
-                AssertThat(is_isomorphic(bdd_2, bdd_2_low_child, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_2, bdd_2_low_child, true, true), Is().False());
-              });
+      it("accepts with nodes swapped [2]", [&]() {
+        // bdd_2 with nodes (3) and (4) swapped (and hence non-canonical)
+        node_file bdd_2b;
+        { // Garbage collect writers to free write-lock
+          node_writer w(bdd_2b);
+          w << create_node(2,MAX_ID,   create_sink_ptr(true),     create_sink_ptr(false))
+            << create_node(2,MAX_ID-1, create_sink_ptr(false),    create_sink_ptr(true))
+            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
+            << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID-1));
+        }
 
+        AssertThat(is_isomorphic(bdd_2, bdd_2b, false, false), Is().True());
+        AssertThat(is_isomorphic(bdd_2n, bdd_2b, true, false), Is().True());
+        AssertThat(is_isomorphic(bdd_2n, bdd_2b, false, true), Is().True());
+        AssertThat(is_isomorphic(bdd_2, bdd_2b, true, true), Is().True());
+      });
 
-            it("rejects on low child mismatch (internal node labels) [3]", [&]() {
-                node_file bdd_3_b;
-                /* Same as bdd_3 but with (2) directly going to (4) on the low */
-                { // Garbage collect writers to free write-lock
-                  node_writer w(bdd_3_b);
-                  w << create_node(3,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
-                    << create_node(2,MAX_ID, create_sink_ptr(true),     create_node_ptr(3,MAX_ID))
-                    << create_node(1,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(false))
-                    << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID));
-                }
+      it("rejects on low child mismatch (leaf value) [1]", [&]() {
+        AssertThat(is_isomorphic(bdd_1n, bdd_1_low_leaf, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_1n, bdd_1_low_leaf, false, true), Is().False());
+      });
 
-                AssertThat(is_isomorphic(bdd_3, bdd_3_b, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_3, bdd_3_b, true, true), Is().False());
-              });
+      it("rejects on low child mismatch (internal node vs. leaf) [2]", [&]() {
+        AssertThat(is_isomorphic(bdd_2n, bdd_2_low_child, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_2n, bdd_2_low_child, false, true), Is().False());
+      });
 
-            it("rejects on high child mismatch (leaf value) [1]", [&]() {
-                AssertThat(is_isomorphic(bdd_1, bdd_1_high_leaf, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_1, bdd_1_high_leaf, true, true), Is().False());
-              });
+      it("rejects on low child mismatch (internal node labels) [3]", [&]() {
+        node_file bdd_3_b;
+        /* Same as bdd_3 negated but with (2) directly going to (4) on the low */
+        { node_writer w(bdd_3_b);
+          w << create_node(3,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
+            << create_node(2,MAX_ID, create_sink_ptr(false),    create_node_ptr(3,MAX_ID))
+            << create_node(1,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(true))
+            << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID));
+        }
 
-            it("rejects on high child mismatch (internal node vs. leaf) [2]", [&]() {
-                AssertThat(is_isomorphic(bdd_2, bdd_2_high_child, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_2, bdd_2_high_child, true, true), Is().False());
-              });
+        AssertThat(is_isomorphic(bdd_3, bdd_3_b, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_3, bdd_3_b, false, true), Is().False());
+      });
 
-            it("rejects on high child mismatch (internal node labels) [4]", [&]() {
-                node_file bdd_4_b;
-                /* Same as bdd_4 but with (2) directly going to (4) on the high */
-                { node_writer w(bdd_4_b);
-                  w << create_node(3,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
-                    << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(true))
-                    << create_node(1,MAX_ID, create_sink_ptr(false),    create_node_ptr(3,MAX_ID))
-                    << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID));
-                }
+      it("rejects on low child mismatch on root", [&]() {
+        node_file bdd_a;
+        { node_writer w(bdd_a);
+          w << create_node(1,MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
+            << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_sink_ptr(false));
+        }
 
-                AssertThat(is_isomorphic(bdd_4, bdd_4_b, false, false), Is().False());
-                AssertThat(is_isomorphic(bdd_4, bdd_4_b, true, true), Is().False());
-              });
-          });
+        node_file bdd_b;
+        { node_writer w(bdd_b);
+          w << create_node(1,MAX_ID, create_sink_ptr(true), create_sink_ptr(false))
+            << create_node(0,MAX_ID, create_sink_ptr(true), create_node_ptr(1,MAX_ID));
+        }
 
-        describe("Slow O(sort(N)) check", [&]() {
-            //////////////////////
-            // Sink-only cases
-            it("accepts two F sinks, where one is negated", [&]() {
-                AssertThat(is_isomorphic(F_a, F_b, true, false), Is().False());
-                AssertThat(is_isomorphic(F_a, F_b, false, true), Is().False());
-              });
+        AssertThat(is_isomorphic(bdd_a, bdd_b, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_a, bdd_b, false, true), Is().False());
+      });
 
-            it("accepts an F with a T sink, where one is negated", [&]() {
-                AssertThat(is_isomorphic(T_a, F_a, true, false), Is().True());
-                AssertThat(is_isomorphic(T_a, F_a, false, true), Is().True());
-                AssertThat(is_isomorphic(F_b, T_a, true, false), Is().True());
-                AssertThat(is_isomorphic(F_b, T_a, false, true), Is().True());
-              });
+      it("rejects on high child mismatch (leaf value) [1]", [&]() {
+        AssertThat(is_isomorphic(bdd_1n, bdd_1_high_leaf, false, true), Is().False());
+        AssertThat(is_isomorphic(bdd_1n, bdd_1_high_leaf, true, false), Is().False());
+      });
 
-            //////////////////////
-            // One-node cases
-            it("rejects two x42, where one is negated", [&]() {
-                AssertThat(is_isomorphic(x42_a, x42_b, false, true), Is().False());
-                AssertThat(is_isomorphic(x42_a, x42_b, true, false), Is().False());
-              });
+      it("rejects on high child mismatch (internal node vs. leaf) [2]", [&]() {
+        AssertThat(is_isomorphic(bdd_2n, bdd_2_high_child, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_2n, bdd_2_high_child, false, true), Is().False());
+      });
 
-            it("accepts x42 with negated ~x42", [&]() {
-                AssertThat(is_isomorphic(x42_a, not_x42, false, true), Is().True());
-                AssertThat(is_isomorphic(x42_a, not_x42, true, false), Is().True());
-              });
+      it("rejects on high child mismatch (internal node labels) [4]", [&]() {
+        node_file bdd_4_b;
+        /* Same as bdd_4 negated but with (2) directly going to (4) on
+           the high */
+        { node_writer w(bdd_4_b);
+          w << create_node(3,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
+            << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(false))
+            << create_node(1,MAX_ID, create_sink_ptr(true),     create_node_ptr(3,MAX_ID))
+            << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID));
+        }
 
-            //////////////////////
-            // Traversal cases
-            it("accepts with negation of negated [1]", [&]() {
-                AssertThat(is_isomorphic(bdd_1, bdd_1n, false, true), Is().True());
-                AssertThat(is_isomorphic(bdd_1, bdd_1n, true, false), Is().True());
-              });
+        AssertThat(is_isomorphic(bdd_4, bdd_4_b, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_4, bdd_4_b, false, true), Is().False());
+      });
 
-            it("accepts with negation of negated [2]", [&]() {
-                AssertThat(is_isomorphic(bdd_2, bdd_2n, false, true), Is().True());
-                AssertThat(is_isomorphic(bdd_2, bdd_2n, true, false), Is().True());
-              });
+      it("rejects on high child mismatch on root", [&]() {
+        node_file bdd_a;
+        { node_writer w(bdd_a);
+          w << create_node(2,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
+            << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_sink_ptr(true))
+            << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_sink_ptr(true));
+        }
 
-            it("accepts with nodes swapped [1]", [&]() {
-                // bdd_1 with nodes (2) and (3) swapped (and hence non-canonical)
-                node_file bdd_1b;
-                { // Garbage collect writers to free write-lock
-                  node_writer w(bdd_1b);
-                  w << create_node(2,MAX_ID,   create_sink_ptr(false),    create_sink_ptr(true))
-                    << create_node(1,MAX_ID,   create_sink_ptr(true),     create_node_ptr(2,MAX_ID))
-                    << create_node(1,MAX_ID-1, create_node_ptr(2,MAX_ID), create_sink_ptr(false))
-                    << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID-1));
-                }
+        node_file bdd_b;
+        { node_writer w(bdd_b);
+          w << create_node(2,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
+            << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_sink_ptr(false))
+            << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_sink_ptr(true));
+        }
 
-                AssertThat(is_isomorphic(bdd_1, bdd_1b, false, false), Is().True());
-                AssertThat(is_isomorphic(bdd_1n, bdd_1b, true, false), Is().True());
-                AssertThat(is_isomorphic(bdd_1n, bdd_1b, false, true), Is().True());
-                AssertThat(is_isomorphic(bdd_1, bdd_1b, true, true), Is().True());
-              });
+        AssertThat(is_isomorphic(bdd_a, bdd_b, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_a, bdd_b, false, true), Is().False());
+      });
 
-            it("accepts with nodes swapped [2]", [&]() {
-                // bdd_2 with nodes (3) and (4) swapped (and hence non-canonical)
-                node_file bdd_2b;
-                { // Garbage collect writers to free write-lock
-                  node_writer w(bdd_2b);
-                  w << create_node(2,MAX_ID,   create_sink_ptr(true),     create_sink_ptr(false))
-                    << create_node(2,MAX_ID-1, create_sink_ptr(false),    create_sink_ptr(true))
-                    << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
-                    << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID-1));
-                }
-
-                AssertThat(is_isomorphic(bdd_2, bdd_2b, false, false), Is().True());
-                AssertThat(is_isomorphic(bdd_2n, bdd_2b, true, false), Is().True());
-                AssertThat(is_isomorphic(bdd_2n, bdd_2b, false, true), Is().True());
-                AssertThat(is_isomorphic(bdd_2, bdd_2b, true, true), Is().True());
-              });
-
-            it("rejects on low child mismatch (leaf value) [1]", [&]() {
-                AssertThat(is_isomorphic(bdd_1n, bdd_1_low_leaf, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_1n, bdd_1_low_leaf, false, true), Is().False());
-              });
-
-            it("rejects on low child mismatch (internal node vs. leaf) [2]", [&]() {
-                AssertThat(is_isomorphic(bdd_2n, bdd_2_low_child, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_2n, bdd_2_low_child, false, true), Is().False());
-              });
-
-            it("rejects on low child mismatch (internal node labels) [3]", [&]() {
-                node_file bdd_3_b;
-                /* Same as bdd_3 negated but with (2) directly going to (4) on the low */
-                { node_writer w(bdd_3_b);
-                  w << create_node(3,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
-                    << create_node(2,MAX_ID, create_sink_ptr(false),    create_node_ptr(3,MAX_ID))
-                    << create_node(1,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(true))
-                    << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID));
-                }
-
-                AssertThat(is_isomorphic(bdd_3, bdd_3_b, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_3, bdd_3_b, false, true), Is().False());
-              });
-
-            it("rejects on low child mismatch on root", [&]() {
-                node_file bdd_a;
-                { node_writer w(bdd_a);
-                  w << create_node(1,MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
-                    << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_sink_ptr(false));
-                }
-
-                node_file bdd_b;
-                { node_writer w(bdd_b);
-                  w << create_node(1,MAX_ID, create_sink_ptr(true), create_sink_ptr(false))
-                    << create_node(0,MAX_ID, create_sink_ptr(true), create_node_ptr(1,MAX_ID));
-                }
-
-                AssertThat(is_isomorphic(bdd_a, bdd_b, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_a, bdd_b, false, true), Is().False());
-              });
-
-            it("rejects on high child mismatch (leaf value) [1]", [&]() {
-                AssertThat(is_isomorphic(bdd_1n, bdd_1_high_leaf, false, true), Is().False());
-                AssertThat(is_isomorphic(bdd_1n, bdd_1_high_leaf, true, false), Is().False());
-              });
-
-            it("rejects on high child mismatch (internal node vs. leaf) [2]", [&]() {
-                AssertThat(is_isomorphic(bdd_2n, bdd_2_high_child, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_2n, bdd_2_high_child, false, true), Is().False());
-              });
-
-            it("rejects on high child mismatch (internal node labels) [4]", [&]() {
-                node_file bdd_4_b;
-                /* Same as bdd_4 negated but with (2) directly going to (4) on
-                   the high */
-                { node_writer w(bdd_4_b);
-                  w << create_node(3,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
-                    << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_sink_ptr(false))
-                    << create_node(1,MAX_ID, create_sink_ptr(true),     create_node_ptr(3,MAX_ID))
-                    << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID));
-                }
-
-                AssertThat(is_isomorphic(bdd_4, bdd_4_b, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_4, bdd_4_b, false, true), Is().False());
-              });
-
-            it("rejects on high child mismatch on root", [&]() {
-                node_file bdd_a;
-                { node_writer w(bdd_a);
-                  w << create_node(2,MAX_ID, create_sink_ptr(false),    create_sink_ptr(true))
-                    << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_sink_ptr(true))
-                    << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_sink_ptr(true));
-                }
-
-                node_file bdd_b;
-                { node_writer w(bdd_b);
-                  w << create_node(2,MAX_ID, create_sink_ptr(true),     create_sink_ptr(false))
-                    << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_sink_ptr(false))
-                    << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_sink_ptr(true));
-                }
-
-                AssertThat(is_isomorphic(bdd_a, bdd_b, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_a, bdd_b, false, true), Is().False());
-              });
-
-            it("rejects when resolving more requests on a level than nodes in original BDDs", [&]() {
-                /*
+      it("rejects when resolving more requests on a level than nodes in original BDDs", [&]() {
+        /*
                        1          ---- x0
                       / \
                       | 2         ---- x1
@@ -581,33 +581,33 @@ go_bandit([]() {
                    which means that (3) in the first one has been related to
                    both (3) and (4) in the other one. Hence, they cannot be
                    isomorphic.
-                */
-                node_file bdd_5_a;
-                { // Garbage collect writers to free write-lock
-                  node_writer w(bdd_5_a);
-                  w << create_node(3,MAX_ID,   create_sink_ptr(false), create_sink_ptr(true))
-                    << create_node(3,MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false))
-                    << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID-1), create_node_ptr(3,MAX_ID))
-                    << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID-1))
-                    << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
-                    << create_node(0,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(1,MAX_ID));
-                }
+        */
+        node_file bdd_5_a;
+        { // Garbage collect writers to free write-lock
+          node_writer w(bdd_5_a);
+          w << create_node(3,MAX_ID,   create_sink_ptr(false), create_sink_ptr(true))
+            << create_node(3,MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false))
+            << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID-1), create_node_ptr(3,MAX_ID))
+            << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID-1))
+            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
+            << create_node(0,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(1,MAX_ID));
+        }
 
-                node_file bdd_5_b;
-                { // Garbage collect writers to free write-lock
-                  node_writer w(bdd_5_b);
-                  w << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
-                    << create_node(3,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))
-                    << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID-1), create_node_ptr(3,MAX_ID))
-                    << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID),   create_node_ptr(3,MAX_ID-1))
-                    // This one has its children flipped
-                    << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_node_ptr(2,MAX_ID-1))
-                    << create_node(0,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(1,MAX_ID));
-                }
+        node_file bdd_5_b;
+        { // Garbage collect writers to free write-lock
+          node_writer w(bdd_5_b);
+          w << create_node(3,MAX_ID,   create_sink_ptr(false),      create_sink_ptr(true))
+            << create_node(3,MAX_ID-1, create_sink_ptr(true),       create_sink_ptr(false))
+            << create_node(2,MAX_ID,   create_node_ptr(3,MAX_ID-1), create_node_ptr(3,MAX_ID))
+            << create_node(2,MAX_ID-1, create_node_ptr(3,MAX_ID),   create_node_ptr(3,MAX_ID-1))
+            // This one has its children flipped
+            << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID),   create_node_ptr(2,MAX_ID-1))
+            << create_node(0,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(1,MAX_ID));
+        }
 
-                AssertThat(is_isomorphic(bdd_5_a, bdd_5_b, true, false), Is().False());
-                AssertThat(is_isomorphic(bdd_5_b, bdd_5_a, false, true), Is().False());
-              });
-          });
+        AssertThat(is_isomorphic(bdd_5_a, bdd_5_b, true, false), Is().False());
+        AssertThat(is_isomorphic(bdd_5_b, bdd_5_a, false, true), Is().False());
       });
+    });
   });
+ });

--- a/test/adiar/internal/test_levelized_priority_queue.cpp
+++ b/test/adiar/internal/test_levelized_priority_queue.cpp
@@ -97,50 +97,50 @@ go_bandit([]() {
       });
 
       it("can pull from merge of two level_info streams, where one is empty [1]", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writer
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writer
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(1,1u));
-         }
+          fw1.unsafe_push(create_level_info(1,1u));
+        }
 
-         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
+        pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
 
-         AssertThat(mgr.hook_meta_stream(f1), Is().False());
-         AssertThat(mgr.hook_meta_stream(f2), Is().True());
+        AssertThat(mgr.hook_meta_stream(f1), Is().False());
+        AssertThat(mgr.hook_meta_stream(f2), Is().True());
 
-         AssertThat(mgr.can_pull(), Is().True());
-         AssertThat(mgr.pull(), Is().EqualTo(1u));
+        AssertThat(mgr.can_pull(), Is().True());
+        AssertThat(mgr.pull(), Is().EqualTo(1u));
 
-         AssertThat(mgr.can_pull(), Is().False());
+        AssertThat(mgr.can_pull(), Is().False());
       });
 
 
       it("can pull from merge of two level_info streams, where one is empty [2]", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writer
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writer
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(1,1u));
-           fw1.unsafe_push(create_level_info(2,1u));
-         }
+          fw1.unsafe_push(create_level_info(1,1u));
+          fw1.unsafe_push(create_level_info(2,1u));
+        }
 
-         pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
+        pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
 
-         AssertThat(mgr.hook_meta_stream(f1), Is().False());
-         AssertThat(mgr.hook_meta_stream(f2), Is().True());
+        AssertThat(mgr.hook_meta_stream(f1), Is().False());
+        AssertThat(mgr.hook_meta_stream(f2), Is().True());
 
-         AssertThat(mgr.can_pull(), Is().True());
-         AssertThat(mgr.pull(), Is().EqualTo(2u));
+        AssertThat(mgr.can_pull(), Is().True());
+        AssertThat(mgr.pull(), Is().EqualTo(2u));
 
-         AssertThat(mgr.can_pull(), Is().True());
-         AssertThat(mgr.pull(), Is().EqualTo(1u));
+        AssertThat(mgr.can_pull(), Is().True());
+        AssertThat(mgr.pull(), Is().EqualTo(1u));
 
-         AssertThat(mgr.can_pull(), Is().False());
+        AssertThat(mgr.can_pull(), Is().False());
       });
 
       it("can pull from merge of two level_info streams [1]", [&]() {
@@ -209,30 +209,30 @@ go_bandit([]() {
       });
 
       it("can pull from merge of two level_info streams [2] (std::greater)", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writers
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writers
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(2,1u));
-           pq_test_writer fw2(f2);
+          fw1.unsafe_push(create_level_info(2,1u));
+          pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(create_level_info(1,1u));
-         }
+          fw2.unsafe_push(create_level_info(1,1u));
+        }
 
-         pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
+        pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
 
-         AssertThat(mgr.hook_meta_stream(f1), Is().False());
-         AssertThat(mgr.hook_meta_stream(f2), Is().True());
+        AssertThat(mgr.hook_meta_stream(f1), Is().False());
+        AssertThat(mgr.hook_meta_stream(f2), Is().True());
 
-         AssertThat(mgr.can_pull(), Is().True());
-         AssertThat(mgr.pull(), Is().EqualTo(2u));
+        AssertThat(mgr.can_pull(), Is().True());
+        AssertThat(mgr.pull(), Is().EqualTo(2u));
 
-         AssertThat(mgr.can_pull(), Is().True());
-         AssertThat(mgr.pull(), Is().EqualTo(1u));
+        AssertThat(mgr.can_pull(), Is().True());
+        AssertThat(mgr.pull(), Is().EqualTo(1u));
 
-         AssertThat(mgr.can_pull(), Is().False());
+        AssertThat(mgr.can_pull(), Is().False());
       });
 
       it("can peek merge of two level_info stream", [&]() {
@@ -301,21 +301,21 @@ go_bandit([]() {
 
     describe("with 1 Bucket", [&]() {
       it("can set up priority queue with more levels than buckets", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(5,2u));
-           fw.unsafe_push(create_level_info(4,3u));
-           fw.unsafe_push(create_level_info(3,2u));
-           fw.unsafe_push(create_level_info(1,1u));
-         }
+          fw.unsafe_push(create_level_info(5,2u));
+          fw.unsafe_push(create_level_info(4,3u));
+          fw.unsafe_push(create_level_info(3,2u));
+          fw.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<1,1> pq({f});
+        test_priority_queue<1,1> pq({f});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue with fewer levels than buckets", [&]() {
@@ -334,47 +334,47 @@ go_bandit([]() {
       });
 
       it("can set up priority queue with empty level_info stream", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         test_priority_queue<1,1> pq({f});
+        test_priority_queue<1,1> pq({f});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue for two level_info streams, where one is empty", [&]() {
-         pq_test_file f1;
+        pq_test_file f1;
 
-         {
-           pq_test_writer fw1(f1);
+        {
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(1,1u));
-         }
+          fw1.unsafe_push(create_level_info(1,1u));
+        }
 
-         pq_test_file f2;
+        pq_test_file f2;
 
-         test_priority_queue<2,1> pq({f1,f2});
+        test_priority_queue<2,1> pq({f1,f2});
 
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
       });
 
       it("can set up priority queue for two level_info streams", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writers early
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writers early
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(1,1u));
+          fw1.unsafe_push(create_level_info(1,1u));
 
-           pq_test_writer fw2(f2);
+          pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(create_level_info(2,1u));
-         }
+          fw2.unsafe_push(create_level_info(2,1u));
+        }
 
-         test_priority_queue<2,1> pq({f1,f2});
+        test_priority_queue<2,1> pq({f1,f2});
 
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
       });
 
       it("can push into and pull from bucket", [&]() {
@@ -694,77 +694,77 @@ go_bandit([]() {
       });
 
       it("can pull after a peek in bucket", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(6,2u));
-           fw.unsafe_push(create_level_info(5,4u));
-           fw.unsafe_push(create_level_info(4,5u));
-           fw.unsafe_push(create_level_info(3,4u));
-           fw.unsafe_push(create_level_info(2,2u));
-           fw.unsafe_push(create_level_info(1,1u));
-         }
+          fw.unsafe_push(create_level_info(6,2u));
+          fw.unsafe_push(create_level_info(5,4u));
+          fw.unsafe_push(create_level_info(4,5u));
+          fw.unsafe_push(create_level_info(3,4u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<1,1> pq({f});
+        test_priority_queue<1,1> pq({f});
 
-         AssertThat(pq.size(), Is().EqualTo(0u));
+        AssertThat(pq.size(), Is().EqualTo(0u));
 
-         pq.push(pq_test_data {2, 42}); // bucket
-         AssertThat(pq.size(), Is().EqualTo(1u));
+        pq.push(pq_test_data {2, 42}); // bucket
+        AssertThat(pq.size(), Is().EqualTo(1u));
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.peek(), Is().EqualTo(pq_test_data {2, 42}));
-         AssertThat(pq.size(), Is().EqualTo(1u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.peek(), Is().EqualTo(pq_test_data {2, 42}));
+        AssertThat(pq.size(), Is().EqualTo(1u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 42}));
-         AssertThat(pq.size(), Is().EqualTo(0u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 42}));
+        AssertThat(pq.size(), Is().EqualTo(0u));
 
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
       });
 
       it("can pull after a peek in overflow", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(6,2u));
-           fw.unsafe_push(create_level_info(5,2u));
-           fw.unsafe_push(create_level_info(4,3u));
-           fw.unsafe_push(create_level_info(3,2u));
-           fw.unsafe_push(create_level_info(2,2u));
-           fw.unsafe_push(create_level_info(1,1u));
-         }
+          fw.unsafe_push(create_level_info(6,2u));
+          fw.unsafe_push(create_level_info(5,2u));
+          fw.unsafe_push(create_level_info(4,3u));
+          fw.unsafe_push(create_level_info(3,2u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<1,1> pq({f});
+        test_priority_queue<1,1> pq({f});
 
-         pq.push(pq_test_data {5, 3});  // overflow
-         AssertThat(pq.size(), Is().EqualTo(1u));
+        pq.push(pq_test_data {5, 3});  // overflow
+        AssertThat(pq.size(), Is().EqualTo(1u));
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(5u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(5u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.peek(), Is().EqualTo(pq_test_data {5, 3}));
-         AssertThat(pq.size(), Is().EqualTo(1u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.peek(), Is().EqualTo(pq_test_data {5, 3}));
+        AssertThat(pq.size(), Is().EqualTo(1u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {5, 3}));
-         AssertThat(pq.size(), Is().EqualTo(0u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {5, 3}));
+        AssertThat(pq.size(), Is().EqualTo(0u));
 
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
       });
 
       it("can push into buckets after bucket level rewrite", [&]() {
@@ -860,93 +860,93 @@ go_bandit([]() {
       });
 
       it("can set up priority queue with fewer levels than buckets [1]", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(4,1u));
-           fw.unsafe_push(create_level_info(3,2u));
-           fw.unsafe_push(create_level_info(1,1u));
-         }
+          fw.unsafe_push(create_level_info(4,1u));
+          fw.unsafe_push(create_level_info(3,2u));
+          fw.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<1,4> pq({f});
-       });
+        test_priority_queue<1,4> pq({f});
+      });
 
       it("can set up priority queue with fewer levels than buckets [2]", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(2,1u));
-           fw.unsafe_push(create_level_info(1,1u));
-         }
+          fw.unsafe_push(create_level_info(2,1u));
+          fw.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<1,4> pq({f});
-       });
+        test_priority_queue<1,4> pq({f});
+      });
 
       it("can set up priority queue with empty level_info stream", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         test_priority_queue<1,4> pq({f});
+        test_priority_queue<1,4> pq({f});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
 
       it("can set up priority queue for two level_info streams, where one is empty [1]", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writer early
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(1,1u));
-         }
+          fw1.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<2,4> pq({f1,f2});
+        test_priority_queue<2,4> pq({f1,f2});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue for two level_info streams, where one is empty [2]", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writer early
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(2,2u));
-           fw1.unsafe_push(create_level_info(1,1u));
-         }
+          fw1.unsafe_push(create_level_info(2,2u));
+          fw1.unsafe_push(create_level_info(1,1u));
+        }
 
-         test_priority_queue<2,4> pq({f1,f2});
+        test_priority_queue<2,4> pq({f1,f2});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can set up priority queue for two level_info streams", [&]() {
-         pq_test_file f1;
-         pq_test_file f2;
+        pq_test_file f1;
+        pq_test_file f2;
 
-         { // Garbage collect the writers early
-           pq_test_writer fw1(f1);
+        { // Garbage collect the writers early
+          pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_level_info(1,1u));
+          fw1.unsafe_push(create_level_info(1,1u));
 
-           pq_test_writer fw2(f2);
+          pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(create_level_info(12,1u));
-         }
+          fw2.unsafe_push(create_level_info(12,1u));
+        }
 
-         test_priority_queue<2,4> pq({f1,f2});
+        test_priority_queue<2,4> pq({f1,f2});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into and pull from buckets", [&]() {
@@ -1639,238 +1639,238 @@ go_bandit([]() {
       });
 
       it("can pull after a peek in bucket", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(6,1u)); // overflow
-           fw.unsafe_push(create_level_info(5,2u)); // write bucket
-           fw.unsafe_push(create_level_info(4,4u)); // write bucket
-           fw.unsafe_push(create_level_info(3,4u)); // write bucket
-           fw.unsafe_push(create_level_info(2,2u)); // write bucket
-           fw.unsafe_push(create_level_info(1,1u)); // read bucket
-         }
+          fw.unsafe_push(create_level_info(6,1u)); // overflow
+          fw.unsafe_push(create_level_info(5,2u)); // write bucket
+          fw.unsafe_push(create_level_info(4,4u)); // write bucket
+          fw.unsafe_push(create_level_info(3,4u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
+        }
 
-         test_priority_queue<1,4> pq({f});
+        test_priority_queue<1,4> pq({f});
 
-         pq.push(pq_test_data {3, 42}); // bucket
+        pq.push(pq_test_data {3, 42}); // bucket
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.peek(), Is().EqualTo(pq_test_data {3, 42}));
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 42}));
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.peek(), Is().EqualTo(pq_test_data {3, 42}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 42}));
+        AssertThat(pq.can_pull(), Is().False());
       });
 
       it("can pull after a peek in overflow", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(8,1u)); // overflow
-           fw.unsafe_push(create_level_info(7,2u)); // overflow
-           fw.unsafe_push(create_level_info(6,4u)); // overflow
-           fw.unsafe_push(create_level_info(5,8u)); // write bucket
-           fw.unsafe_push(create_level_info(4,4u)); // write bucket
-           fw.unsafe_push(create_level_info(3,2u)); // write bucket
-           fw.unsafe_push(create_level_info(2,2u)); // write bucket
-           fw.unsafe_push(create_level_info(1,1u)); // read bucket
-         }
+          fw.unsafe_push(create_level_info(8,1u)); // overflow
+          fw.unsafe_push(create_level_info(7,2u)); // overflow
+          fw.unsafe_push(create_level_info(6,4u)); // overflow
+          fw.unsafe_push(create_level_info(5,8u)); // write bucket
+          fw.unsafe_push(create_level_info(4,4u)); // write bucket
+          fw.unsafe_push(create_level_info(3,2u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
+        }
 
-         test_priority_queue<1,4> pq({f});
+        test_priority_queue<1,4> pq({f});
 
-         pq.push(pq_test_data {7, 3});  // overflow
+        pq.push(pq_test_data {7, 3});  // overflow
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(7u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(7u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.peek(), Is().EqualTo(pq_test_data {7, 3}));
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {7, 3}));
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.peek(), Is().EqualTo(pq_test_data {7, 3}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {7, 3}));
+        AssertThat(pq.can_pull(), Is().False());
       });
 
       it("can deal with exactly as many levels as buckets", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(4,2u)); // write bucket
-           fw.unsafe_push(create_level_info(3,3u)); // write bucket
-           fw.unsafe_push(create_level_info(2,4u)); // write bucket
-           fw.unsafe_push(create_level_info(1,2u)); // write bucket
-           fw.unsafe_push(create_level_info(0,1u)); // read bucket
-         }
+          fw.unsafe_push(create_level_info(4,2u)); // write bucket
+          fw.unsafe_push(create_level_info(3,3u)); // write bucket
+          fw.unsafe_push(create_level_info(2,4u)); // write bucket
+          fw.unsafe_push(create_level_info(1,2u)); // write bucket
+          fw.unsafe_push(create_level_info(0,1u)); // read bucket
+        }
 
-         test_priority_queue<1,4> pq({f});
+        test_priority_queue<1,4> pq({f});
 
-         pq.push(pq_test_data {4, 3});
-         pq.push(pq_test_data {2, 1});
+        pq.push(pq_test_data {4, 3});
+        pq.push(pq_test_data {2, 1});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(0u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(0u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
 
-         pq.push(pq_test_data {3, 2});
-         pq.push(pq_test_data {3, 1});
+        pq.push(pq_test_data {3, 2});
+        pq.push(pq_test_data {3, 1});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(2u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
 
-         pq.push(pq_test_data {4, 1});
+        pq.push(pq_test_data {4, 1});
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 2}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 2}));
 
-         pq.push(pq_test_data {4, 2});
+        pq.push(pq_test_data {4, 2});
 
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(3u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(4u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(4u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 1}));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 2}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 2}));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 3}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {4, 3}));
 
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can deal with fewer levels as buckets", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(2,2u)); // write bucket
-           fw.unsafe_push(create_level_info(1,2u)); // write bucket
-           fw.unsafe_push(create_level_info(0,1u)); // read bucket
-         }
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,2u)); // write bucket
+          fw.unsafe_push(create_level_info(0,1u)); // read bucket
+        }
 
-         test_priority_queue<1,4> pq({f});
+        test_priority_queue<1,4> pq({f});
 
-         pq.push(pq_test_data {2, 1});
-         pq.push(pq_test_data {1, 1});
+        pq.push(pq_test_data {2, 1});
+        pq.push(pq_test_data {1, 1});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(0u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(0u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {1, 1}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {1, 1}));
 
-         pq.push(pq_test_data {2, 2});
+        pq.push(pq_test_data {2, 2});
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(1u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level();
-         AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(1u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level();
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 2}));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 2}));
 
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
 
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can forward to stop_label with an empty overflow queue", [&]() {
-         pq_test_file f;
+        pq_test_file f;
 
-         { // Garbage collect the writer early
-           pq_test_writer fw(f);
+        { // Garbage collect the writer early
+          pq_test_writer fw(f);
 
-           fw.unsafe_push(create_level_info(8,2u)); // overflow
-           fw.unsafe_push(create_level_info(7,4u)); // overflow
-           fw.unsafe_push(create_level_info(6,2u)); // overflow
-           fw.unsafe_push(create_level_info(5,6u)); // write bucket
-           fw.unsafe_push(create_level_info(4,8u)); // write bucket
-           fw.unsafe_push(create_level_info(3,4u)); // write bucket
-           fw.unsafe_push(create_level_info(2,2u)); // write bucket
-           fw.unsafe_push(create_level_info(0,1u)); // read bucket
-         }
+          fw.unsafe_push(create_level_info(8,2u)); // overflow
+          fw.unsafe_push(create_level_info(7,4u)); // overflow
+          fw.unsafe_push(create_level_info(6,2u)); // overflow
+          fw.unsafe_push(create_level_info(5,6u)); // write bucket
+          fw.unsafe_push(create_level_info(4,8u)); // write bucket
+          fw.unsafe_push(create_level_info(3,4u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(0,1u)); // read bucket
+        }
 
-         test_priority_queue<1,4> pq({f});
+        test_priority_queue<1,4> pq({f});
 
-         AssertThat(pq.size(), Is().EqualTo(0u));
+        AssertThat(pq.size(), Is().EqualTo(0u));
 
-         pq.push(pq_test_data {3, 3});
-         AssertThat(pq.size(), Is().EqualTo(1u));
+        pq.push(pq_test_data {3, 3});
+        AssertThat(pq.size(), Is().EqualTo(1u));
 
-         pq.push(pq_test_data {3, 1});
-         AssertThat(pq.size(), Is().EqualTo(2u));
+        pq.push(pq_test_data {3, 1});
+        AssertThat(pq.size(), Is().EqualTo(2u));
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(0u));
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level(2u);
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(0u));
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(2u);
 
-         AssertThat(pq.current_level(), Is().EqualTo(2u));
-         AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.can_pull(), Is().False());
 
-         pq.push(pq_test_data {3, 2});
-         AssertThat(pq.size(), Is().EqualTo(3u));
+        pq.push(pq_test_data {3, 2});
+        AssertThat(pq.size(), Is().EqualTo(3u));
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.current_level(), Is().EqualTo(2u));
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.current_level(), Is().EqualTo(2u));
 
-         AssertThat(pq.has_next_level(), Is().True());
-         pq.setup_next_level(4u);
+        AssertThat(pq.has_next_level(), Is().True());
+        pq.setup_next_level(4u);
 
-         AssertThat(pq.current_level(), Is().EqualTo(3u));
+        AssertThat(pq.current_level(), Is().EqualTo(3u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
-         AssertThat(pq.size(), Is().EqualTo(2u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 1}));
+        AssertThat(pq.size(), Is().EqualTo(2u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 2}));
-         AssertThat(pq.size(), Is().EqualTo(1u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 2}));
+        AssertThat(pq.size(), Is().EqualTo(1u));
 
-         AssertThat(pq.can_pull(), Is().True());
-         AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 3}));
-         AssertThat(pq.size(), Is().EqualTo(0u));
+        AssertThat(pq.can_pull(), Is().True());
+        AssertThat(pq.pull(), Is().EqualTo(pq_test_data {3, 3}));
+        AssertThat(pq.size(), Is().EqualTo(0u));
 
-         AssertThat(pq.can_pull(), Is().False());
-         AssertThat(pq.has_next_level(), Is().False());
+        AssertThat(pq.can_pull(), Is().False());
+        AssertThat(pq.has_next_level(), Is().False());
       });
 
       it("can push into buckets after bucket level rewrite", [&]() {

--- a/test/adiar/internal/test_levelized_priority_queue.cpp
+++ b/test/adiar/internal/test_levelized_priority_queue.cpp
@@ -44,10 +44,10 @@ go_bandit([]() {
         { // Garbage collect the writer
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,1u));
-          fw.unsafe_push(create_meta(3,2u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(4,1u));
+          fw.unsafe_push(create_level_info(3,2u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 1u> mgr;
@@ -75,10 +75,10 @@ go_bandit([]() {
         { // Garbage collect the writer
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,1u));
-          fw.unsafe_push(create_meta(3,2u));
-          fw.unsafe_push(create_meta(2,1u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(4,1u));
+          fw.unsafe_push(create_level_info(3,2u));
+          fw.unsafe_push(create_level_info(2,1u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 1> mgr;
@@ -103,7 +103,7 @@ go_bandit([]() {
          { // Garbage collect the writer
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_level_info(1,1u));
          }
 
          pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -125,8 +125,8 @@ go_bandit([]() {
          { // Garbage collect the writer
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(1,1u));
-           fw1.unsafe_push(create_meta(2,1u));
+           fw1.unsafe_push(create_level_info(1,1u));
+           fw1.unsafe_push(create_level_info(2,1u));
          }
 
          pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
@@ -150,14 +150,14 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(f1);
 
-          fw1.unsafe_push(create_meta(4,1u));
-          fw1.unsafe_push(create_meta(2,2u));
-          fw1.unsafe_push(create_meta(1,1u));
+          fw1.unsafe_push(create_level_info(4,1u));
+          fw1.unsafe_push(create_level_info(2,2u));
+          fw1.unsafe_push(create_level_info(1,1u));
 
           pq_test_writer fw2(f2);
 
-          fw2.unsafe_push(create_meta(4,1u));
-          fw2.unsafe_push(create_meta(3,1u));
+          fw2.unsafe_push(create_level_info(4,1u));
+          fw2.unsafe_push(create_level_info(3,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -187,11 +187,11 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(f1);
 
-          fw1.unsafe_push(create_meta(2,1u));
+          fw1.unsafe_push(create_level_info(2,1u));
 
           pq_test_writer fw2(f2);
 
-          fw2.unsafe_push(create_meta(1,1u));
+          fw2.unsafe_push(create_level_info(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -215,10 +215,10 @@ go_bandit([]() {
          { // Garbage collect the writers
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(2,1u));
+           fw1.unsafe_push(create_level_info(2,1u));
            pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(create_meta(1,1u));
+           fw2.unsafe_push(create_level_info(1,1u));
          }
 
          pq_label_mgr<pq_test_data, 1u, std::greater<>, 2> mgr;
@@ -242,14 +242,14 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(f1);
 
-          fw1.unsafe_push(create_meta(4,2u));
-          fw1.unsafe_push(create_meta(2,1u));
+          fw1.unsafe_push(create_level_info(4,2u));
+          fw1.unsafe_push(create_level_info(2,1u));
 
           pq_test_writer fw2(f2);
 
-          fw2.unsafe_push(create_meta(4,3u));
-          fw2.unsafe_push(create_meta(3,2u));
-          fw2.unsafe_push(create_meta(1,1u));
+          fw2.unsafe_push(create_level_info(4,3u));
+          fw2.unsafe_push(create_level_info(3,2u));
+          fw2.unsafe_push(create_level_info(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -274,14 +274,14 @@ go_bandit([]() {
         { // Garbage collect the writers
           pq_test_writer fw1(*f1);
 
-          fw1.unsafe_push(create_meta(4,2u));
-          fw1.unsafe_push(create_meta(2,1u));
+          fw1.unsafe_push(create_level_info(4,2u));
+          fw1.unsafe_push(create_level_info(2,1u));
 
           pq_test_writer fw2(*f2);
 
-          fw2.unsafe_push(create_meta(4,1u));
-          fw2.unsafe_push(create_meta(3,2u));
-          fw2.unsafe_push(create_meta(1,1u));
+          fw2.unsafe_push(create_level_info(4,1u));
+          fw2.unsafe_push(create_level_info(3,2u));
+          fw2.unsafe_push(create_level_info(1,1u));
         }
 
         pq_label_mgr<pq_test_data, 1u, std::less<>, 2> mgr;
@@ -306,10 +306,10 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(5,2u));
-           fw.unsafe_push(create_meta(4,3u));
-           fw.unsafe_push(create_meta(3,2u));
-           fw.unsafe_push(create_meta(1,1u));
+           fw.unsafe_push(create_level_info(5,2u));
+           fw.unsafe_push(create_level_info(4,3u));
+           fw.unsafe_push(create_level_info(3,2u));
+           fw.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<1,1> pq({f});
@@ -324,7 +324,7 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -348,7 +348,7 @@ go_bandit([]() {
          {
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_level_info(1,1u));
          }
 
          pq_test_file f2;
@@ -365,11 +365,11 @@ go_bandit([]() {
          { // Garbage collect the writers early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_level_info(1,1u));
 
            pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(create_meta(2,1u));
+           fw2.unsafe_push(create_level_info(2,1u));
          }
 
          test_priority_queue<2,1> pq({f1,f2});
@@ -383,10 +383,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,2u));
-          fw.unsafe_push(create_meta(3,3u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(4,2u));
+          fw.unsafe_push(create_level_info(3,3u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -461,10 +461,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,2u));
-          fw.unsafe_push(create_meta(3,3u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(4,2u));
+          fw.unsafe_push(create_level_info(3,3u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -508,10 +508,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,1u));
-          fw.unsafe_push(create_meta(3,3u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(4,1u));
+          fw.unsafe_push(create_level_info(3,3u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -541,10 +541,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,2u));
-          fw.unsafe_push(create_meta(3,4u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1));
+          fw.unsafe_push(create_level_info(4,2u));
+          fw.unsafe_push(create_level_info(3,4u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -580,11 +580,11 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(5,2u));
-          fw.unsafe_push(create_meta(4,4u));
-          fw.unsafe_push(create_meta(3,4u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(5,2u));
+          fw.unsafe_push(create_level_info(4,4u));
+          fw.unsafe_push(create_level_info(3,4u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -621,10 +621,10 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(4,2u));
-          fw.unsafe_push(create_meta(3,3u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(4,2u));
+          fw.unsafe_push(create_level_info(3,3u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,1> pq({f});
@@ -699,12 +699,12 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(6,2u));
-           fw.unsafe_push(create_meta(5,4u));
-           fw.unsafe_push(create_meta(4,5u));
-           fw.unsafe_push(create_meta(3,4u));
-           fw.unsafe_push(create_meta(2,2u));
-           fw.unsafe_push(create_meta(1,1u));
+           fw.unsafe_push(create_level_info(6,2u));
+           fw.unsafe_push(create_level_info(5,4u));
+           fw.unsafe_push(create_level_info(4,5u));
+           fw.unsafe_push(create_level_info(3,4u));
+           fw.unsafe_push(create_level_info(2,2u));
+           fw.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<1,1> pq({f});
@@ -737,12 +737,12 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(6,2u));
-           fw.unsafe_push(create_meta(5,2u));
-           fw.unsafe_push(create_meta(4,3u));
-           fw.unsafe_push(create_meta(3,2u));
-           fw.unsafe_push(create_meta(2,2u));
-           fw.unsafe_push(create_meta(1,1u));
+           fw.unsafe_push(create_level_info(6,2u));
+           fw.unsafe_push(create_level_info(5,2u));
+           fw.unsafe_push(create_level_info(4,3u));
+           fw.unsafe_push(create_level_info(3,2u));
+           fw.unsafe_push(create_level_info(2,2u));
+           fw.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<1,1> pq({f});
@@ -773,16 +773,16 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(16,2u)); // overflow
-          fw.unsafe_push(create_meta(15,3u)); // overflow
-          fw.unsafe_push(create_meta(14,5u)); // overflow
-          fw.unsafe_push(create_meta(12,8u)); // overflow
-          fw.unsafe_push(create_meta(10,8u)); // overflow
-          fw.unsafe_push(create_meta(9,7u)); // overflow
-          fw.unsafe_push(create_meta(8,3u)); // overflow
-          fw.unsafe_push(create_meta(6,3u)); // overflow
-          fw.unsafe_push(create_meta(4,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(16,2u)); // overflow
+          fw.unsafe_push(create_level_info(15,3u)); // overflow
+          fw.unsafe_push(create_level_info(14,5u)); // overflow
+          fw.unsafe_push(create_level_info(12,8u)); // overflow
+          fw.unsafe_push(create_level_info(10,8u)); // overflow
+          fw.unsafe_push(create_level_info(9,7u)); // overflow
+          fw.unsafe_push(create_level_info(8,3u)); // overflow
+          fw.unsafe_push(create_level_info(6,3u)); // overflow
+          fw.unsafe_push(create_level_info(4,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,1> pq({f});
@@ -846,14 +846,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(8,1u));
-          fw.unsafe_push(create_meta(7,3u));
-          fw.unsafe_push(create_meta(6,4u));
-          fw.unsafe_push(create_meta(5,6u));
-          fw.unsafe_push(create_meta(4,5u));
-          fw.unsafe_push(create_meta(3,4u));
-          fw.unsafe_push(create_meta(2,2u));
-          fw.unsafe_push(create_meta(1,1u));
+          fw.unsafe_push(create_level_info(8,1u));
+          fw.unsafe_push(create_level_info(7,3u));
+          fw.unsafe_push(create_level_info(6,4u));
+          fw.unsafe_push(create_level_info(5,6u));
+          fw.unsafe_push(create_level_info(4,5u));
+          fw.unsafe_push(create_level_info(3,4u));
+          fw.unsafe_push(create_level_info(2,2u));
+          fw.unsafe_push(create_level_info(1,1u));
         }
 
         test_priority_queue<1,4> pq({f});
@@ -865,9 +865,9 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(4,1u));
-           fw.unsafe_push(create_meta(3,2u));
-           fw.unsafe_push(create_meta(1,1u));
+           fw.unsafe_push(create_level_info(4,1u));
+           fw.unsafe_push(create_level_info(3,2u));
+           fw.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<1,4> pq({f});
@@ -879,8 +879,8 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(2,1u));
-           fw.unsafe_push(create_meta(1,1u));
+           fw.unsafe_push(create_level_info(2,1u));
+           fw.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<1,4> pq({f});
@@ -903,7 +903,7 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<2,4> pq({f1,f2});
@@ -919,8 +919,8 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(2,2u));
-           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_level_info(2,2u));
+           fw1.unsafe_push(create_level_info(1,1u));
          }
 
          test_priority_queue<2,4> pq({f1,f2});
@@ -936,11 +936,11 @@ go_bandit([]() {
          { // Garbage collect the writers early
            pq_test_writer fw1(f1);
 
-           fw1.unsafe_push(create_meta(1,1u));
+           fw1.unsafe_push(create_level_info(1,1u));
 
            pq_test_writer fw2(f2);
 
-           fw2.unsafe_push(create_meta(12,1u));
+           fw2.unsafe_push(create_level_info(12,1u));
          }
 
          test_priority_queue<2,4> pq({f1,f2});
@@ -955,13 +955,13 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(7,2u)); // overflow
-          fw.unsafe_push(create_meta(6,3u)); // overflow
-          fw.unsafe_push(create_meta(5,6u)); // write bucket
-          fw.unsafe_push(create_meta(4,8u)); // write bucket
-          fw.unsafe_push(create_meta(3,4u)); // write bucket
-          fw.unsafe_push(create_meta(2,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(7,2u)); // overflow
+          fw.unsafe_push(create_level_info(6,3u)); // overflow
+          fw.unsafe_push(create_level_info(5,6u)); // write bucket
+          fw.unsafe_push(create_level_info(4,8u)); // write bucket
+          fw.unsafe_push(create_level_info(3,4u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1163,14 +1163,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(8,1u)); // overflow
-          fw.unsafe_push(create_meta(7,4u)); // overflow
-          fw.unsafe_push(create_meta(6,7u)); // overflow
-          fw.unsafe_push(create_meta(5,10u)); // write bucket
-          fw.unsafe_push(create_meta(4,8u)); // write bucket
-          fw.unsafe_push(create_meta(3,4u)); // write bucket
-          fw.unsafe_push(create_meta(2,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(8,1u)); // overflow
+          fw.unsafe_push(create_level_info(7,4u)); // overflow
+          fw.unsafe_push(create_level_info(6,7u)); // overflow
+          fw.unsafe_push(create_level_info(5,10u)); // write bucket
+          fw.unsafe_push(create_level_info(4,8u)); // write bucket
+          fw.unsafe_push(create_level_info(3,4u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1217,14 +1217,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(8,2u)); // overflow
-          fw.unsafe_push(create_meta(7,3u)); // overflow
-          fw.unsafe_push(create_meta(6,4u)); // overflow
-          fw.unsafe_push(create_meta(5,5u)); // write bucket
-          fw.unsafe_push(create_meta(4,3u)); // write bucket
-          fw.unsafe_push(create_meta(3,2u)); // write bucket
-          fw.unsafe_push(create_meta(2,1u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(8,2u)); // overflow
+          fw.unsafe_push(create_level_info(7,3u)); // overflow
+          fw.unsafe_push(create_level_info(6,4u)); // overflow
+          fw.unsafe_push(create_level_info(5,5u)); // write bucket
+          fw.unsafe_push(create_level_info(4,3u)); // write bucket
+          fw.unsafe_push(create_level_info(3,2u)); // write bucket
+          fw.unsafe_push(create_level_info(2,1u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1257,18 +1257,18 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(12,2u)); // overflow
-          fw.unsafe_push(create_meta(11,4u)); // overflow
-          fw.unsafe_push(create_meta(10,8u)); // overflow
-          fw.unsafe_push(create_meta(9,16u)); // overflow
-          fw.unsafe_push(create_meta(8,32u)); // overflow
-          fw.unsafe_push(create_meta(7,64u)); // overflow
-          fw.unsafe_push(create_meta(6,32u)); // overflow
-          fw.unsafe_push(create_meta(5,16u)); // write bucket
-          fw.unsafe_push(create_meta(4,8u)); // write bucket
-          fw.unsafe_push(create_meta(3,4u)); // write bucket
-          fw.unsafe_push(create_meta(2,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(12,2u)); // overflow
+          fw.unsafe_push(create_level_info(11,4u)); // overflow
+          fw.unsafe_push(create_level_info(10,8u)); // overflow
+          fw.unsafe_push(create_level_info(9,16u)); // overflow
+          fw.unsafe_push(create_level_info(8,32u)); // overflow
+          fw.unsafe_push(create_level_info(7,64u)); // overflow
+          fw.unsafe_push(create_level_info(6,32u)); // overflow
+          fw.unsafe_push(create_level_info(5,16u)); // write bucket
+          fw.unsafe_push(create_level_info(4,8u)); // write bucket
+          fw.unsafe_push(create_level_info(3,4u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1317,14 +1317,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(8,1u)); // overflow
-          fw.unsafe_push(create_meta(7,1u)); // overflow
-          fw.unsafe_push(create_meta(6,2u)); // overflow
-          fw.unsafe_push(create_meta(5,3u)); // write bucket
-          fw.unsafe_push(create_meta(4,4u)); // write bucket
-          fw.unsafe_push(create_meta(3,3u)); // write bucket
-          fw.unsafe_push(create_meta(2,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(8,1u)); // overflow
+          fw.unsafe_push(create_level_info(7,1u)); // overflow
+          fw.unsafe_push(create_level_info(6,2u)); // overflow
+          fw.unsafe_push(create_level_info(5,3u)); // write bucket
+          fw.unsafe_push(create_level_info(4,4u)); // write bucket
+          fw.unsafe_push(create_level_info(3,3u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1363,14 +1363,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(8,1)); // overflow
-          fw.unsafe_push(create_meta(7,2u)); // overflow
-          fw.unsafe_push(create_meta(6,3u)); // overflow
-          fw.unsafe_push(create_meta(5,2u)); // write bucket
-          fw.unsafe_push(create_meta(4,3u)); // write bucket
-          fw.unsafe_push(create_meta(3,1u)); // write bucket
-          fw.unsafe_push(create_meta(2,1u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(8,1)); // overflow
+          fw.unsafe_push(create_level_info(7,2u)); // overflow
+          fw.unsafe_push(create_level_info(6,3u)); // overflow
+          fw.unsafe_push(create_level_info(5,2u)); // write bucket
+          fw.unsafe_push(create_level_info(4,3u)); // write bucket
+          fw.unsafe_push(create_level_info(3,1u)); // write bucket
+          fw.unsafe_push(create_level_info(2,1u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1409,14 +1409,14 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(8,2u)); // overflow
-          fw.unsafe_push(create_meta(7,2u)); // overflow
-          fw.unsafe_push(create_meta(6,4u)); // overflow
-          fw.unsafe_push(create_meta(5,3u)); // write bucket
-          fw.unsafe_push(create_meta(4,5u)); // write bucket
-          fw.unsafe_push(create_meta(3,4u)); // write bucket
-          fw.unsafe_push(create_meta(2,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(8,2u)); // overflow
+          fw.unsafe_push(create_level_info(7,2u)); // overflow
+          fw.unsafe_push(create_level_info(6,4u)); // overflow
+          fw.unsafe_push(create_level_info(5,3u)); // write bucket
+          fw.unsafe_push(create_level_info(4,5u)); // write bucket
+          fw.unsafe_push(create_level_info(3,4u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});
@@ -1644,12 +1644,12 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(6,1u)); // overflow
-           fw.unsafe_push(create_meta(5,2u)); // write bucket
-           fw.unsafe_push(create_meta(4,4u)); // write bucket
-           fw.unsafe_push(create_meta(3,4u)); // write bucket
-           fw.unsafe_push(create_meta(2,2u)); // write bucket
-           fw.unsafe_push(create_meta(1,1u)); // read bucket
+           fw.unsafe_push(create_level_info(6,1u)); // overflow
+           fw.unsafe_push(create_level_info(5,2u)); // write bucket
+           fw.unsafe_push(create_level_info(4,4u)); // write bucket
+           fw.unsafe_push(create_level_info(3,4u)); // write bucket
+           fw.unsafe_push(create_level_info(2,2u)); // write bucket
+           fw.unsafe_push(create_level_info(1,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1675,14 +1675,14 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(8,1u)); // overflow
-           fw.unsafe_push(create_meta(7,2u)); // overflow
-           fw.unsafe_push(create_meta(6,4u)); // overflow
-           fw.unsafe_push(create_meta(5,8u)); // write bucket
-           fw.unsafe_push(create_meta(4,4u)); // write bucket
-           fw.unsafe_push(create_meta(3,2u)); // write bucket
-           fw.unsafe_push(create_meta(2,2u)); // write bucket
-           fw.unsafe_push(create_meta(1,1u)); // read bucket
+           fw.unsafe_push(create_level_info(8,1u)); // overflow
+           fw.unsafe_push(create_level_info(7,2u)); // overflow
+           fw.unsafe_push(create_level_info(6,4u)); // overflow
+           fw.unsafe_push(create_level_info(5,8u)); // write bucket
+           fw.unsafe_push(create_level_info(4,4u)); // write bucket
+           fw.unsafe_push(create_level_info(3,2u)); // write bucket
+           fw.unsafe_push(create_level_info(2,2u)); // write bucket
+           fw.unsafe_push(create_level_info(1,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1708,11 +1708,11 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(4,2u)); // write bucket
-           fw.unsafe_push(create_meta(3,3u)); // write bucket
-           fw.unsafe_push(create_meta(2,4u)); // write bucket
-           fw.unsafe_push(create_meta(1,2u)); // write bucket
-           fw.unsafe_push(create_meta(0,1u)); // read bucket
+           fw.unsafe_push(create_level_info(4,2u)); // write bucket
+           fw.unsafe_push(create_level_info(3,3u)); // write bucket
+           fw.unsafe_push(create_level_info(2,4u)); // write bucket
+           fw.unsafe_push(create_level_info(1,2u)); // write bucket
+           fw.unsafe_push(create_level_info(0,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1774,9 +1774,9 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(2,2u)); // write bucket
-           fw.unsafe_push(create_meta(1,2u)); // write bucket
-           fw.unsafe_push(create_meta(0,1u)); // read bucket
+           fw.unsafe_push(create_level_info(2,2u)); // write bucket
+           fw.unsafe_push(create_level_info(1,2u)); // write bucket
+           fw.unsafe_push(create_level_info(0,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1818,14 +1818,14 @@ go_bandit([]() {
          { // Garbage collect the writer early
            pq_test_writer fw(f);
 
-           fw.unsafe_push(create_meta(8,2u)); // overflow
-           fw.unsafe_push(create_meta(7,4u)); // overflow
-           fw.unsafe_push(create_meta(6,2u)); // overflow
-           fw.unsafe_push(create_meta(5,6u)); // write bucket
-           fw.unsafe_push(create_meta(4,8u)); // write bucket
-           fw.unsafe_push(create_meta(3,4u)); // write bucket
-           fw.unsafe_push(create_meta(2,2u)); // write bucket
-           fw.unsafe_push(create_meta(0,1u)); // read bucket
+           fw.unsafe_push(create_level_info(8,2u)); // overflow
+           fw.unsafe_push(create_level_info(7,4u)); // overflow
+           fw.unsafe_push(create_level_info(6,2u)); // overflow
+           fw.unsafe_push(create_level_info(5,6u)); // write bucket
+           fw.unsafe_push(create_level_info(4,8u)); // write bucket
+           fw.unsafe_push(create_level_info(3,4u)); // write bucket
+           fw.unsafe_push(create_level_info(2,2u)); // write bucket
+           fw.unsafe_push(create_level_info(0,1u)); // read bucket
          }
 
          test_priority_queue<1,4> pq({f});
@@ -1879,23 +1879,23 @@ go_bandit([]() {
         { // Garbage collect the writer early
           pq_test_writer fw(f);
 
-          fw.unsafe_push(create_meta(17,2u)); // overflow
-          fw.unsafe_push(create_meta(16,4u)); // overflow
-          fw.unsafe_push(create_meta(15,8u)); // overflow
-          fw.unsafe_push(create_meta(14,11u)); // overflow
-          fw.unsafe_push(create_meta(13,13u)); // overflow
-          fw.unsafe_push(create_meta(12,17u)); // overflow
-          fw.unsafe_push(create_meta(11,19u)); // overflow
-          fw.unsafe_push(create_meta(10,23u)); // overflow
-          fw.unsafe_push(create_meta(9,19u)); // overflow
-          fw.unsafe_push(create_meta(8,17u)); // overflow
-          fw.unsafe_push(create_meta(7,13u)); // overflow
-          fw.unsafe_push(create_meta(6,11u)); // overflow
-          fw.unsafe_push(create_meta(5,7u)); // write bucket
-          fw.unsafe_push(create_meta(4,5u)); // write bucket
-          fw.unsafe_push(create_meta(3,3u)); // write bucket
-          fw.unsafe_push(create_meta(2,2u)); // write bucket
-          fw.unsafe_push(create_meta(1,1u)); // read bucket
+          fw.unsafe_push(create_level_info(17,2u)); // overflow
+          fw.unsafe_push(create_level_info(16,4u)); // overflow
+          fw.unsafe_push(create_level_info(15,8u)); // overflow
+          fw.unsafe_push(create_level_info(14,11u)); // overflow
+          fw.unsafe_push(create_level_info(13,13u)); // overflow
+          fw.unsafe_push(create_level_info(12,17u)); // overflow
+          fw.unsafe_push(create_level_info(11,19u)); // overflow
+          fw.unsafe_push(create_level_info(10,23u)); // overflow
+          fw.unsafe_push(create_level_info(9,19u)); // overflow
+          fw.unsafe_push(create_level_info(8,17u)); // overflow
+          fw.unsafe_push(create_level_info(7,13u)); // overflow
+          fw.unsafe_push(create_level_info(6,11u)); // overflow
+          fw.unsafe_push(create_level_info(5,7u)); // write bucket
+          fw.unsafe_push(create_level_info(4,5u)); // write bucket
+          fw.unsafe_push(create_level_info(3,3u)); // write bucket
+          fw.unsafe_push(create_level_info(2,2u)); // write bucket
+          fw.unsafe_push(create_level_info(1,1u)); // read bucket
         }
 
         test_priority_queue<1,4> pq({f});

--- a/test/adiar/internal/test_reduce.cpp
+++ b/test/adiar/internal/test_reduce.cpp
@@ -54,10 +54,10 @@ go_bandit([]() {
             level_info_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -97,10 +97,10 @@ go_bandit([]() {
             level_info_test_stream<node_t, 1> out_meta(out);
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
             AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(out_meta.can_pull(), Is().False());
           });
@@ -137,9 +137,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n4,sink_F });
                   aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
                 }
 
                 // Reduce it
@@ -174,13 +174,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -221,9 +221,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n5, sink_F });
                   aw.unsafe_push_sink({ flag(n5), sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(2,2u));
-                  aw.unsafe_push(create_meta(3,2u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
+                  aw.unsafe_push(create_level_info(3,2u));
                 }
 
                 // Reduce it
@@ -258,13 +258,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -308,10 +308,10 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n6,sink_T });
                   aw.unsafe_push_sink({ flag(n6),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
-                  aw.unsafe_push(create_meta(3,2u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
+                  aw.unsafe_push(create_level_info(3,2u));
                 }
 
                 // Reduce it
@@ -354,16 +354,16 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,2u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,2u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -404,10 +404,10 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n5,sink_F });
                   aw.unsafe_push_sink({ flag(n5),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
-                  aw.unsafe_push(create_meta(3,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
+                  aw.unsafe_push(create_level_info(3,1u));
                 }
 
                 // Reduce it
@@ -445,16 +445,16 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -502,10 +502,10 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n7,sink_F });
                   aw.unsafe_push_sink({ flag(n7),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,2u));
-                  aw.unsafe_push(create_meta(2,3u));
-                  aw.unsafe_push(create_meta(3,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,2u));
+                  aw.unsafe_push(create_level_info(2,3u));
+                  aw.unsafe_push(create_level_info(3,1u));
                 }
 
 
@@ -558,16 +558,16 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,2u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,2u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -609,9 +609,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n6,sink_T });
                   aw.unsafe_push_sink({ flag(n6),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,2u));
-                  aw.unsafe_push(create_meta(2,3u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,2u));
+                  aw.unsafe_push(create_level_info(2,3u));
                 }
 
                 // Reduce it
@@ -647,13 +647,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -695,9 +695,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n6,sink_F });
                   aw.unsafe_push_sink({ flag(n6),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,2u));
-                  aw.unsafe_push(create_meta(2,3u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,2u));
+                  aw.unsafe_push(create_level_info(2,3u));
                 }
 
                 // Reduce it
@@ -733,13 +733,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -777,9 +777,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n4,sink_T });
                   aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
                 }
 
                 // Reduce it
@@ -814,13 +814,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -861,10 +861,10 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n5,sink_F });
                   aw.unsafe_push_sink({ flag(n5),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
-                  aw.unsafe_push(create_meta(3,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
+                  aw.unsafe_push(create_level_info(3,1u));
                 }
 
                 // Reduce it
@@ -901,16 +901,16 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -946,9 +946,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n4,sink_F });
                   aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
                 }
 
                 // Reduce it
@@ -976,10 +976,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1015,9 +1015,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n4,sink_F });
                   aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
                 }
 
                 // Reduce it
@@ -1037,7 +1037,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1059,7 +1059,7 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n1,sink_F });
                   aw.unsafe_push_sink({ flag(n1),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
                 }
 
                 // Reduce it
@@ -1103,8 +1103,8 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n2,sink_T });
                   aw.unsafe_push_sink({ flag(n2),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
                 }
 
                 // Reduce it
@@ -1140,7 +1140,7 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n1,sink_F });
                   aw.unsafe_push_sink({ flag(n1),sink_T });
 
-                  aw.unsafe_push(create_meta(0u,1u));
+                  aw.unsafe_push(create_level_info(0u,1u));
                 }
 
                 // Reduce it
@@ -1158,7 +1158,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
                 AssertThat(out_meta.can_pull(), Is().False());
               });
           });
@@ -1187,8 +1187,8 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n2,sink_T });
                   aw.unsafe_push_sink({ flag(n2),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
                 }
 
                 // Reduce it
@@ -1207,7 +1207,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1248,10 +1248,10 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n5,sink_F });
                   aw.unsafe_push_sink({ flag(n5),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
-                  aw.unsafe_push(create_meta(2,2u));
-                  aw.unsafe_push(create_meta(3,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
+                  aw.unsafe_push(create_level_info(2,2u));
+                  aw.unsafe_push(create_level_info(3,1u));
                 }
 
                 // Reduce it
@@ -1288,16 +1288,16 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1333,9 +1333,9 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n4,sink_T });
                   aw.unsafe_push_sink({ flag(n4),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,2u));
-                  aw.unsafe_push(create_meta(2,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,2u));
+                  aw.unsafe_push(create_level_info(2,1u));
                 }
 
                 // Reduce it
@@ -1363,10 +1363,10 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1388,7 +1388,7 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n1,sink_T });
                   aw.unsafe_push_sink({ flag(n1),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
                 }
 
                 // Reduce it
@@ -1432,8 +1432,8 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n2,sink_F });
                   aw.unsafe_push_sink({ flag(n2),sink_T });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
                 }
 
                 // Reduce it
@@ -1453,7 +1453,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(out_meta.can_pull(), Is().False());
               });
@@ -1481,8 +1481,8 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n2,sink_F });
                   aw.unsafe_push_sink({ flag(n2),sink_F });
 
-                  aw.unsafe_push(create_meta(0,1u));
-                  aw.unsafe_push(create_meta(1,1u));
+                  aw.unsafe_push(create_level_info(0,1u));
+                  aw.unsafe_push(create_level_info(1,1u));
                 }
 
                 // Reduce it
@@ -1518,7 +1518,7 @@ go_bandit([]() {
                   aw.unsafe_push_sink({ n1,sink_F });
                   aw.unsafe_push_sink({ flag(n1),sink_T });
 
-                  aw.unsafe_push(create_meta(42,1u));
+                  aw.unsafe_push(create_level_info(42,1u));
                 }
 
                 // Reduce it
@@ -1536,7 +1536,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, 1> out_meta(out);
 
                 AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_meta(42u,1u)));
+                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(42u,1u)));
                 AssertThat(out_meta.can_pull(), Is().False());
               });
           });

--- a/test/adiar/internal/test_reduce.cpp
+++ b/test/adiar/internal/test_reduce.cpp
@@ -6,108 +6,108 @@
 #include <adiar/zdd/zdd.h>
 
 go_bandit([]() {
-    describe("INTERNAL: Reduce", [&]() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+  describe("INTERNAL: Reduce", [&]() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        node_file x0x1_node_file;
+    node_file x0x1_node_file;
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw(x0x1_node_file);
+    { // Garbage collect writer to free write-lock
+      node_writer nw(x0x1_node_file);
 
-          nw << create_node(1,MAX_ID, sink_F, sink_T)
-             << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID));
-        }
+      nw << create_node(1,MAX_ID, sink_F, sink_T)
+         << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID));
+    }
 
-        it("preserves negation flag on reduced input [1]", [&]() {
-            /*
+    it("preserves negation flag on reduced input [1]", [&]() {
+      /*
                1                  1      ---- x0
               / \                / \
               F 2        =>      F 2     ---- x1
                / \                / \
                F T                F T
-            */
+      */
 
-            // Reduce it
-            bdd in(x0x1_node_file, false);
-            bdd out = reduce<bdd_policy>(in);
+      // Reduce it
+      bdd in(x0x1_node_file, false);
+      bdd out = reduce<bdd_policy>(in);
 
-            AssertThat(is_canonical(out), Is().True());
+      AssertThat(is_canonical(out), Is().True());
 
-            // Check it looks all right
-            node_test_stream out_nodes(out);
+      // Check it looks all right
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.can_pull(), Is().True());
 
-            // n2
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                  sink_F,
-                                                                  sink_T)));
-            AssertThat(out_nodes.can_pull(), Is().True());
+      // n2
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                            sink_F,
+                                                            sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
 
-            // n1
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                  sink_F,
-                                                                  create_node_ptr(1,MAX_ID))));
-            AssertThat(out_nodes.can_pull(), Is().False());
+      // n1
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                            sink_F,
+                                                            create_node_ptr(1,MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, 1> out_meta(out);
+      level_info_test_stream<node_t, 1> out_meta(out);
 
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(out_meta.can_pull(), Is().True());
+      AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(out_meta.can_pull(), Is().True());
+      AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(out_meta.can_pull(), Is().False());
-          });
+      AssertThat(out_meta.can_pull(), Is().False());
+    });
 
-        it("preserves negation flag on reduced input [2]", [&]() {
-            /*
+    it("preserves negation flag on reduced input [2]", [&]() {
+      /*
                1                  1      ---- x0
               / \                / \
               F 2      = ~ =>    T 2     ---- x1
                / \                / \
                F T                T F
-            */
+      */
 
-            // Reduce it
-            bdd in(x0x1_node_file, true);
-            bdd out = reduce<bdd_policy>(in);
+      // Reduce it
+      bdd in(x0x1_node_file, true);
+      bdd out = reduce<bdd_policy>(in);
 
-            AssertThat(is_canonical(out), Is().True());
+      AssertThat(is_canonical(out), Is().True());
 
-            // Check it looks all right
-            node_test_stream out_nodes(out);
+      // Check it looks all right
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.can_pull(), Is().True());
 
-            // n2
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                  sink_T,
-                                                                  sink_F)));
-            AssertThat(out_nodes.can_pull(), Is().True());
+      // n2
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                            sink_T,
+                                                            sink_F)));
+      AssertThat(out_nodes.can_pull(), Is().True());
 
-            // n1
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                  sink_T,
-                                                                  create_node_ptr(1,MAX_ID))));
-            AssertThat(out_nodes.can_pull(), Is().False());
+      // n1
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                            sink_T,
+                                                            create_node_ptr(1,MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, 1> out_meta(out);
+      level_info_test_stream<node_t, 1> out_meta(out);
 
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+      AssertThat(out_meta.can_pull(), Is().True());
+      AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-            AssertThat(out_meta.can_pull(), Is().True());
-            AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(out_meta.can_pull(), Is().True());
+      AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(out_meta.can_pull(), Is().False());
-          });
+      AssertThat(out_meta.can_pull(), Is().False());
+    });
 
-        describe("Reduction Rule 2", [&]() {
-            it("applies to sink arcs [1]", [&]() {
-                /*
+    describe("Reduction Rule 2", [&]() {
+      it("applies to sink arcs [1]", [&]() {
+        /*
                    1                  1      ---- x0
                   / \                / \
                   | 2_               | 2     ---- x1
@@ -115,78 +115,78 @@ go_bandit([]() {
                   3 4 T              4  T    ---- x2
                   |X|               / \
                   F T               F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n4 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n4 });
 
-                  aw.unsafe_push_sink({ flag(n2),sink_T });
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ n4,sink_F });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ flag(n2),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ n4,sink_F });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+        }
 
-                // Reduce it
+        // Reduce it
 
-                bdd out = reduce<bdd_policy>(in);
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n4
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n4
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to sink arcs [2]", [&]() {
-                /*
+      it("applies to sink arcs [2]", [&]() {
+        /*
                     1      ---- x0            1
                    / \                       / \
                    | |     ---- x1           | |
@@ -197,80 +197,80 @@ go_bandit([]() {
                    4 5     ---- x3            4
                   /| |\                      / \
                   FT FT                      F T
-                */
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(2,0);
-                ptr_t n3 = create_node_ptr(2,1);
-                ptr_t n4 = create_node_ptr(3,0);
-                ptr_t n5 = create_node_ptr(3,1);
+        */
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(2,0);
+        ptr_t n3 = create_node_ptr(2,1);
+        ptr_t n4 = create_node_ptr(3,0);
+        ptr_t n5 = create_node_ptr(3,1);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1, n2 });
-                  aw.unsafe_push_node({ flag(n1), n3 });
-                  aw.unsafe_push_node({ n3, n4 });
-                  aw.unsafe_push_node({ flag(n2), n5 });
+          aw.unsafe_push_node({ n1, n2 });
+          aw.unsafe_push_node({ flag(n1), n3 });
+          aw.unsafe_push_node({ n3, n4 });
+          aw.unsafe_push_node({ flag(n2), n5 });
 
-                  aw.unsafe_push_sink({ n2, sink_F });
-                  aw.unsafe_push_sink({ flag(n3), sink_T });
-                  aw.unsafe_push_sink({ n4, sink_F });
-                  aw.unsafe_push_sink({ flag(n4), sink_T });
-                  aw.unsafe_push_sink({ n5, sink_F });
-                  aw.unsafe_push_sink({ flag(n5), sink_T });
+          aw.unsafe_push_sink({ n2, sink_F });
+          aw.unsafe_push_sink({ flag(n3), sink_T });
+          aw.unsafe_push_sink({ n4, sink_F });
+          aw.unsafe_push_sink({ flag(n4), sink_T });
+          aw.unsafe_push_sink({ n5, sink_F });
+          aw.unsafe_push_sink({ flag(n5), sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                  aw.unsafe_push(create_level_info(3,2u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+          aw.unsafe_push(create_level_info(3,2u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      create_node_ptr(3, MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
-                                                                      sink_F,
-                                                                      create_node_ptr(3, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              create_node_ptr(3, MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
+                                                              sink_F,
+                                                              create_node_ptr(3, MAX_ID))));
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2, MAX_ID-1),
-                                                                      create_node_ptr(2, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2, MAX_ID-1),
+                                                              create_node_ptr(2, MAX_ID))));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to node arcs", [&]() {
-                /*
+      it("applies to node arcs", [&]() {
+        /*
                     1                  1       ---- x0
                    / \                / \
                    | 2_               | 2      ---- x1
@@ -280,96 +280,96 @@ go_bandit([]() {
                    5 6               5  6      ---- x3
                   / \ \\            / \ \\
                   F T T F           F T T F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
-                ptr_t n5 = create_node_ptr(3,0);
-                ptr_t n6 = create_node_ptr(3,1);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n5 = create_node_ptr(3,0);
+        ptr_t n6 = create_node_ptr(3,1);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n4 });
-                  aw.unsafe_push_node({ n3,n5 });
-                  aw.unsafe_push_node({ n4,n5 });
-                  aw.unsafe_push_node({ flag(n3),n6 });
-                  aw.unsafe_push_node({ flag(n4),n6 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n4 });
+          aw.unsafe_push_node({ n3,n5 });
+          aw.unsafe_push_node({ n4,n5 });
+          aw.unsafe_push_node({ flag(n3),n6 });
+          aw.unsafe_push_node({ flag(n4),n6 });
 
-                  aw.unsafe_push_sink({ flag(n2),sink_T });
-                  aw.unsafe_push_sink({ n5,sink_F });
-                  aw.unsafe_push_sink({ flag(n5),sink_T });
-                  aw.unsafe_push_sink({ n6,sink_T });
-                  aw.unsafe_push_sink({ flag(n6),sink_F });
+          aw.unsafe_push_sink({ flag(n2),sink_T });
+          aw.unsafe_push_sink({ n5,sink_F });
+          aw.unsafe_push_sink({ flag(n5),sink_T });
+          aw.unsafe_push_sink({ n6,sink_T });
+          aw.unsafe_push_sink({ flag(n6),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                  aw.unsafe_push(create_level_info(3,2u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+          aw.unsafe_push(create_level_info(3,2u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n6
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID-1, sink_T, sink_F)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n6
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID-1, sink_T, sink_F)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n4
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      create_node_ptr(3, MAX_ID),
-                                                                      create_node_ptr(3, MAX_ID-1))));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n4
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              create_node_ptr(3, MAX_ID),
+                                                              create_node_ptr(3, MAX_ID-1))));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,2u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,2u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to both node and sink arcs", [&]() {
-                /*
+      it("applies to both node and sink arcs", [&]() {
+        /*
                     1                  1     ---- x0
                    / \                / \
                    | 2_               | 2    ---- x1
@@ -379,88 +379,88 @@ go_bandit([]() {
                    5 T               5 T     ---- x3
                   / \               / \
                   F T               F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
-                ptr_t n5 = create_node_ptr(3,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n5 = create_node_ptr(3,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n4 });
-                  aw.unsafe_push_node({ n3,n5 });
-                  aw.unsafe_push_node({ n4,n5 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n4 });
+          aw.unsafe_push_node({ n3,n5 });
+          aw.unsafe_push_node({ n4,n5 });
 
-                  aw.unsafe_push_sink({ flag(n2),sink_T });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
-                  aw.unsafe_push_sink({ n5,sink_F });
-                  aw.unsafe_push_sink({ flag(n5),sink_T });
+          aw.unsafe_push_sink({ flag(n2),sink_T });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ n5,sink_F });
+          aw.unsafe_push_sink({ flag(n5),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                  aw.unsafe_push(create_level_info(3,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+          aw.unsafe_push(create_level_info(3,1u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n4
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      create_node_ptr(3,MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n4
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              create_node_ptr(3,MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to 'disjoint' branches", [&]() {
-                /*
+      it("applies to 'disjoint' branches", [&]() {
+        /*
                        1                         1         ---- x0
                       / \                       / \
                      2   3                     2   3       ---- x1
@@ -471,109 +471,109 @@ go_bandit([]() {
                   F T 7 T F T                   7 T F T    ---- x3
                      / \                       / \
                      F T                       F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(1,1);
-                ptr_t n4 = create_node_ptr(2,0);
-                ptr_t n5 = create_node_ptr(2,1);
-                ptr_t n6 = create_node_ptr(2,2);
-                ptr_t n7 = create_node_ptr(3,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(1,1);
+        ptr_t n4 = create_node_ptr(2,0);
+        ptr_t n5 = create_node_ptr(2,1);
+        ptr_t n6 = create_node_ptr(2,2);
+        ptr_t n7 = create_node_ptr(3,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1,n2 });
-                  aw.unsafe_push_node({ flag(n1),n3 });
-                  aw.unsafe_push_node({ n2,n4 });
-                  aw.unsafe_push_node({ flag(n2),n5 });
-                  aw.unsafe_push_node({ n3,n5 });
-                  aw.unsafe_push_node({ flag(n3),n6 });
-                  aw.unsafe_push_node({ n5,n7 });
+          aw.unsafe_push_node({ n1,n2 });
+          aw.unsafe_push_node({ flag(n1),n3 });
+          aw.unsafe_push_node({ n2,n4 });
+          aw.unsafe_push_node({ flag(n2),n5 });
+          aw.unsafe_push_node({ n3,n5 });
+          aw.unsafe_push_node({ flag(n3),n6 });
+          aw.unsafe_push_node({ n5,n7 });
 
-                  aw.unsafe_push_sink({ n4,sink_F });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
-                  aw.unsafe_push_sink({ flag(n5),sink_T });
-                  aw.unsafe_push_sink({ n6,sink_F });
-                  aw.unsafe_push_sink({ flag(n6),sink_T });
-                  aw.unsafe_push_sink({ n7,sink_F });
-                  aw.unsafe_push_sink({ flag(n7),sink_T });
+          aw.unsafe_push_sink({ n4,sink_F });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ flag(n5),sink_T });
+          aw.unsafe_push_sink({ n6,sink_F });
+          aw.unsafe_push_sink({ flag(n6),sink_T });
+          aw.unsafe_push_sink({ n7,sink_F });
+          aw.unsafe_push_sink({ flag(n7),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,2u));
-                  aw.unsafe_push(create_level_info(2,3u));
-                  aw.unsafe_push(create_level_info(3,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,2u));
+          aw.unsafe_push(create_level_info(2,3u));
+          aw.unsafe_push(create_level_info(3,1u));
+        }
 
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n7
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n7
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n6
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n6
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
-                                                                      create_node_ptr(3, MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
+                                                              create_node_ptr(3, MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2, MAX_ID-1),
-                                                                      create_node_ptr(2, MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2, MAX_ID-1),
+                                                              create_node_ptr(2, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID-1,
-                                                                      create_node_ptr(2, MAX_ID),
-                                                                      create_node_ptr(2, MAX_ID-1))));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID-1,
+                                                              create_node_ptr(2, MAX_ID),
+                                                              create_node_ptr(2, MAX_ID-1))));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(1,MAX_ID-1),
-                                                                      create_node_ptr(1, MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(1,MAX_ID-1),
+                                                              create_node_ptr(1, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,2u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("does forward the correct children [1]", [&]() {
-                /*
+      it("does forward the correct children [1]", [&]() {
+        /*
                        1                1        ---- x0
                       / \              / \
                      2   3             | 3       ---- x1
@@ -581,85 +581,85 @@ go_bandit([]() {
                    4   5   6           5   6     ---- x2
                   / \ / \ / \         / \ / \
                   F T F T T F         F T T F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(1,1);
-                ptr_t n4 = create_node_ptr(2,0);
-                ptr_t n5 = create_node_ptr(2,1);
-                ptr_t n6 = create_node_ptr(2,2);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(1,1);
+        ptr_t n4 = create_node_ptr(2,0);
+        ptr_t n5 = create_node_ptr(2,1);
+        ptr_t n6 = create_node_ptr(2,2);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1,n2 });
-                  aw.unsafe_push_node({ flag(n1),n3 });
-                  aw.unsafe_push_node({ n2,n4 });
-                  aw.unsafe_push_node({ flag(n2),n5 });
-                  aw.unsafe_push_node({ n3,n5 });
-                  aw.unsafe_push_node({ flag(n3),n6 });
+          aw.unsafe_push_node({ n1,n2 });
+          aw.unsafe_push_node({ flag(n1),n3 });
+          aw.unsafe_push_node({ n2,n4 });
+          aw.unsafe_push_node({ flag(n2),n5 });
+          aw.unsafe_push_node({ n3,n5 });
+          aw.unsafe_push_node({ flag(n3),n6 });
 
-                  aw.unsafe_push_sink({ n4,sink_F });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
-                  aw.unsafe_push_sink({ n5,sink_F });
-                  aw.unsafe_push_sink({ flag(n5),sink_T });
-                  aw.unsafe_push_sink({ n6,sink_T });
-                  aw.unsafe_push_sink({ flag(n6),sink_F });
+          aw.unsafe_push_sink({ n4,sink_F });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ n5,sink_F });
+          aw.unsafe_push_sink({ flag(n5),sink_T });
+          aw.unsafe_push_sink({ n6,sink_T });
+          aw.unsafe_push_sink({ flag(n6),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,2u));
-                  aw.unsafe_push(create_level_info(2,3u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,2u));
+          aw.unsafe_push(create_level_info(2,3u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 6
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
-                                                                      sink_T,
-                                                                      sink_F)));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 6
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
+                                                              sink_T,
+                                                              sink_F)));
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2, MAX_ID),
-                                                                      create_node_ptr(2, MAX_ID-1))));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2, MAX_ID),
+                                                              create_node_ptr(2, MAX_ID-1))));
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2, MAX_ID),
-                                                                      create_node_ptr(1, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2, MAX_ID),
+                                                              create_node_ptr(1, MAX_ID))));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("does forward the correct children [2]", [&]() {
-                /*
+      it("does forward the correct children [2]", [&]() {
+        /*
                        1                1        ---- x0
                       / \              / \
                      2   3             | 3       ---- x1
@@ -667,87 +667,87 @@ go_bandit([]() {
                    4   5   6           5   6     ---- x2
                   / \ / \ / \         / \ / \
                   T F T F F T         T F F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(1,1);
-                ptr_t n4 = create_node_ptr(2,0);
-                ptr_t n5 = create_node_ptr(2,1);
-                ptr_t n6 = create_node_ptr(2,2);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(1,1);
+        ptr_t n4 = create_node_ptr(2,0);
+        ptr_t n5 = create_node_ptr(2,1);
+        ptr_t n6 = create_node_ptr(2,2);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1,n2 });
-                  aw.unsafe_push_node({ flag(n1),n3 });
-                  aw.unsafe_push_node({ n2,n4 });
-                  aw.unsafe_push_node({ flag(n2),n5 });
-                  aw.unsafe_push_node({ n3,n5 });
-                  aw.unsafe_push_node({ flag(n3),n6 });
+          aw.unsafe_push_node({ n1,n2 });
+          aw.unsafe_push_node({ flag(n1),n3 });
+          aw.unsafe_push_node({ n2,n4 });
+          aw.unsafe_push_node({ flag(n2),n5 });
+          aw.unsafe_push_node({ n3,n5 });
+          aw.unsafe_push_node({ flag(n3),n6 });
 
-                  aw.unsafe_push_sink({ n4,sink_T });
-                  aw.unsafe_push_sink({ flag(n4),sink_F });
-                  aw.unsafe_push_sink({ n5,sink_T });
-                  aw.unsafe_push_sink({ flag(n5),sink_F });
-                  aw.unsafe_push_sink({ n6,sink_F });
-                  aw.unsafe_push_sink({ flag(n6),sink_T });
+          aw.unsafe_push_sink({ n4,sink_T });
+          aw.unsafe_push_sink({ flag(n4),sink_F });
+          aw.unsafe_push_sink({ n5,sink_T });
+          aw.unsafe_push_sink({ flag(n5),sink_F });
+          aw.unsafe_push_sink({ n6,sink_F });
+          aw.unsafe_push_sink({ flag(n6),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,2u));
-                  aw.unsafe_push(create_level_info(2,3u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,2u));
+          aw.unsafe_push(create_level_info(2,3u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 6
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 6
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
-                                                                      sink_T,
-                                                                      sink_F)));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID-1,
+                                                              sink_T,
+                                                              sink_F)));
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2, MAX_ID-1),
-                                                                      create_node_ptr(2, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2, MAX_ID-1),
+                                                              create_node_ptr(2, MAX_ID))));
 
-                AssertThat(out_nodes.can_pull(), Is().True()); // 1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2, MAX_ID-1),
-                                                                      create_node_ptr(1, MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True()); // 1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2, MAX_ID-1),
+                                                              create_node_ptr(1, MAX_ID))));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-          });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+    });
 
-        describe("Reduction Rule 1: BDD", [&]() {
-            it("applies to sink arcs", [&]() {
-                /*
+    describe("Reduction Rule 1: BDD", [&]() {
+      it("applies to sink arcs", [&]() {
+        /*
                     1                  1     ---- x0
                    / \                / \
                    | 2                | 2    ---- x1
@@ -755,78 +755,78 @@ go_bandit([]() {
                    3  4               3  |   ---- x2
                   / \//               |\ /
                   F  T                F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer early
-                  arc_writer aw(in);
+        { // Garbage collect writer early
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n3 });
-                  aw.unsafe_push_node({ flag(n2),n4 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n3 });
+          aw.unsafe_push_node({ flag(n2),n4 });
 
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ n4,sink_T });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ n4,sink_T });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to node arcs", [&]() {
-                /*
+      it("applies to node arcs", [&]() {
+        /*
                     1                  1        ---- x0
                    / \                / \
                    | 2                | 2       ---- x1
@@ -836,87 +836,87 @@ go_bandit([]() {
                   F T  5             F T  5     ---- x3
                       / \                / \
                       F T                F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
-                ptr_t n5 = create_node_ptr(3,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n5 = create_node_ptr(3,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n3 });
-                  aw.unsafe_push_node({ flag(n2),n4 });
-                  aw.unsafe_push_node({ n4,n5 });
-                  aw.unsafe_push_node({ flag(n4),n5 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n3 });
+          aw.unsafe_push_node({ flag(n2),n4 });
+          aw.unsafe_push_node({ n4,n5 });
+          aw.unsafe_push_node({ flag(n4),n5 });
 
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ n5,sink_F });
-                  aw.unsafe_push_sink({ flag(n5),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ n5,sink_F });
+          aw.unsafe_push_sink({ flag(n5),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                  aw.unsafe_push(create_level_info(3,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+          aw.unsafe_push(create_level_info(3,1u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(3,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(3,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can be applied together with reduction rule 2", [&]() {
-                /*
+      it("can be applied together with reduction rule 2", [&]() {
+        /*
                     1                  1     ---- x0
                    / \                / \
                    2 T                | T    ---- x1
@@ -924,68 +924,68 @@ go_bandit([]() {
                   3 4                 4      ---- x2
                   |X|                / \
                   F T                F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1,n2 });
-                  aw.unsafe_push_node({ n2,n3 });
-                  aw.unsafe_push_node({ flag(n2),n4 });
+          aw.unsafe_push_node({ n1,n2 });
+          aw.unsafe_push_node({ n2,n3 });
+          aw.unsafe_push_node({ flag(n2),n4 });
 
-                  aw.unsafe_push_sink({ flag(n1),sink_T });
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ n4,sink_F });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ flag(n1),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ n4,sink_F });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n4
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n4
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can reduce the root", [&]() {
-                /*
+      it("can reduce the root", [&]() {
+        /*
                    1                         ---- x0
                   / \
                   | 2                        ---- x1
@@ -993,227 +993,227 @@ go_bandit([]() {
                   3 4                 4      ---- x2
                   |X|                / \
                   F T                F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n3 });
-                  aw.unsafe_push_node({ flag(n2),n4 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n3 });
+          aw.unsafe_push_node({ flag(n2),n4 });
 
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ n4,sink_F });
-                  aw.unsafe_push_sink({ flag(n4),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ n4,sink_F });
+          aw.unsafe_push_sink({ flag(n4),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n4
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n4
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can apply reduction rule 1 to a single node", [&]() {
-                /*
+      it("can apply reduction rule 1 to a single node", [&]() {
+        /*
                    1                 F       ---- x0
                   / \      =>
                   F F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n1 = create_node_ptr(0,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_sink({ n1,sink_F });
-                  aw.unsafe_push_sink({ flag(n1),sink_F });
+          aw.unsafe_push_sink({ n1,sink_F });
+          aw.unsafe_push_sink({ flag(n1),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // F
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // F
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        level_info_test_stream<node_t, 1> out_meta(out);
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can propagate reduction rule 1 up to a sink", [&]() {
-                /*
+      it("can propagate reduction rule 1 up to a sink", [&]() {
+        /*
                    1                  T
                   / \
                   | 2         =>
                   |/ \
                   T  T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ flag(n1),n2 });
 
-                  aw.unsafe_push_sink({ n1,sink_T });
-                  aw.unsafe_push_sink({ n2,sink_T });
-                  aw.unsafe_push_sink({ flag(n2),sink_T });
+          aw.unsafe_push_sink({ n1,sink_T });
+          aw.unsafe_push_sink({ n2,sink_T });
+          aw.unsafe_push_sink({ flag(n2),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        level_info_test_stream<node_t, 1> out_meta(out);
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can return non-reducible single-node variable with MAX_ID", [&]() {
-                /*
+      it("can return non-reducible single-node variable with MAX_ID", [&]() {
+        /*
                    1                 1       ---- x0
                   / \      =>       / \
                   F T               F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n1 = create_node_ptr(0,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_sink({ n1,sink_F });
-                  aw.unsafe_push_sink({ flag(n1),sink_T });
+          aw.unsafe_push_sink({ n1,sink_F });
+          aw.unsafe_push_sink({ flag(n1),sink_T });
 
-                  aw.unsafe_push(create_level_info(0u,1u));
-                }
+          aw.unsafe_push(create_level_info(0u,1u));
+        }
 
-                // Reduce it
-                bdd out = reduce<bdd_policy>(in);
+        // Reduce it
+        bdd out = reduce<bdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-          });
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0u,1u)));
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
+    });
 
-        describe("Reduction Rule 1: ZDD", [&]() {
-            it("applies to sink arcs", [&]() {
-                /*
+    describe("Reduction Rule 1: ZDD", [&]() {
+      it("applies to sink arcs", [&]() {
+        /*
                    1                  1     ---- x0
                   / \                / \
                   | 2         =>     T T    ---- x1
                   |/ \
                   T  F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ flag(n1),n2 });
 
-                  aw.unsafe_push_sink({ n1,sink_T });
-                  aw.unsafe_push_sink({ n2,sink_T });
-                  aw.unsafe_push_sink({ flag(n2),sink_F });
+          aw.unsafe_push_sink({ n1,sink_T });
+          aw.unsafe_push_sink({ n2,sink_T });
+          aw.unsafe_push_sink({ flag(n2),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID, sink_T, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID, sink_T, sink_T)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to node arcs", [&]() {
-                /*
+      it("applies to node arcs", [&]() {
+        /*
                     1                  1        ---- x0
                    / \                / \
                    | 2                | 2       ---- x1
@@ -1223,87 +1223,87 @@ go_bandit([]() {
                   F T 5 F            F T  5     ---- x3
                      / \                 / \
                      F T                 F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(2,0);
-                ptr_t n4 = create_node_ptr(2,1);
-                ptr_t n5 = create_node_ptr(3,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(2,0);
+        ptr_t n4 = create_node_ptr(2,1);
+        ptr_t n5 = create_node_ptr(3,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
-                  aw.unsafe_push_node({ n1,n3 });
-                  aw.unsafe_push_node({ n2,n3 });
-                  aw.unsafe_push_node({ flag(n2),n4 });
-                  aw.unsafe_push_node({ n4,n5 });
+          aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ n1,n3 });
+          aw.unsafe_push_node({ n2,n3 });
+          aw.unsafe_push_node({ flag(n2),n4 });
+          aw.unsafe_push_node({ n4,n5 });
 
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ flag(n3),sink_T });
-                  aw.unsafe_push_sink({ flag(n4),sink_F });
-                  aw.unsafe_push_sink({ n5,sink_F });
-                  aw.unsafe_push_sink({ flag(n5),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ flag(n3),sink_T });
+          aw.unsafe_push_sink({ flag(n4),sink_F });
+          aw.unsafe_push_sink({ n5,sink_F });
+          aw.unsafe_push_sink({ flag(n5),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                  aw.unsafe_push(create_level_info(2,2u));
-                  aw.unsafe_push(create_level_info(3,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+          aw.unsafe_push(create_level_info(2,2u));
+          aw.unsafe_push(create_level_info(3,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n5
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n5
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(3,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(3,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(2,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(2,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can be applied together with reduction rule 2", [&]() {
-                /*
+      it("can be applied together with reduction rule 2", [&]() {
+        /*
                       1                  1     ---- x0
                      / \                ||
                     2   3                3     ---- x1
@@ -1311,234 +1311,234 @@ go_bandit([]() {
                    F T F 4              F T
                         / \
                         T F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
-                ptr_t n3 = create_node_ptr(1,1);
-                ptr_t n4 = create_node_ptr(2,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n3 = create_node_ptr(1,1);
+        ptr_t n4 = create_node_ptr(2,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1,n2 });
-                  aw.unsafe_push_node({ flag(n1),n3 });
-                  aw.unsafe_push_node({ flag(n3),n4 });
+          aw.unsafe_push_node({ n1,n2 });
+          aw.unsafe_push_node({ flag(n1),n3 });
+          aw.unsafe_push_node({ flag(n3),n4 });
 
-                  aw.unsafe_push_sink({ n2,sink_F });
-                  aw.unsafe_push_sink({ flag(n2),sink_T });
-                  aw.unsafe_push_sink({ n3,sink_F });
-                  aw.unsafe_push_sink({ n4,sink_T });
-                  aw.unsafe_push_sink({ flag(n4),sink_F });
+          aw.unsafe_push_sink({ n2,sink_F });
+          aw.unsafe_push_sink({ flag(n2),sink_T });
+          aw.unsafe_push_sink({ n3,sink_F });
+          aw.unsafe_push_sink({ n4,sink_T });
+          aw.unsafe_push_sink({ flag(n4),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,2u));
-                  aw.unsafe_push(create_level_info(2,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,2u));
+          aw.unsafe_push(create_level_info(2,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n3
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                                      sink_F,
-                                                                      sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().True());
+        // n3
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                              sink_F,
+                                                              sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n1
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                      create_node_ptr(1,MAX_ID),
-                                                                      create_node_ptr(1,MAX_ID))));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                              create_node_ptr(1,MAX_ID),
+                                                              create_node_ptr(1,MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("applies to a single node", [&]() {
-                /*
+      it("applies to a single node", [&]() {
+        /*
                    1                 T       ---- x0
                   / \      =>
                   T F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n1 = create_node_ptr(0,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_sink({ n1,sink_T });
-                  aw.unsafe_push_sink({ flag(n1),sink_F });
+          aw.unsafe_push_sink({ n1,sink_T });
+          aw.unsafe_push_sink({ flag(n1),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // F
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // F
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        level_info_test_stream<node_t, 1> out_meta(out);
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can reduce the root", [&]() {
-                /*
+      it("can reduce the root", [&]() {
+        /*
                     1                        ---- x0
                    / \
                    2 F        =>      2      ---- x1
                   / \                / \
                   F T                F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ n1,n2 });
+          aw.unsafe_push_node({ n1,n2 });
 
-                  aw.unsafe_push_sink({ flag(n1),sink_F });
-                  aw.unsafe_push_sink({ n2,sink_F });
-                  aw.unsafe_push_sink({ flag(n2),sink_T });
+          aw.unsafe_push_sink({ flag(n1),sink_F });
+          aw.unsafe_push_sink({ n2,sink_F });
+          aw.unsafe_push_sink({ flag(n2),sink_T });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.can_pull(), Is().True());
 
-                // n2
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        // n2
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(1, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can propagate reduction rule 1 up to a sink", [&]() {
-                /*
+      it("can propagate reduction rule 1 up to a sink", [&]() {
+        /*
                    1                  F
                   / \
                   | 2         =>
                   |/ \
                   F  F
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(0,0);
-                ptr_t n2 = create_node_ptr(1,0);
+        ptr_t n1 = create_node_ptr(0,0);
+        ptr_t n2 = create_node_ptr(1,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_node({ flag(n1),n2 });
+          aw.unsafe_push_node({ flag(n1),n2 });
 
-                  aw.unsafe_push_sink({ n1,sink_F });
-                  aw.unsafe_push_sink({ n2,sink_F });
-                  aw.unsafe_push_sink({ flag(n2),sink_F });
+          aw.unsafe_push_sink({ n1,sink_F });
+          aw.unsafe_push_sink({ n2,sink_F });
+          aw.unsafe_push_sink({ flag(n2),sink_F });
 
-                  aw.unsafe_push(create_level_info(0,1u));
-                  aw.unsafe_push(create_level_info(1,1u));
-                }
+          aw.unsafe_push(create_level_info(0,1u));
+          aw.unsafe_push(create_level_info(1,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
+        level_info_test_stream<node_t, 1> out_meta(out);
+        AssertThat(out_meta.can_pull(), Is().False());
+      });
 
-            it("can return non-reducible single-node variable with MAX_ID", [&]() {
-                /*
+      it("can return non-reducible single-node variable with MAX_ID", [&]() {
+        /*
                    1                 1       ---- x42
                   / \      =>       / \
                   F T               F T
-                */
+        */
 
-                ptr_t n1 = create_node_ptr(42,0);
+        ptr_t n1 = create_node_ptr(42,0);
 
-                arc_file in;
+        arc_file in;
 
-                { // Garbage collect writer to free write-lock
-                  arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-                  aw.unsafe_push_sink({ n1,sink_F });
-                  aw.unsafe_push_sink({ flag(n1),sink_T });
+          aw.unsafe_push_sink({ n1,sink_F });
+          aw.unsafe_push_sink({ flag(n1),sink_T });
 
-                  aw.unsafe_push(create_level_info(42,1u));
-                }
+          aw.unsafe_push(create_level_info(42,1u));
+        }
 
-                // Reduce it
-                zdd out = reduce<zdd_policy>(in);
+        // Reduce it
+        zdd out = reduce<zdd_policy>(in);
 
-                AssertThat(is_canonical(out), Is().True());
+        AssertThat(is_canonical(out), Is().True());
 
-                // Check it looks all right
-                node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                level_info_test_stream<node_t, 1> out_meta(out);
+        level_info_test_stream<node_t, 1> out_meta(out);
 
-                AssertThat(out_meta.can_pull(), Is().True());
-                AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(42u,1u)));
-                AssertThat(out_meta.can_pull(), Is().False());
-              });
-          });
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(create_level_info(42u,1u)));
+        AssertThat(out_meta.can_pull(), Is().False());
       });
+    });
   });
+ });

--- a/test/adiar/test_data.cpp
+++ b/test/adiar/test_data.cpp
@@ -1,897 +1,897 @@
 go_bandit([]() {
-    describe("CORE: Data types", []() {
-
-        describe("Nil", [&](){
-            it("should recognise Nil (unflagged)", [&]() {
-                auto some_value = NIL;
-                AssertThat(is_nil(some_value), Is().True());
-              });
-
-            it("should recognise Nil (flagged)", [&]() {
-                auto some_value = flag(NIL);
-                AssertThat(is_nil(some_value), Is().True());
-              });
-
-
-            it("can see whether the flag is set", [&]() {
-                AssertThat(is_flagged(flag(NIL)), Is().True());
-              });
-
-            it("can see whether the flag is not set", [&]() {
-                AssertThat(is_flagged(NIL), Is().False());
-              });
-          });
-
-        describe("Sink Ptr", [&](){
-            it("should store and retrieve value", [&]() {
-                ptr_t p = create_sink_ptr(true);
-                AssertThat(value_of(p), Is().True());
-
-                p = create_sink_ptr(false);
-                AssertThat(value_of(p), Is().False());
-              });
-
-            it("should recognise Sinks as such", [&]() {
-                ptr_t sink_f = create_sink_ptr(false);
-                ptr_t sink_t = create_sink_ptr(true);
-
-                AssertThat(is_sink(sink_f), Is().True());
-                AssertThat(is_sink(sink_t), Is().True());
-              });
-
-            it("should not be confused with Node Ptr (unflagged)", [&]() {
-                ptr_t arc_node_max = create_node_ptr(MAX_LABEL,MAX_ID);
-                AssertThat(is_sink(arc_node_max), Is().False());
-
-                ptr_t arc_node_min = create_node_ptr(0,0);
-                AssertThat(is_sink(arc_node_min), Is().False());
-
-                ptr_t arc_node = create_node_ptr(42,18);
-                AssertThat(is_sink(arc_node), Is().False());
-              });
-
-            it("should not be confused with Node Ptr (flagged)", [&]() {
-                ptr_t arc_node_max = flag(create_node_ptr(MAX_LABEL,MAX_ID));
-                AssertThat(is_sink(arc_node_max), Is().False());
-
-                ptr_t arc_node_min = flag(create_node_ptr(0,0));
-                AssertThat(is_sink(arc_node_min), Is().False());
-
-                ptr_t arc_node = flag(create_node_ptr(42,18));
-                AssertThat(is_sink(arc_node), Is().False());
-              });
-
-            it("can see whether the flag is set", [&]() {
-                ptr_t p = flag(create_sink_ptr(false));
-                AssertThat(is_flagged(p), Is().True());
-
-                p = flag(create_sink_ptr(false));
-                AssertThat(is_flagged(p), Is().True());
-              });
-
-            it("can see whether the flag is not set", [&]() {
-                ptr_t p = create_sink_ptr(true);
-                AssertThat(is_flagged(p), Is().False());
-
-                p = create_sink_ptr(false);
-                AssertThat(is_flagged(p), Is().False());
-              });
-
-            it("should not be confused with Nil (unflagged)", [&]() {
-                AssertThat(is_sink(NIL), Is().False());
-              });
-
-            it("should not be confused with Nil (flagged)", [&]() {
-                AssertThat(is_sink(flag(NIL)), Is().False());
-              });
-
-            it("should negate sink (unflagged)", [&]() {
-                ptr_t p1 = create_sink_ptr(false);
-                AssertThat(negate(p1), Is().EqualTo(create_sink_ptr(true)));
-
-                ptr_t p2 = create_sink_ptr(true);
-                AssertThat(negate(p2), Is().EqualTo(create_sink_ptr(false)));
-              });
-
-            it("should negate sink into sink (flagged)", [&]() {
-                 ptr_t p1 = flag(create_sink_ptr(false));
-                 AssertThat(negate(p1), Is().EqualTo(flag(create_sink_ptr(true))));
-
-                 ptr_t p2 = flag(create_sink_ptr(true));
-                 AssertThat(negate(p2), Is().EqualTo(flag(create_sink_ptr(false))));
-              });
-
-            it("should take up 8 bytes of memory", [&]() {
-                ptr_t sink = create_sink_ptr(false);
-                AssertThat(sizeof(sink), Is().EqualTo(8u));
-              });
-
-            describe("predicates", []() {
-                ptr_t sink_T = create_sink_ptr(true);
-                ptr_t sink_F = create_sink_ptr(false);
-
-                it("should accept T sink with is_true and is_any", [&]() {
-                    AssertThat(is_true(sink_T), Is().True());
-                    AssertThat(is_any(sink_T), Is().True());
-                  });
-
-                it("should reject T sink with is_false", [&]() {
-                    AssertThat(is_false(sink_T), Is().False());
-                  });
-
-                it("should accept F sink with is_false and is_any", [&]() {
-                    AssertThat(is_false(sink_F), Is().True());
-                    AssertThat(is_any(sink_F), Is().True());
-                  });
-
-                it("should reject F sink with is_true", [&]() {
-                    AssertThat(is_true(sink_F), Is().False());
-                  });
-              });
-
-            describe("operators", [&]() {
-                it("AND", [&]() {
-                    AssertThat(and_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(and_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(and_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(and_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                  });
-
-                it("NAND", [&]() {
-                    AssertThat(nand_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(nand_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(nand_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(nand_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("OR", [&]() {
-                    AssertThat(or_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(or_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(or_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(or_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                  });
-
-                it("NOR", [&]() {
-                    AssertThat(nor_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(nor_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(nor_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(nor_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("XOR", [&]() {
-                    AssertThat(xor_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(xor_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(xor_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(xor_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                  });
-
-                it("XNOR", [&]() {
-                    AssertThat(xnor_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(xnor_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(xnor_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(xnor_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("IMP", [&]() {
-                    AssertThat(imp_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(imp_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(imp_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(imp_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("INVIMP", [&]() {
-                    AssertThat(invimp_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(invimp_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(invimp_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(invimp_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("EQUIV", [&]() {
-                    AssertThat(equiv_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(equiv_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(equiv_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(equiv_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("EQUIV (flags)", [&]() {
-                    AssertThat(equiv_op(flag(create_sink_ptr(true)), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(equiv_op(create_sink_ptr(true), flag(create_sink_ptr(false))),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(equiv_op(flag(create_sink_ptr(false)), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(equiv_op(create_sink_ptr(false), flag(create_sink_ptr(false))),
-                               Is().EqualTo(create_sink_ptr(true)));
-                  });
-
-                it("DIFF", [&]() {
-                    AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(diff_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(diff_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                  });
-
-                it("LESS", [&]() {
-                    AssertThat(less_op(create_sink_ptr(true), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(less_op(create_sink_ptr(true), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                    AssertThat(less_op(create_sink_ptr(false), create_sink_ptr(true)),
-                               Is().EqualTo(create_sink_ptr(true)));
-                    AssertThat(less_op(create_sink_ptr(false), create_sink_ptr(false)),
-                               Is().EqualTo(create_sink_ptr(false)));
-                  });
-              });
-
-            describe("operator predicates", []() {
-                describe("can_shortcut", []() {
-                    it("can check on T sink on the left", [&]() {
-                        AssertThat(can_left_shortcut(and_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(can_left_shortcut(or_op, create_sink_ptr(true)), Is().True());
-                        AssertThat(can_left_shortcut(xor_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(can_left_shortcut(imp_op, create_sink_ptr(true)), Is().False());
-                      });
-
-                    it("can check on F sink on the left", [&]() {
-                        AssertThat(can_left_shortcut(and_op, create_sink_ptr(false)), Is().True());
-                        AssertThat(can_left_shortcut(or_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(can_left_shortcut(xor_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(can_left_shortcut(imp_op, create_sink_ptr(false)), Is().True());
-                      });
-
-                    it("can check on T sink on the right", [&]() {
-                        AssertThat(can_right_shortcut(and_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(can_right_shortcut(or_op, create_sink_ptr(true)), Is().True());
-                        AssertThat(can_right_shortcut(xor_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(can_right_shortcut(imp_op, create_sink_ptr(true)), Is().True());
-                      });
-
-                    it("can check on F sink on the right", [&]() {
-                        AssertThat(can_right_shortcut(and_op, create_sink_ptr(false)), Is().True());
-                        AssertThat(can_right_shortcut(or_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(can_right_shortcut(xor_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(can_right_shortcut(imp_op, create_sink_ptr(false)), Is().False());
-                      });
-                  });
-
-                describe("is_irrelevant", []() {
-                    it("can check on T sink on the left", [&]() {
-                        AssertThat(is_left_irrelevant(and_op, create_sink_ptr(true)), Is().True());
-                        AssertThat(is_left_irrelevant(or_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_left_irrelevant(xor_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_left_irrelevant(imp_op, create_sink_ptr(true)), Is().True());
-                      });
-
-                    it("can check on F sink on the left", [&]() {
-                        AssertThat(is_left_irrelevant(and_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_left_irrelevant(or_op, create_sink_ptr(false)), Is().True());
-                        AssertThat(is_left_irrelevant(xor_op, create_sink_ptr(false)), Is().True());
-                        AssertThat(is_left_irrelevant(imp_op, create_sink_ptr(false)), Is().False());
-                      });
-
-                    it("can check on T sink on the right", [&]() {
-                        AssertThat(is_right_irrelevant(and_op, create_sink_ptr(true)), Is().True());
-                        AssertThat(is_right_irrelevant(or_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_right_irrelevant(xor_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_right_irrelevant(imp_op, create_sink_ptr(true)), Is().False());
-                      });
-
-                    it("can check on F sink on the right", [&]() {
-                        AssertThat(is_right_irrelevant(and_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_right_irrelevant(or_op, create_sink_ptr(false)), Is().True());
-                        AssertThat(is_right_irrelevant(xor_op, create_sink_ptr(false)), Is().True());
-                        AssertThat(is_right_irrelevant(imp_op, create_sink_ptr(false)), Is().False());
-                      });
-                  });
-
-                describe("is_negating", []() {
-                    it("can check on T sink on the left", [&]() {
-                        AssertThat(is_left_negating(and_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_left_negating(or_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_left_negating(xor_op, create_sink_ptr(true)), Is().True());
-                        AssertThat(is_left_negating(imp_op, create_sink_ptr(true)), Is().False());
-                      });
-
-                    it("can check on F sink on the left", [&]() {
-                        AssertThat(is_left_negating(and_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_left_negating(or_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_left_negating(xor_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_left_negating(imp_op, create_sink_ptr(false)), Is().False());
-                      });
-
-                    it("can check on T sink on the right", [&]() {
-                        AssertThat(is_right_negating(and_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_right_negating(or_op, create_sink_ptr(true)), Is().False());
-                        AssertThat(is_right_negating(xor_op, create_sink_ptr(true)), Is().True());
-                        AssertThat(is_right_negating(imp_op, create_sink_ptr(true)), Is().False());
-                      });
-
-                    it("can check on F sink on the right", [&]() {
-                        AssertThat(is_right_negating(and_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_right_negating(or_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_right_negating(xor_op, create_sink_ptr(false)), Is().False());
-                        AssertThat(is_right_negating(imp_op, create_sink_ptr(false)), Is().False());
-                      });
-                  });
-
-                it("can check the operators for being commutative", [&]() {
-                    AssertThat(is_commutative(and_op), Is().True());
-                    AssertThat(is_commutative(nand_op), Is().True());
-                    AssertThat(is_commutative(or_op), Is().True());
-                    AssertThat(is_commutative(nor_op), Is().True());
-                    AssertThat(is_commutative(xor_op), Is().True());
-                    AssertThat(is_commutative(imp_op), Is().False());
-                    AssertThat(is_commutative(invimp_op), Is().False());
-                    AssertThat(is_commutative(equiv_op), Is().True());
-                    AssertThat(is_commutative(diff_op), Is().False());
-                    AssertThat(is_commutative(diff_op), Is().False());
-                  });
-              });
-          });
-
-        describe("Node Ptr", [&]() {
-            it("should store and retrieve label for Ptr with maximal id (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(12,MAX_ID);
-                AssertThat(label_of(p), Is().EqualTo(12u));
-              });
-
-            it("should store and retrieve 42 label Ptr (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(42,2);
-                AssertThat(label_of(p), Is().EqualTo(42u));
-              });
-
-            it("should store and retrieve 21 label Ptr (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(21,2);
-                AssertThat(label_of(p), Is().EqualTo(21u));
-              });
-
-            it("should store and retrieve MAX label Ptr (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
-                AssertThat(label_of(p), Is().EqualTo(MAX_LABEL));
-              });
-
-            it("should store and retrieve label for Ptr with maximal id (flagged)", [&]() {
-                ptr_t p = flag(create_node_ptr(12,MAX_ID));
-                AssertThat(label_of(p), Is().EqualTo(12u));
-              });
-
-            it("should store and retrieve 42 label Ptr (flagged)", [&]() {
-                ptr_t p = flag(create_node_ptr(42,2));
-                AssertThat(label_of(p), Is().EqualTo(42u));
-              });
-
-            it("should store and retrieve 21 label Ptr (flagged)", [&]() {
-                ptr_t p = flag(create_node_ptr(21,2));
-                AssertThat(label_of(p), Is().EqualTo(21u));
-              });
-
-            it("should store and retrieve MAX label Ptr (flagged)", [&]() {
-                ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
-                AssertThat(label_of(p), Is().EqualTo(MAX_LABEL));
-              });
-
-            it("should store and retrieve 42 id (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(2,42);
-                AssertThat(id_of(p), Is().EqualTo(42u));
-              });
-
-            it("should store and retrieve 21 id (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(2,21);
-                AssertThat(id_of(p), Is().EqualTo(21u));
-              });
-
-            it("should store and retrieve MAX id (unflagged)", [&]() {
-                ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
-                AssertThat(id_of(p), Is().EqualTo(MAX_ID));
-              });
-
-            it("should store and retrieve 42 id (flagged)", [&]() {
-                ptr_t p = flag(create_node_ptr(2,42));
-                AssertThat(id_of(p), Is().EqualTo(42u));
-              });
-
-            it("should store and retrieve 21 id (flagged)", [&]() {
-                ptr_t p = flag(create_node_ptr(2,21));
-                AssertThat(id_of(p), Is().EqualTo(21u));
-              });
-
-            it("should store and retrieve MAX id (flagged)", [&]() {
-                ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
-                AssertThat(id_of(p), Is().EqualTo(MAX_ID));
-              });
-
-            it("should create uid without being flagged", [&]() {
-                adiar::uid_t n_uid = create_node_uid(53, 4);
-                AssertThat(is_flagged(n_uid), Is().False());
-
-                n_uid = create_node_uid(42, 9);
-                AssertThat(is_flagged(n_uid), Is().False());
-              });
-
-            it("should sort Sink arcs after Node Ptr (unflagged)", [&]() {
-                // Create a node pointer with the highest possible raw value
-                ptr_t p_node = create_node_ptr(MAX_LABEL,MAX_ID);
-
-                // Create a sink pointer with the lowest raw value
-                ptr_t p_sink = create_sink_ptr(false);
-
-                AssertThat(p_node < p_sink, Is().True());
-                AssertThat(flag(p_node) < p_sink, Is().True());
-              });
-
-            it("should sort Sink arcs after Node Ptr (flagged)", [&]() {
-                // Create a node pointer with the highest possible raw value
-                ptr_t p_node = flag(create_node_ptr(MAX_LABEL,MAX_ID));
-
-                // Create a sink pointer with the lowest raw value
-                ptr_t p_sink = create_sink_ptr(false);
-
-                AssertThat(p_node < p_sink, Is().True());
-                AssertThat(flag(p_node) < p_sink, Is().True());
-              });
-
-            it("should recognise Node Ptr (unflagged)", [&]() {
-                ptr_t p_node_max = create_node_ptr(MAX_LABEL,MAX_ID);
-                AssertThat(is_node(p_node_max), Is().True());
-
-                ptr_t p_node_min = create_node_ptr(0,0);
-                AssertThat(is_node(p_node_min), Is().True());
-
-                ptr_t p_node = create_node_ptr(42,18);
-                AssertThat(is_node(p_node), Is().True());
-              });
-
-            it("should recognise Node Ptr (flagged)", [&]() {
-                ptr_t p_node_max = flag(create_node_ptr(MAX_LABEL,MAX_ID));
-                AssertThat(is_node(p_node_max), Is().True());
-
-                ptr_t p_node_min = flag(create_node_ptr(0,0));
-                AssertThat(is_node(p_node_min), Is().True());
-
-                ptr_t p_node = flag(create_node_ptr(42,18));
-                AssertThat(is_node(p_node), Is().True());
-              });
-
-            it("should not be confused with Sinks", [&]() {
-                ptr_t sink_f = create_sink_ptr(false);
-                ptr_t sink_t = create_sink_ptr(true);
-
-                AssertThat(is_node(sink_f), Is().False());
-                AssertThat(is_node(sink_t), Is().False());
-              });
-
-            it("should not be confused with Nil (unflagged)", [&]() {
-                AssertThat(is_node(NIL), Is().False());
-              });
-
-            it("should not be confused with Nil (flagged)", [&]() {
-                AssertThat(is_node(flag(NIL)), Is().False());
-              });
-
-            it("can recognise the flag is set", [&]() {
-                ptr_t p = flag(create_node_ptr(42,2));
-                AssertThat(is_flagged(p), Is().True());
-
-                p = flag(create_node_ptr(17,3));
-                AssertThat(is_flagged(p), Is().True());
-              });
-
-            it("can recognise the flag is not set", [&]() {
-                ptr_t p = create_node_ptr(42,2);
-                AssertThat(is_flagged(p), Is().False());
-
-                p = create_node_ptr(17,3);
-                AssertThat(is_flagged(p), Is().False());
-              });
-
-            it("should sort by label, then by id", [&]() {
-                auto node_1_2 = create_node_ptr(1,2);
-                auto node_2_1 = create_node_ptr(2,1);
-                auto node_2_2 = create_node_ptr(2,2);
-
-                AssertThat(node_1_2 < node_2_1, Is().True());
-                AssertThat(node_2_1 < node_2_2, Is().True());
-              });
-
-            it("should take up 8 bytes of memory", [&]() {
-                auto node_ptr = create_node_ptr(42,2);
-                AssertThat(sizeof(node_ptr), Is().EqualTo(8u));
-              });
-          });
-
-        describe("Nodes", [&]() {
-            it("should create node", [&]() {
-                auto sink_f = create_sink_ptr(false);
-                auto sink_t = create_sink_ptr(true);
-
-                // Test create_node(label, id, ptr, ptr)
-                auto n1 = create_node(3,12,sink_f,sink_t);
-                AssertThat(n1.uid, Is().EqualTo(create_node_ptr(3,12)));
-                AssertThat(label_of(n1), Is().EqualTo(3u));
-                AssertThat(id_of(n1), Is().EqualTo(12u));
-
-                AssertThat(n1.low, Is().EqualTo(sink_f));
-                AssertThat(n1.high, Is().EqualTo(sink_t));
-
-                auto n2 = create_node(3,42,sink_t,sink_f);
-                AssertThat(n2.uid, Is().EqualTo(create_node_ptr(3,42)));
-                AssertThat(label_of(n2), Is().EqualTo(3u));
-                AssertThat(id_of(n2), Is().EqualTo(42u));
-
-                AssertThat(n2.low, Is().EqualTo(sink_t));
-                AssertThat(n2.high, Is().EqualTo(sink_f));
-
-                // Test create_node(label, id, node&, node&)
-                auto n3 = create_node(2,2,n1,n2);
-                AssertThat(n3.uid, Is().EqualTo(create_node_ptr(2,2)));
-                AssertThat(label_of(n3), Is().EqualTo(2u));
-                AssertThat(id_of(n3), Is().EqualTo(2u));
-
-                AssertThat(n3.low, Is().EqualTo(n1.uid));
-                AssertThat(n3.high, Is().EqualTo(n2.uid));
-
-                // Test create_node(label, ptr, node&)
-                auto n4 = create_node(1,7,sink_t,n3);
-                AssertThat(n4.uid, Is().EqualTo(create_node_ptr(1,7)));
-                AssertThat(label_of(n4), Is().EqualTo(1u));
-                AssertThat(id_of(n4), Is().EqualTo(7u));
-
-                AssertThat(n4.low, Is().EqualTo(sink_t));
-                AssertThat(n4.high, Is().EqualTo(n3.uid));
-
-                // Test create_node(label, ptr, node&)
-                auto n5 = create_node(0,3,sink_t,n4);
-                AssertThat(n5.uid, Is().EqualTo(create_node_ptr(0,3)));
-                AssertThat(label_of(n5), Is().EqualTo(0u));
-                AssertThat(id_of(n5), Is().EqualTo(3u));
-
-                AssertThat(n5.low, Is().EqualTo(sink_t));
-                AssertThat(n5.high, Is().EqualTo(n4.uid));
-              });
-
-            it("should sort by label, then by id", [&]() {
-                auto sink_f = create_sink_ptr(false);
-                auto sink_t = create_sink_ptr(true);
-
-                auto node_1_2 = create_node(1,2,sink_f,sink_t);
-                auto node_2_1 = create_node(2,1,sink_t,sink_f);
-
-                AssertThat(node_1_2 < node_2_1, Is().True());
-                AssertThat(node_2_1 > node_1_2, Is().True());
-
-                auto node_2_2 = create_node(2,2,sink_f,sink_f);
-
-                AssertThat(node_2_1 < node_2_2, Is().True());
-                AssertThat(node_2_2 > node_2_1, Is().True());
-              });
-
-            it("should be equal by their content", [&]() {
-                auto sink_f = create_sink_ptr(false);
-                auto sink_t = create_sink_ptr(true);
-
-                auto node_1_v1 = create_node(42,2,sink_f,sink_t);
-                auto node_1_v2 = create_node(42,2,sink_f,sink_t);
-
-                AssertThat(node_1_v1 == node_1_v2, Is().True());
-                AssertThat(node_1_v1 != node_1_v2, Is().False());
-              });
-
-            it("should be unequal by their content", [&]() {
-                auto sink_f = create_sink_ptr(false);
-                auto sink_t = create_sink_ptr(true);
-
-                auto node_1 = create_node(42,2,sink_f,sink_t);
-                auto node_2 = create_node(42,2,sink_f,sink_f);
-                auto node_3 = create_node(42,3,sink_f,sink_t);
-                auto node_4 = create_node(21,2,sink_f,sink_t);
-
-                AssertThat(node_1 == node_2, Is().False());
-                AssertThat(node_1 != node_2, Is().True());
-
-                AssertThat(node_1 == node_3, Is().False());
-                AssertThat(node_1 != node_3, Is().True());
-
-                AssertThat(node_1 == node_4, Is().False());
-                AssertThat(node_1 != node_4, Is().True());
-              });
-
-            it("should leave node_ptr children unchanged", [&]() {
-                auto node = create_node(2,2,
-                                        create_node_ptr(42,3),
-                                        create_node_ptr(8,2));
-
-                AssertThat(!node, Is().EqualTo(node));
-              });
-
-            it("should negate sink_ptr child", [&]() {
-                auto node = create_node(2,2,
-                                        create_sink_ptr(false),
-                                        create_node_ptr(8,2));
-
-                AssertThat(!node, Is().EqualTo(create_node(2,2,
-                                                           create_sink_ptr(true),
-                                                           create_node_ptr(8,2))));
-             });
-
-            it("should negate sink_ptr children", [&]() {
-                auto node = create_node(2,2,
-                                        create_sink_ptr(false),
-                                        flag(create_sink_ptr(true)));
-
-                AssertThat(!node, Is().EqualTo(create_node(2,2,
-                                                           create_sink_ptr(true),
-                                                           flag(create_sink_ptr(false)))));
-              });
-
-            it("should negate sink_ptr children", [&]() {
-                AssertThat(!create_sink(true), Is().EqualTo(create_sink(false)));
-                AssertThat(!create_sink(false), Is().EqualTo(create_sink(true)));
-              });
-
-            it("should be a POD", [&]() {
-                AssertThat(std::is_pod<node>::value, Is().True());
-              });
-
-            it("should take up 24 bytes of memory", [&]() {
-                ptr_t node_ptr = create_node_ptr(42,2);
-                ptr_t sink = create_sink_ptr(false);
-                node_t node = create_node(1,
-                                          8,
-                                          node_ptr,
-                                          sink);
-
-                AssertThat(sizeof(node), Is().EqualTo(3u * 8u));
-              });
-
-            describe("Sink nodes", [&]() {
-                it("should recognise sink nodes as such", [&]() {
-                    node_t sink_node_T = create_sink(true);
-                    AssertThat(is_sink(sink_node_T), Is().True());
-
-                    node_t sink_node_F = create_sink(false);
-                    AssertThat(is_sink(sink_node_F), Is().True());
-                  });
-
-                it("should recognise normal nodes not as sink nodes", [&]() {
-                    node_t node_1 = create_node(42,2,
-                                                create_sink_ptr(false),
-                                                create_sink_ptr(true));
-                    AssertThat(is_sink(node_1), Is().False());
-
-                    node_t node_2 = create_node(0,0,
-                                                create_sink_ptr(true),
-                                                node_1.uid);
-                    AssertThat(is_sink(node_2), Is().False());
-                  });
-
-                it("should retrive value of a sink node", [&]() {
-                    node_t sink_node_T = create_sink(true);
-                    AssertThat(value_of(sink_node_T), Is().True());
-
-                    node_t sink_node_F = create_sink(false);
-                    AssertThat(value_of(sink_node_F), Is().False());
-                  });
-              });
-          });
-
-        describe("Arcs", [&]() {
-            it("should be equal by their content", [&]() {
-                ptr_t source = create_node_ptr(4,2);
-                ptr_t target = create_node_ptr(42,3);
-
-                arc_t arc_1 = { source, target };
-                arc_t arc_2 = { source, target };
-
-                AssertThat(arc_1 == arc_2, Is().True());
-                AssertThat(arc_1 != arc_2, Is().False());
-              });
-
-            it("should unequal by their content", [&]() {
-                ptr_t node_ptr_1 = create_node_ptr(4,2);
-                ptr_t node_ptr_2 = create_node_ptr(4,3);
-                ptr_t node_ptr_3 = create_node_ptr(3,2);
-
-                arc_t arc_1 = { node_ptr_1, node_ptr_2 };
-                arc_t arc_2 = { node_ptr_1, node_ptr_3 };
-
-                AssertThat(arc_1 == arc_2, Is().False());
-                AssertThat(arc_1 != arc_2, Is().True());
-
-                arc_t arc_3 = { node_ptr_1, node_ptr_2 };
-                arc_t arc_4 = { flag(node_ptr_1), node_ptr_2 };
-
-                AssertThat(arc_3 == arc_4, Is().False());
-                AssertThat(arc_3 != arc_4, Is().True());
-
-                arc_t arc_5 = { node_ptr_1, node_ptr_2 };
-                arc_t arc_6 = { node_ptr_3, node_ptr_2 };
-
-                AssertThat(arc_5 == arc_6, Is().False());
-                AssertThat(arc_5 != arc_6, Is().True());
-              });
-
-            it("should recognise low arcs from bit-flag on source", [&]() {
-                ptr_t node_ptr_1 = create_node_ptr(4,2);
-                ptr_t node_ptr_2 = create_node_ptr(4,3);
-
-                arc_t arc_low = { node_ptr_1, node_ptr_2 };
-                AssertThat(is_high(arc_low), Is().False());
-              });
-
-            it("should recognise high arcs from bit-flag on source", [&]() {
-                ptr_t node_ptr_1 = create_node_ptr(4,2);
-                ptr_t node_ptr_2 = create_node_ptr(4,3);
-
-                arc_t arc_high = { flag(node_ptr_1), node_ptr_2 };
-                AssertThat(is_high(arc_high), Is().True());
-              });
-
-            it("should leave node_ptr target unchanged", [&]() {
-                arc_t a = { create_node_ptr(1,0), create_node_ptr(2,0) };
-                AssertThat(!a, Is().EqualTo(a));
-              });
-
-            it("should negate unflagged sink_ptr target", [&]() {
-                arc_t a = { create_node_ptr(1,0), create_sink_ptr(true) };
-                AssertThat(!a, Is().EqualTo(arc { create_node_ptr(1,0), create_sink_ptr(false) }));
-             });
-
-            it("should negate flagged sink_ptr target", [&]() {
-                arc_t a = { create_node_ptr(1,0), flag(create_sink_ptr(false)) };
-                AssertThat(!a, Is().EqualTo(arc { create_node_ptr(1,0), flag(create_sink_ptr(true)) }));
-              });
-
-            it("should be a POD", [&]() {
-                AssertThat(std::is_pod<arc_t>::value, Is().True());
-              });
-
-            it("should take up 16 bytes of memory", [&]() {
-                ptr_t node_ptr = create_node_ptr(42,2);
-                ptr_t sink = create_sink_ptr(false);
-                arc_t arc = { node_ptr, sink };
-
-                AssertThat(sizeof(arc), Is().EqualTo(2u * 8u));
-              });
-          });
-
-        describe("Converters", [&]() {
-            it("should extract low arc from node", [&]() {
-                node_t node = create_node(7,42,
-                                          create_node_ptr(8,21),
-                                          create_node_ptr(9,8));
-
-                arc_t arc = low_arc_of(node);
-
-                AssertThat(label_of(arc.source), Is().EqualTo(7u));
-                AssertThat(id_of(arc.source), Is().EqualTo(42u));
-                AssertThat(label_of(arc.target), Is().EqualTo(8u));
-                AssertThat(id_of(arc.target), Is().EqualTo(21u));
-              });
-
-            it("should extract high arc from node", [&]() {
-                node_t node = create_node(6,13,
-                                          create_node_ptr(8,21),
-                                          create_node_ptr(9,8));
-
-                arc_t arc = high_arc_of(node);
-
-                AssertThat(label_of(arc.source), Is().EqualTo(6u));
-                AssertThat(id_of(arc.source), Is().EqualTo(13u));
-                AssertThat(label_of(arc.target), Is().EqualTo(9u));
-                AssertThat(id_of(arc.target), Is().EqualTo(8u));
-              });
-
-            it("should combine low and high arcs into single node", [&]() {
-                arc_t low_arc = { create_node_ptr(17,42), create_node_ptr(9,8) };
-                arc_t high_arc = { flag(create_node_ptr(17,42)), create_node_ptr(8,21) };
-
-                node_t node = node_of(low_arc, high_arc);
-
-                AssertThat(label_of(node), Is().EqualTo(17u));
-                AssertThat(id_of(node), Is().EqualTo(42u));
-
-                AssertThat(label_of(node.low), Is().EqualTo(label_of(low_arc.target)));
-                AssertThat(id_of(node.low), Is().EqualTo(id_of(low_arc.target)));
-
-                AssertThat(label_of(node.high), Is().EqualTo(label_of(high_arc.target)));
-                AssertThat(id_of(node.high), Is().EqualTo(id_of(high_arc.target)));
-              });
-          });
-
-        describe("Assignment", [&]() {
-            assignment_t a1 = create_assignment(2, false);
-            assignment_t a2 = create_assignment(2, true);
-            assignment_t a3 = create_assignment(3, false);
-
-            it("is sorted first by label", [&]() {
-                // Less than
-                AssertThat(a1 < a3, Is().True());
-                AssertThat(a2 < a3, Is().True());
-                AssertThat(a3 < a1, Is().False());
-                AssertThat(a3 < a2, Is().False());
-
-                // Greater than
-                AssertThat(a3 > a1, Is().True());
-                AssertThat(a3 > a2, Is().True());
-                AssertThat(a1 > a3, Is().False());
-                AssertThat(a2 > a3, Is().False());
-            });
-
-            it("is not sorted by value second", [&]() {
-                // Less than
-                AssertThat(a1 < a2, Is().False());
-
-                // Greater than
-                AssertThat(a2 > a1, Is().False());
-              });
-
-            assignment_t b1 = create_assignment(2, false);
-            assignment_t b2 = create_assignment(2, true);
-            assignment_t b3 = create_assignment(3, false);
-
-            it("should be equal by content", [&]() {
-                AssertThat(a1 == b1, Is().True());
-                AssertThat(a2 == b2, Is().True());
-                AssertThat(a3 == b3, Is().True());
-                AssertThat(a2 == b1, Is().False());
-                AssertThat(a3 == b1, Is().False());
-                AssertThat(a3 == b2, Is().False());
-              });
-
-            it("should be equal by content", [&]() {
-                AssertThat(a2 != b1, Is().True());
-                AssertThat(a3 != b1, Is().True());
-                AssertThat(a3 != b2, Is().True());
-                AssertThat(a1 != b1, Is().False());
-                AssertThat(a2 != b2, Is().False());
-                AssertThat(a3 != b3, Is().False());
-              });
-
-            it("can be negated on its value", [&]() {
-                AssertThat(!a1, Is().EqualTo(create_assignment(2, true)));
-                AssertThat(!a2, Is().EqualTo(create_assignment(2, false)));
-                AssertThat(!a3, Is().EqualTo(create_assignment(3, true)));
-              });
-          });
+  describe("CORE: Data types", []() {
+
+    describe("Nil", [&](){
+      it("should recognise Nil (unflagged)", [&]() {
+        auto some_value = NIL;
+        AssertThat(is_nil(some_value), Is().True());
       });
+
+      it("should recognise Nil (flagged)", [&]() {
+        auto some_value = flag(NIL);
+        AssertThat(is_nil(some_value), Is().True());
+      });
+
+
+      it("can see whether the flag is set", [&]() {
+        AssertThat(is_flagged(flag(NIL)), Is().True());
+      });
+
+      it("can see whether the flag is not set", [&]() {
+        AssertThat(is_flagged(NIL), Is().False());
+      });
+    });
+
+    describe("Sink Ptr", [&](){
+      it("should store and retrieve value", [&]() {
+        ptr_t p = create_sink_ptr(true);
+        AssertThat(value_of(p), Is().True());
+
+        p = create_sink_ptr(false);
+        AssertThat(value_of(p), Is().False());
+      });
+
+      it("should recognise Sinks as such", [&]() {
+        ptr_t sink_f = create_sink_ptr(false);
+        ptr_t sink_t = create_sink_ptr(true);
+
+        AssertThat(is_sink(sink_f), Is().True());
+        AssertThat(is_sink(sink_t), Is().True());
+      });
+
+      it("should not be confused with Node Ptr (unflagged)", [&]() {
+        ptr_t arc_node_max = create_node_ptr(MAX_LABEL,MAX_ID);
+        AssertThat(is_sink(arc_node_max), Is().False());
+
+        ptr_t arc_node_min = create_node_ptr(0,0);
+        AssertThat(is_sink(arc_node_min), Is().False());
+
+        ptr_t arc_node = create_node_ptr(42,18);
+        AssertThat(is_sink(arc_node), Is().False());
+      });
+
+      it("should not be confused with Node Ptr (flagged)", [&]() {
+        ptr_t arc_node_max = flag(create_node_ptr(MAX_LABEL,MAX_ID));
+        AssertThat(is_sink(arc_node_max), Is().False());
+
+        ptr_t arc_node_min = flag(create_node_ptr(0,0));
+        AssertThat(is_sink(arc_node_min), Is().False());
+
+        ptr_t arc_node = flag(create_node_ptr(42,18));
+        AssertThat(is_sink(arc_node), Is().False());
+      });
+
+      it("can see whether the flag is set", [&]() {
+        ptr_t p = flag(create_sink_ptr(false));
+        AssertThat(is_flagged(p), Is().True());
+
+        p = flag(create_sink_ptr(false));
+        AssertThat(is_flagged(p), Is().True());
+      });
+
+      it("can see whether the flag is not set", [&]() {
+        ptr_t p = create_sink_ptr(true);
+        AssertThat(is_flagged(p), Is().False());
+
+        p = create_sink_ptr(false);
+        AssertThat(is_flagged(p), Is().False());
+      });
+
+      it("should not be confused with Nil (unflagged)", [&]() {
+        AssertThat(is_sink(NIL), Is().False());
+      });
+
+      it("should not be confused with Nil (flagged)", [&]() {
+        AssertThat(is_sink(flag(NIL)), Is().False());
+      });
+
+      it("should negate sink (unflagged)", [&]() {
+        ptr_t p1 = create_sink_ptr(false);
+        AssertThat(negate(p1), Is().EqualTo(create_sink_ptr(true)));
+
+        ptr_t p2 = create_sink_ptr(true);
+        AssertThat(negate(p2), Is().EqualTo(create_sink_ptr(false)));
+      });
+
+      it("should negate sink into sink (flagged)", [&]() {
+        ptr_t p1 = flag(create_sink_ptr(false));
+        AssertThat(negate(p1), Is().EqualTo(flag(create_sink_ptr(true))));
+
+        ptr_t p2 = flag(create_sink_ptr(true));
+        AssertThat(negate(p2), Is().EqualTo(flag(create_sink_ptr(false))));
+      });
+
+      it("should take up 8 bytes of memory", [&]() {
+        ptr_t sink = create_sink_ptr(false);
+        AssertThat(sizeof(sink), Is().EqualTo(8u));
+      });
+
+      describe("predicates", []() {
+        ptr_t sink_T = create_sink_ptr(true);
+        ptr_t sink_F = create_sink_ptr(false);
+
+        it("should accept T sink with is_true and is_any", [&]() {
+          AssertThat(is_true(sink_T), Is().True());
+          AssertThat(is_any(sink_T), Is().True());
+        });
+
+        it("should reject T sink with is_false", [&]() {
+          AssertThat(is_false(sink_T), Is().False());
+        });
+
+        it("should accept F sink with is_false and is_any", [&]() {
+          AssertThat(is_false(sink_F), Is().True());
+          AssertThat(is_any(sink_F), Is().True());
+        });
+
+        it("should reject F sink with is_true", [&]() {
+          AssertThat(is_true(sink_F), Is().False());
+        });
+      });
+
+      describe("operators", [&]() {
+        it("AND", [&]() {
+          AssertThat(and_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(and_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(and_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(and_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+        });
+
+        it("NAND", [&]() {
+          AssertThat(nand_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(nand_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(nand_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(nand_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("OR", [&]() {
+          AssertThat(or_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(or_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(or_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(or_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+        });
+
+        it("NOR", [&]() {
+          AssertThat(nor_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(nor_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(nor_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(nor_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("XOR", [&]() {
+          AssertThat(xor_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(xor_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(xor_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(xor_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+        });
+
+        it("XNOR", [&]() {
+          AssertThat(xnor_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(xnor_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(xnor_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(xnor_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("IMP", [&]() {
+          AssertThat(imp_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(imp_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(imp_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(imp_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("INVIMP", [&]() {
+          AssertThat(invimp_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(invimp_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(invimp_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(invimp_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("EQUIV", [&]() {
+          AssertThat(equiv_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(equiv_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(equiv_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(equiv_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("EQUIV (flags)", [&]() {
+          AssertThat(equiv_op(flag(create_sink_ptr(true)), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(equiv_op(create_sink_ptr(true), flag(create_sink_ptr(false))),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(equiv_op(flag(create_sink_ptr(false)), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(equiv_op(create_sink_ptr(false), flag(create_sink_ptr(false))),
+                     Is().EqualTo(create_sink_ptr(true)));
+        });
+
+        it("DIFF", [&]() {
+          AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(diff_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(diff_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(diff_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+        });
+
+        it("LESS", [&]() {
+          AssertThat(less_op(create_sink_ptr(true), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(less_op(create_sink_ptr(true), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+          AssertThat(less_op(create_sink_ptr(false), create_sink_ptr(true)),
+                     Is().EqualTo(create_sink_ptr(true)));
+          AssertThat(less_op(create_sink_ptr(false), create_sink_ptr(false)),
+                     Is().EqualTo(create_sink_ptr(false)));
+        });
+      });
+
+      describe("operator predicates", []() {
+        describe("can_shortcut", []() {
+          it("can check on T sink on the left", [&]() {
+            AssertThat(can_left_shortcut(and_op, create_sink_ptr(true)), Is().False());
+            AssertThat(can_left_shortcut(or_op, create_sink_ptr(true)), Is().True());
+            AssertThat(can_left_shortcut(xor_op, create_sink_ptr(true)), Is().False());
+            AssertThat(can_left_shortcut(imp_op, create_sink_ptr(true)), Is().False());
+          });
+
+          it("can check on F sink on the left", [&]() {
+            AssertThat(can_left_shortcut(and_op, create_sink_ptr(false)), Is().True());
+            AssertThat(can_left_shortcut(or_op, create_sink_ptr(false)), Is().False());
+            AssertThat(can_left_shortcut(xor_op, create_sink_ptr(false)), Is().False());
+            AssertThat(can_left_shortcut(imp_op, create_sink_ptr(false)), Is().True());
+          });
+
+          it("can check on T sink on the right", [&]() {
+            AssertThat(can_right_shortcut(and_op, create_sink_ptr(true)), Is().False());
+            AssertThat(can_right_shortcut(or_op, create_sink_ptr(true)), Is().True());
+            AssertThat(can_right_shortcut(xor_op, create_sink_ptr(true)), Is().False());
+            AssertThat(can_right_shortcut(imp_op, create_sink_ptr(true)), Is().True());
+          });
+
+          it("can check on F sink on the right", [&]() {
+            AssertThat(can_right_shortcut(and_op, create_sink_ptr(false)), Is().True());
+            AssertThat(can_right_shortcut(or_op, create_sink_ptr(false)), Is().False());
+            AssertThat(can_right_shortcut(xor_op, create_sink_ptr(false)), Is().False());
+            AssertThat(can_right_shortcut(imp_op, create_sink_ptr(false)), Is().False());
+          });
+        });
+
+        describe("is_irrelevant", []() {
+          it("can check on T sink on the left", [&]() {
+            AssertThat(is_left_irrelevant(and_op, create_sink_ptr(true)), Is().True());
+            AssertThat(is_left_irrelevant(or_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_left_irrelevant(xor_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_left_irrelevant(imp_op, create_sink_ptr(true)), Is().True());
+          });
+
+          it("can check on F sink on the left", [&]() {
+            AssertThat(is_left_irrelevant(and_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_left_irrelevant(or_op, create_sink_ptr(false)), Is().True());
+            AssertThat(is_left_irrelevant(xor_op, create_sink_ptr(false)), Is().True());
+            AssertThat(is_left_irrelevant(imp_op, create_sink_ptr(false)), Is().False());
+          });
+
+          it("can check on T sink on the right", [&]() {
+            AssertThat(is_right_irrelevant(and_op, create_sink_ptr(true)), Is().True());
+            AssertThat(is_right_irrelevant(or_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_right_irrelevant(xor_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_right_irrelevant(imp_op, create_sink_ptr(true)), Is().False());
+          });
+
+          it("can check on F sink on the right", [&]() {
+            AssertThat(is_right_irrelevant(and_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_right_irrelevant(or_op, create_sink_ptr(false)), Is().True());
+            AssertThat(is_right_irrelevant(xor_op, create_sink_ptr(false)), Is().True());
+            AssertThat(is_right_irrelevant(imp_op, create_sink_ptr(false)), Is().False());
+          });
+        });
+
+        describe("is_negating", []() {
+          it("can check on T sink on the left", [&]() {
+            AssertThat(is_left_negating(and_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_left_negating(or_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_left_negating(xor_op, create_sink_ptr(true)), Is().True());
+            AssertThat(is_left_negating(imp_op, create_sink_ptr(true)), Is().False());
+          });
+
+          it("can check on F sink on the left", [&]() {
+            AssertThat(is_left_negating(and_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_left_negating(or_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_left_negating(xor_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_left_negating(imp_op, create_sink_ptr(false)), Is().False());
+          });
+
+          it("can check on T sink on the right", [&]() {
+            AssertThat(is_right_negating(and_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_right_negating(or_op, create_sink_ptr(true)), Is().False());
+            AssertThat(is_right_negating(xor_op, create_sink_ptr(true)), Is().True());
+            AssertThat(is_right_negating(imp_op, create_sink_ptr(true)), Is().False());
+          });
+
+          it("can check on F sink on the right", [&]() {
+            AssertThat(is_right_negating(and_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_right_negating(or_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_right_negating(xor_op, create_sink_ptr(false)), Is().False());
+            AssertThat(is_right_negating(imp_op, create_sink_ptr(false)), Is().False());
+          });
+        });
+
+        it("can check the operators for being commutative", [&]() {
+          AssertThat(is_commutative(and_op), Is().True());
+          AssertThat(is_commutative(nand_op), Is().True());
+          AssertThat(is_commutative(or_op), Is().True());
+          AssertThat(is_commutative(nor_op), Is().True());
+          AssertThat(is_commutative(xor_op), Is().True());
+          AssertThat(is_commutative(imp_op), Is().False());
+          AssertThat(is_commutative(invimp_op), Is().False());
+          AssertThat(is_commutative(equiv_op), Is().True());
+          AssertThat(is_commutative(diff_op), Is().False());
+          AssertThat(is_commutative(diff_op), Is().False());
+        });
+      });
+    });
+
+    describe("Node Ptr", [&]() {
+      it("should store and retrieve label for Ptr with maximal id (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(12,MAX_ID);
+        AssertThat(label_of(p), Is().EqualTo(12u));
+      });
+
+      it("should store and retrieve 42 label Ptr (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(42,2);
+        AssertThat(label_of(p), Is().EqualTo(42u));
+      });
+
+      it("should store and retrieve 21 label Ptr (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(21,2);
+        AssertThat(label_of(p), Is().EqualTo(21u));
+      });
+
+      it("should store and retrieve MAX label Ptr (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
+        AssertThat(label_of(p), Is().EqualTo(MAX_LABEL));
+      });
+
+      it("should store and retrieve label for Ptr with maximal id (flagged)", [&]() {
+        ptr_t p = flag(create_node_ptr(12,MAX_ID));
+        AssertThat(label_of(p), Is().EqualTo(12u));
+      });
+
+      it("should store and retrieve 42 label Ptr (flagged)", [&]() {
+        ptr_t p = flag(create_node_ptr(42,2));
+        AssertThat(label_of(p), Is().EqualTo(42u));
+      });
+
+      it("should store and retrieve 21 label Ptr (flagged)", [&]() {
+        ptr_t p = flag(create_node_ptr(21,2));
+        AssertThat(label_of(p), Is().EqualTo(21u));
+      });
+
+      it("should store and retrieve MAX label Ptr (flagged)", [&]() {
+        ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
+        AssertThat(label_of(p), Is().EqualTo(MAX_LABEL));
+      });
+
+      it("should store and retrieve 42 id (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(2,42);
+        AssertThat(id_of(p), Is().EqualTo(42u));
+      });
+
+      it("should store and retrieve 21 id (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(2,21);
+        AssertThat(id_of(p), Is().EqualTo(21u));
+      });
+
+      it("should store and retrieve MAX id (unflagged)", [&]() {
+        ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
+        AssertThat(id_of(p), Is().EqualTo(MAX_ID));
+      });
+
+      it("should store and retrieve 42 id (flagged)", [&]() {
+        ptr_t p = flag(create_node_ptr(2,42));
+        AssertThat(id_of(p), Is().EqualTo(42u));
+      });
+
+      it("should store and retrieve 21 id (flagged)", [&]() {
+        ptr_t p = flag(create_node_ptr(2,21));
+        AssertThat(id_of(p), Is().EqualTo(21u));
+      });
+
+      it("should store and retrieve MAX id (flagged)", [&]() {
+        ptr_t p = create_node_ptr(MAX_LABEL, MAX_ID);
+        AssertThat(id_of(p), Is().EqualTo(MAX_ID));
+      });
+
+      it("should create uid without being flagged", [&]() {
+        adiar::uid_t n_uid = create_node_uid(53, 4);
+        AssertThat(is_flagged(n_uid), Is().False());
+
+        n_uid = create_node_uid(42, 9);
+        AssertThat(is_flagged(n_uid), Is().False());
+      });
+
+      it("should sort Sink arcs after Node Ptr (unflagged)", [&]() {
+        // Create a node pointer with the highest possible raw value
+        ptr_t p_node = create_node_ptr(MAX_LABEL,MAX_ID);
+
+        // Create a sink pointer with the lowest raw value
+        ptr_t p_sink = create_sink_ptr(false);
+
+        AssertThat(p_node < p_sink, Is().True());
+        AssertThat(flag(p_node) < p_sink, Is().True());
+      });
+
+      it("should sort Sink arcs after Node Ptr (flagged)", [&]() {
+        // Create a node pointer with the highest possible raw value
+        ptr_t p_node = flag(create_node_ptr(MAX_LABEL,MAX_ID));
+
+        // Create a sink pointer with the lowest raw value
+        ptr_t p_sink = create_sink_ptr(false);
+
+        AssertThat(p_node < p_sink, Is().True());
+        AssertThat(flag(p_node) < p_sink, Is().True());
+      });
+
+      it("should recognise Node Ptr (unflagged)", [&]() {
+        ptr_t p_node_max = create_node_ptr(MAX_LABEL,MAX_ID);
+        AssertThat(is_node(p_node_max), Is().True());
+
+        ptr_t p_node_min = create_node_ptr(0,0);
+        AssertThat(is_node(p_node_min), Is().True());
+
+        ptr_t p_node = create_node_ptr(42,18);
+        AssertThat(is_node(p_node), Is().True());
+      });
+
+      it("should recognise Node Ptr (flagged)", [&]() {
+        ptr_t p_node_max = flag(create_node_ptr(MAX_LABEL,MAX_ID));
+        AssertThat(is_node(p_node_max), Is().True());
+
+        ptr_t p_node_min = flag(create_node_ptr(0,0));
+        AssertThat(is_node(p_node_min), Is().True());
+
+        ptr_t p_node = flag(create_node_ptr(42,18));
+        AssertThat(is_node(p_node), Is().True());
+      });
+
+      it("should not be confused with Sinks", [&]() {
+        ptr_t sink_f = create_sink_ptr(false);
+        ptr_t sink_t = create_sink_ptr(true);
+
+        AssertThat(is_node(sink_f), Is().False());
+        AssertThat(is_node(sink_t), Is().False());
+      });
+
+      it("should not be confused with Nil (unflagged)", [&]() {
+        AssertThat(is_node(NIL), Is().False());
+      });
+
+      it("should not be confused with Nil (flagged)", [&]() {
+        AssertThat(is_node(flag(NIL)), Is().False());
+      });
+
+      it("can recognise the flag is set", [&]() {
+        ptr_t p = flag(create_node_ptr(42,2));
+        AssertThat(is_flagged(p), Is().True());
+
+        p = flag(create_node_ptr(17,3));
+        AssertThat(is_flagged(p), Is().True());
+      });
+
+      it("can recognise the flag is not set", [&]() {
+        ptr_t p = create_node_ptr(42,2);
+        AssertThat(is_flagged(p), Is().False());
+
+        p = create_node_ptr(17,3);
+        AssertThat(is_flagged(p), Is().False());
+      });
+
+      it("should sort by label, then by id", [&]() {
+        auto node_1_2 = create_node_ptr(1,2);
+        auto node_2_1 = create_node_ptr(2,1);
+        auto node_2_2 = create_node_ptr(2,2);
+
+        AssertThat(node_1_2 < node_2_1, Is().True());
+        AssertThat(node_2_1 < node_2_2, Is().True());
+      });
+
+      it("should take up 8 bytes of memory", [&]() {
+        auto node_ptr = create_node_ptr(42,2);
+        AssertThat(sizeof(node_ptr), Is().EqualTo(8u));
+      });
+    });
+
+    describe("Nodes", [&]() {
+      it("should create node", [&]() {
+        auto sink_f = create_sink_ptr(false);
+        auto sink_t = create_sink_ptr(true);
+
+        // Test create_node(label, id, ptr, ptr)
+        auto n1 = create_node(3,12,sink_f,sink_t);
+        AssertThat(n1.uid, Is().EqualTo(create_node_ptr(3,12)));
+        AssertThat(label_of(n1), Is().EqualTo(3u));
+        AssertThat(id_of(n1), Is().EqualTo(12u));
+
+        AssertThat(n1.low, Is().EqualTo(sink_f));
+        AssertThat(n1.high, Is().EqualTo(sink_t));
+
+        auto n2 = create_node(3,42,sink_t,sink_f);
+        AssertThat(n2.uid, Is().EqualTo(create_node_ptr(3,42)));
+        AssertThat(label_of(n2), Is().EqualTo(3u));
+        AssertThat(id_of(n2), Is().EqualTo(42u));
+
+        AssertThat(n2.low, Is().EqualTo(sink_t));
+        AssertThat(n2.high, Is().EqualTo(sink_f));
+
+        // Test create_node(label, id, node&, node&)
+        auto n3 = create_node(2,2,n1,n2);
+        AssertThat(n3.uid, Is().EqualTo(create_node_ptr(2,2)));
+        AssertThat(label_of(n3), Is().EqualTo(2u));
+        AssertThat(id_of(n3), Is().EqualTo(2u));
+
+        AssertThat(n3.low, Is().EqualTo(n1.uid));
+        AssertThat(n3.high, Is().EqualTo(n2.uid));
+
+        // Test create_node(label, ptr, node&)
+        auto n4 = create_node(1,7,sink_t,n3);
+        AssertThat(n4.uid, Is().EqualTo(create_node_ptr(1,7)));
+        AssertThat(label_of(n4), Is().EqualTo(1u));
+        AssertThat(id_of(n4), Is().EqualTo(7u));
+
+        AssertThat(n4.low, Is().EqualTo(sink_t));
+        AssertThat(n4.high, Is().EqualTo(n3.uid));
+
+        // Test create_node(label, ptr, node&)
+        auto n5 = create_node(0,3,sink_t,n4);
+        AssertThat(n5.uid, Is().EqualTo(create_node_ptr(0,3)));
+        AssertThat(label_of(n5), Is().EqualTo(0u));
+        AssertThat(id_of(n5), Is().EqualTo(3u));
+
+        AssertThat(n5.low, Is().EqualTo(sink_t));
+        AssertThat(n5.high, Is().EqualTo(n4.uid));
+      });
+
+      it("should sort by label, then by id", [&]() {
+        auto sink_f = create_sink_ptr(false);
+        auto sink_t = create_sink_ptr(true);
+
+        auto node_1_2 = create_node(1,2,sink_f,sink_t);
+        auto node_2_1 = create_node(2,1,sink_t,sink_f);
+
+        AssertThat(node_1_2 < node_2_1, Is().True());
+        AssertThat(node_2_1 > node_1_2, Is().True());
+
+        auto node_2_2 = create_node(2,2,sink_f,sink_f);
+
+        AssertThat(node_2_1 < node_2_2, Is().True());
+        AssertThat(node_2_2 > node_2_1, Is().True());
+      });
+
+      it("should be equal by their content", [&]() {
+        auto sink_f = create_sink_ptr(false);
+        auto sink_t = create_sink_ptr(true);
+
+        auto node_1_v1 = create_node(42,2,sink_f,sink_t);
+        auto node_1_v2 = create_node(42,2,sink_f,sink_t);
+
+        AssertThat(node_1_v1 == node_1_v2, Is().True());
+        AssertThat(node_1_v1 != node_1_v2, Is().False());
+      });
+
+      it("should be unequal by their content", [&]() {
+        auto sink_f = create_sink_ptr(false);
+        auto sink_t = create_sink_ptr(true);
+
+        auto node_1 = create_node(42,2,sink_f,sink_t);
+        auto node_2 = create_node(42,2,sink_f,sink_f);
+        auto node_3 = create_node(42,3,sink_f,sink_t);
+        auto node_4 = create_node(21,2,sink_f,sink_t);
+
+        AssertThat(node_1 == node_2, Is().False());
+        AssertThat(node_1 != node_2, Is().True());
+
+        AssertThat(node_1 == node_3, Is().False());
+        AssertThat(node_1 != node_3, Is().True());
+
+        AssertThat(node_1 == node_4, Is().False());
+        AssertThat(node_1 != node_4, Is().True());
+      });
+
+      it("should leave node_ptr children unchanged", [&]() {
+        auto node = create_node(2,2,
+                                create_node_ptr(42,3),
+                                create_node_ptr(8,2));
+
+        AssertThat(!node, Is().EqualTo(node));
+      });
+
+      it("should negate sink_ptr child", [&]() {
+        auto node = create_node(2,2,
+                                create_sink_ptr(false),
+                                create_node_ptr(8,2));
+
+        AssertThat(!node, Is().EqualTo(create_node(2,2,
+                                                   create_sink_ptr(true),
+                                                   create_node_ptr(8,2))));
+      });
+
+      it("should negate sink_ptr children", [&]() {
+        auto node = create_node(2,2,
+                                create_sink_ptr(false),
+                                flag(create_sink_ptr(true)));
+
+        AssertThat(!node, Is().EqualTo(create_node(2,2,
+                                                   create_sink_ptr(true),
+                                                   flag(create_sink_ptr(false)))));
+      });
+
+      it("should negate sink_ptr children", [&]() {
+        AssertThat(!create_sink(true), Is().EqualTo(create_sink(false)));
+        AssertThat(!create_sink(false), Is().EqualTo(create_sink(true)));
+      });
+
+      it("should be a POD", [&]() {
+        AssertThat(std::is_pod<node>::value, Is().True());
+      });
+
+      it("should take up 24 bytes of memory", [&]() {
+        ptr_t node_ptr = create_node_ptr(42,2);
+        ptr_t sink = create_sink_ptr(false);
+        node_t node = create_node(1,
+                                  8,
+                                  node_ptr,
+                                  sink);
+
+        AssertThat(sizeof(node), Is().EqualTo(3u * 8u));
+      });
+
+      describe("Sink nodes", [&]() {
+        it("should recognise sink nodes as such", [&]() {
+          node_t sink_node_T = create_sink(true);
+          AssertThat(is_sink(sink_node_T), Is().True());
+
+          node_t sink_node_F = create_sink(false);
+          AssertThat(is_sink(sink_node_F), Is().True());
+        });
+
+        it("should recognise normal nodes not as sink nodes", [&]() {
+          node_t node_1 = create_node(42,2,
+                                      create_sink_ptr(false),
+                                      create_sink_ptr(true));
+          AssertThat(is_sink(node_1), Is().False());
+
+          node_t node_2 = create_node(0,0,
+                                      create_sink_ptr(true),
+                                      node_1.uid);
+          AssertThat(is_sink(node_2), Is().False());
+        });
+
+        it("should retrive value of a sink node", [&]() {
+          node_t sink_node_T = create_sink(true);
+          AssertThat(value_of(sink_node_T), Is().True());
+
+          node_t sink_node_F = create_sink(false);
+          AssertThat(value_of(sink_node_F), Is().False());
+        });
+      });
+    });
+
+    describe("Arcs", [&]() {
+      it("should be equal by their content", [&]() {
+        ptr_t source = create_node_ptr(4,2);
+        ptr_t target = create_node_ptr(42,3);
+
+        arc_t arc_1 = { source, target };
+        arc_t arc_2 = { source, target };
+
+        AssertThat(arc_1 == arc_2, Is().True());
+        AssertThat(arc_1 != arc_2, Is().False());
+      });
+
+      it("should unequal by their content", [&]() {
+        ptr_t node_ptr_1 = create_node_ptr(4,2);
+        ptr_t node_ptr_2 = create_node_ptr(4,3);
+        ptr_t node_ptr_3 = create_node_ptr(3,2);
+
+        arc_t arc_1 = { node_ptr_1, node_ptr_2 };
+        arc_t arc_2 = { node_ptr_1, node_ptr_3 };
+
+        AssertThat(arc_1 == arc_2, Is().False());
+        AssertThat(arc_1 != arc_2, Is().True());
+
+        arc_t arc_3 = { node_ptr_1, node_ptr_2 };
+        arc_t arc_4 = { flag(node_ptr_1), node_ptr_2 };
+
+        AssertThat(arc_3 == arc_4, Is().False());
+        AssertThat(arc_3 != arc_4, Is().True());
+
+        arc_t arc_5 = { node_ptr_1, node_ptr_2 };
+        arc_t arc_6 = { node_ptr_3, node_ptr_2 };
+
+        AssertThat(arc_5 == arc_6, Is().False());
+        AssertThat(arc_5 != arc_6, Is().True());
+      });
+
+      it("should recognise low arcs from bit-flag on source", [&]() {
+        ptr_t node_ptr_1 = create_node_ptr(4,2);
+        ptr_t node_ptr_2 = create_node_ptr(4,3);
+
+        arc_t arc_low = { node_ptr_1, node_ptr_2 };
+        AssertThat(is_high(arc_low), Is().False());
+      });
+
+      it("should recognise high arcs from bit-flag on source", [&]() {
+        ptr_t node_ptr_1 = create_node_ptr(4,2);
+        ptr_t node_ptr_2 = create_node_ptr(4,3);
+
+        arc_t arc_high = { flag(node_ptr_1), node_ptr_2 };
+        AssertThat(is_high(arc_high), Is().True());
+      });
+
+      it("should leave node_ptr target unchanged", [&]() {
+        arc_t a = { create_node_ptr(1,0), create_node_ptr(2,0) };
+        AssertThat(!a, Is().EqualTo(a));
+      });
+
+      it("should negate unflagged sink_ptr target", [&]() {
+        arc_t a = { create_node_ptr(1,0), create_sink_ptr(true) };
+        AssertThat(!a, Is().EqualTo(arc { create_node_ptr(1,0), create_sink_ptr(false) }));
+      });
+
+      it("should negate flagged sink_ptr target", [&]() {
+        arc_t a = { create_node_ptr(1,0), flag(create_sink_ptr(false)) };
+        AssertThat(!a, Is().EqualTo(arc { create_node_ptr(1,0), flag(create_sink_ptr(true)) }));
+      });
+
+      it("should be a POD", [&]() {
+        AssertThat(std::is_pod<arc_t>::value, Is().True());
+      });
+
+      it("should take up 16 bytes of memory", [&]() {
+        ptr_t node_ptr = create_node_ptr(42,2);
+        ptr_t sink = create_sink_ptr(false);
+        arc_t arc = { node_ptr, sink };
+
+        AssertThat(sizeof(arc), Is().EqualTo(2u * 8u));
+      });
+    });
+
+    describe("Converters", [&]() {
+      it("should extract low arc from node", [&]() {
+        node_t node = create_node(7,42,
+                                  create_node_ptr(8,21),
+                                  create_node_ptr(9,8));
+
+        arc_t arc = low_arc_of(node);
+
+        AssertThat(label_of(arc.source), Is().EqualTo(7u));
+        AssertThat(id_of(arc.source), Is().EqualTo(42u));
+        AssertThat(label_of(arc.target), Is().EqualTo(8u));
+        AssertThat(id_of(arc.target), Is().EqualTo(21u));
+      });
+
+      it("should extract high arc from node", [&]() {
+        node_t node = create_node(6,13,
+                                  create_node_ptr(8,21),
+                                  create_node_ptr(9,8));
+
+        arc_t arc = high_arc_of(node);
+
+        AssertThat(label_of(arc.source), Is().EqualTo(6u));
+        AssertThat(id_of(arc.source), Is().EqualTo(13u));
+        AssertThat(label_of(arc.target), Is().EqualTo(9u));
+        AssertThat(id_of(arc.target), Is().EqualTo(8u));
+      });
+
+      it("should combine low and high arcs into single node", [&]() {
+        arc_t low_arc = { create_node_ptr(17,42), create_node_ptr(9,8) };
+        arc_t high_arc = { flag(create_node_ptr(17,42)), create_node_ptr(8,21) };
+
+        node_t node = node_of(low_arc, high_arc);
+
+        AssertThat(label_of(node), Is().EqualTo(17u));
+        AssertThat(id_of(node), Is().EqualTo(42u));
+
+        AssertThat(label_of(node.low), Is().EqualTo(label_of(low_arc.target)));
+        AssertThat(id_of(node.low), Is().EqualTo(id_of(low_arc.target)));
+
+        AssertThat(label_of(node.high), Is().EqualTo(label_of(high_arc.target)));
+        AssertThat(id_of(node.high), Is().EqualTo(id_of(high_arc.target)));
+      });
+    });
+
+    describe("Assignment", [&]() {
+      assignment_t a1 = create_assignment(2, false);
+      assignment_t a2 = create_assignment(2, true);
+      assignment_t a3 = create_assignment(3, false);
+
+      it("is sorted first by label", [&]() {
+        // Less than
+        AssertThat(a1 < a3, Is().True());
+        AssertThat(a2 < a3, Is().True());
+        AssertThat(a3 < a1, Is().False());
+        AssertThat(a3 < a2, Is().False());
+
+        // Greater than
+        AssertThat(a3 > a1, Is().True());
+        AssertThat(a3 > a2, Is().True());
+        AssertThat(a1 > a3, Is().False());
+        AssertThat(a2 > a3, Is().False());
+      });
+
+      it("is not sorted by value second", [&]() {
+        // Less than
+        AssertThat(a1 < a2, Is().False());
+
+        // Greater than
+        AssertThat(a2 > a1, Is().False());
+      });
+
+      assignment_t b1 = create_assignment(2, false);
+      assignment_t b2 = create_assignment(2, true);
+      assignment_t b3 = create_assignment(3, false);
+
+      it("should be equal by content", [&]() {
+        AssertThat(a1 == b1, Is().True());
+        AssertThat(a2 == b2, Is().True());
+        AssertThat(a3 == b3, Is().True());
+        AssertThat(a2 == b1, Is().False());
+        AssertThat(a3 == b1, Is().False());
+        AssertThat(a3 == b2, Is().False());
+      });
+
+      it("should be equal by content", [&]() {
+        AssertThat(a2 != b1, Is().True());
+        AssertThat(a3 != b1, Is().True());
+        AssertThat(a3 != b2, Is().True());
+        AssertThat(a1 != b1, Is().False());
+        AssertThat(a2 != b2, Is().False());
+        AssertThat(a3 != b3, Is().False());
+      });
+
+      it("can be negated on its value", [&]() {
+        AssertThat(!a1, Is().EqualTo(create_assignment(2, true)));
+        AssertThat(!a2, Is().EqualTo(create_assignment(2, false)));
+        AssertThat(!a3, Is().EqualTo(create_assignment(3, true)));
+      });
+    });
   });
+ });

--- a/test/adiar/test_dot.cpp
+++ b/test/adiar/test_dot.cpp
@@ -1,50 +1,50 @@
 go_bandit([]() {
-    describe("DEBUG: DOT Files", [&]() {
-        it("can output .dot for a sink-only BDD", [&]() {
-          bdd sink_T = bdd_sink(true);
-          output_dot(sink_T, "dot_test_sink.dot");
-          int exit_value = system("dot -O -Tpng dot_test_sink.dot");
-          AssertThat(exit_value, Is().EqualTo(0));
-        });
-
-        it("can output .dot for a reduced BDD with internal nodes", [&]() {
-          node_file reduced_bdd;
-
-          { // Garbage collect writer early
-            node_writer rw(reduced_bdd);
-
-            rw << create_node(42,1, create_sink_ptr(false), create_sink_ptr(true))
-               << create_node(42,0, create_sink_ptr(true), create_sink_ptr(false))
-               << create_node(1,2, create_node_ptr(42,0), create_node_ptr(42,1))
-               << create_node(0,1, create_node_ptr(1,2), create_sink_ptr(false))
-              ;
-          }
-
-          output_dot(reduced_bdd, "dot_test_reduced.dot");
-          int exit_value = system("dot -O -Tpng dot_test_reduced.dot");
-          AssertThat(exit_value, Is().EqualTo(0));
-        });
-
-        it("can output a reduced BDD with internal nodes", [&]() {
-          arc_file unreduced_bdd;
-
-          { // Garbage collect writer early
-            arc_writer uw(unreduced_bdd);
-
-            uw.unsafe_push_sink({ flag(create_node_ptr(2,0)), create_sink_ptr(true) });
-            uw.unsafe_push_sink({ create_node_ptr(2,0), create_sink_ptr(true) });
-            uw.unsafe_push_sink({ create_node_ptr(1,1), create_sink_ptr(true) });
-
-            uw.unsafe_push_node({ create_node_ptr(0,0), create_node_ptr(1,0) });
-            uw.unsafe_push_node({ create_node_ptr(0,0), create_node_ptr(1,1) });
-            uw.unsafe_push_node({ create_node_ptr(1,0), create_node_ptr(2,0) });
-            uw.unsafe_push_node({ flag(create_node_ptr(1,0)), create_node_ptr(2,0) });
-            uw.unsafe_push_node({ flag(create_node_ptr(1,1)), create_node_ptr(2,0) });
-          }
-
-          output_dot(unreduced_bdd, "dot_test_unreduced.dot");
-          int exit_value = system("dot -O -Tpng dot_test_unreduced.dot");
-          AssertThat(exit_value, Is().EqualTo(0));
-        });
+  describe("DEBUG: DOT Files", [&]() {
+    it("can output .dot for a sink-only BDD", [&]() {
+      bdd sink_T = bdd_sink(true);
+      output_dot(sink_T, "dot_test_sink.dot");
+      int exit_value = system("dot -O -Tpng dot_test_sink.dot");
+      AssertThat(exit_value, Is().EqualTo(0));
     });
-});
+
+    it("can output .dot for a reduced BDD with internal nodes", [&]() {
+      node_file reduced_bdd;
+
+      { // Garbage collect writer early
+        node_writer rw(reduced_bdd);
+
+        rw << create_node(42,1, create_sink_ptr(false), create_sink_ptr(true))
+           << create_node(42,0, create_sink_ptr(true), create_sink_ptr(false))
+           << create_node(1,2, create_node_ptr(42,0), create_node_ptr(42,1))
+           << create_node(0,1, create_node_ptr(1,2), create_sink_ptr(false))
+          ;
+      }
+
+      output_dot(reduced_bdd, "dot_test_reduced.dot");
+      int exit_value = system("dot -O -Tpng dot_test_reduced.dot");
+      AssertThat(exit_value, Is().EqualTo(0));
+    });
+
+    it("can output a reduced BDD with internal nodes", [&]() {
+      arc_file unreduced_bdd;
+
+      { // Garbage collect writer early
+        arc_writer uw(unreduced_bdd);
+
+        uw.unsafe_push_sink({ flag(create_node_ptr(2,0)), create_sink_ptr(true) });
+        uw.unsafe_push_sink({ create_node_ptr(2,0), create_sink_ptr(true) });
+        uw.unsafe_push_sink({ create_node_ptr(1,1), create_sink_ptr(true) });
+
+        uw.unsafe_push_node({ create_node_ptr(0,0), create_node_ptr(1,0) });
+        uw.unsafe_push_node({ create_node_ptr(0,0), create_node_ptr(1,1) });
+        uw.unsafe_push_node({ create_node_ptr(1,0), create_node_ptr(2,0) });
+        uw.unsafe_push_node({ flag(create_node_ptr(1,0)), create_node_ptr(2,0) });
+        uw.unsafe_push_node({ flag(create_node_ptr(1,1)), create_node_ptr(2,0) });
+      }
+
+      output_dot(unreduced_bdd, "dot_test_unreduced.dot");
+      int exit_value = system("dot -O -Tpng dot_test_unreduced.dot");
+      AssertThat(exit_value, Is().EqualTo(0));
+    });
+  });
+ });

--- a/test/adiar/test_file.cpp
+++ b/test/adiar/test_file.cpp
@@ -94,7 +94,7 @@ go_bandit([]() {
                   fw.unsafe_push(21);
                   fw.unsafe_push(42);
 
-                  fw.unsafe_push(create_meta(0,2u));
+                  fw.unsafe_push(create_level_info(0,2u));
 
                   AssertThat(test_file_meta_1.is_read_only(), Is().False());
                 });
@@ -103,8 +103,8 @@ go_bandit([]() {
                 it("can hook into and write to test_file_meta_2", [&]() {
                   meta_file_writer<int,2> fw(test_file_meta_2);
 
-                  fw.unsafe_push(create_meta(5,1u));
-                  fw.unsafe_push(create_meta(4,1u));
+                  fw.unsafe_push(create_level_info(5,1u));
+                  fw.unsafe_push(create_level_info(4,1u));
 
                   fw.unsafe_push(1); // Check idx argument is defaulted to 0
                   fw.unsafe_push(2, 0);
@@ -124,7 +124,7 @@ go_bandit([]() {
                   delete f;
 
                   fw.unsafe_push(42);
-                  fw.unsafe_push(create_meta(0,1u));
+                  fw.unsafe_push(create_level_info(0,1u));
                 });
 
                 describe("node_writer", [&]() {
@@ -216,8 +216,8 @@ go_bandit([]() {
                     });
 
                     it("can hook into arc_test_file and write level_info", [&]() {
-                        aw.unsafe_push(create_meta(0,1u));
-                        aw.unsafe_push(create_meta(1,1u));
+                        aw.unsafe_push(create_level_info(0,1u));
+                        aw.unsafe_push(create_level_info(1,1u));
                       });
 
                     it("can hook into arc_test_file and  write sink arcs out of order", [&]() {
@@ -430,7 +430,7 @@ go_bandit([]() {
                        level_info_stream ms(test_file_meta_1);
 
                        AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(create_meta(0,2u)));
+                       AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,2u)));
                        AssertThat(ms.can_pull(), Is().False());
                      });
 
@@ -438,9 +438,9 @@ go_bandit([]() {
                        level_info_stream ms(node_test_file);
 
                        AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                       AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                        AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
+                       AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
                        AssertThat(ms.can_pull(), Is().False());
                      });
                 });

--- a/test/adiar/test_file.cpp
+++ b/test/adiar/test_file.cpp
@@ -1,780 +1,780 @@
 #include <filesystem>
 
 go_bandit([]() {
-    describe("CORE: Files, writers, and streams", [&]() {
-        describe("file", [&]() {
-            it("can construct fresh file<T> and make it read-only", [&]() {
-              file<int> f;
+  describe("CORE: Files, writers, and streams", [&]() {
+    describe("file", [&]() {
+      it("can construct fresh file<T> and make it read-only", [&]() {
+        file<int> f;
 
-              AssertThat(f.is_read_only(), Is().False());
+        AssertThat(f.is_read_only(), Is().False());
 
-              f.make_read_only();
+        f.make_read_only();
 
-              AssertThat(f.is_read_only(), Is().True());
-            });
+        AssertThat(f.is_read_only(), Is().True());
+      });
 
-            it("can construct fresh __meta_file<T> and make it read-only", [&]() {
-              __meta_file<int, 1> f;
+      it("can construct fresh __meta_file<T> and make it read-only", [&]() {
+        __meta_file<int, 1> f;
 
-              AssertThat(f.is_read_only(), Is().False());
+        AssertThat(f.is_read_only(), Is().False());
 
-              f.make_read_only();
+        f.make_read_only();
 
-              AssertThat(f.is_read_only(), Is().True());
-            });
+        AssertThat(f.is_read_only(), Is().True());
+      });
+    });
+
+    simple_file<int> test_file_simple;
+    simple_file<int> test_file_simple_sorted;
+
+    meta_file<int,1> test_file_meta_1;
+    meta_file<int,2> test_file_meta_2;
+
+    node_file node_test_file;
+
+    node_t n2 = create_node(1,1, create_sink_ptr(false), create_sink_ptr(true));
+    node_t n1 = create_node(1,0, create_sink_ptr(true), create_sink_ptr(false));
+    node_t n0 = create_node(0,0, create_node_ptr(1,1), create_node_ptr(1,0));
+
+    arc_file arc_test_file;
+
+    arc_t node_arc_1 = { create_node_ptr(0,0), create_node_ptr(1,0) };
+    arc_t sink_arc_1 = { flag(create_node_ptr(0,0)), create_sink_ptr(false) };
+
+    arc_t sink_arc_2 = { create_node_ptr(1,0), create_sink_ptr(true) };
+    arc_t sink_arc_3 = { flag(create_node_ptr(1,0)), create_sink_ptr(false) };
+
+    describe("file_writer", [&]() {
+      describe("simple_file_writer", [&]() {
+        it("can hook into and write to test_file_simple", [&]() {
+          AssertThat(test_file_simple.is_read_only(), Is().False());
+
+          simple_file_writer<int> fw(test_file_simple);
+
+          fw.unsafe_push(21);
+          fw.unsafe_push(42);
+
+          AssertThat(test_file_simple.is_read_only(), Is().False());
         });
 
-        simple_file<int> test_file_simple;
-        simple_file<int> test_file_simple_sorted;
+        it("can sort after pushing out-of-order", [&]() {
+          AssertThat(test_file_simple_sorted.is_read_only(), Is().False());
 
-        meta_file<int,1> test_file_meta_1;
-        meta_file<int,2> test_file_meta_2;
+          simple_file_writer<int, std::less<int>> fw(test_file_simple_sorted);
 
-        node_file node_test_file;
+          fw.unsafe_push(5);
+          fw.unsafe_push(3);
+          fw.unsafe_push(4);
+          fw.unsafe_push(1);
+          fw.unsafe_push(2);
 
-        node_t n2 = create_node(1,1, create_sink_ptr(false), create_sink_ptr(true));
-        node_t n1 = create_node(1,0, create_sink_ptr(true), create_sink_ptr(false));
-        node_t n0 = create_node(0,0, create_node_ptr(1,1), create_node_ptr(1,0));
+          fw.sort();
 
-        arc_file arc_test_file;
-
-        arc_t node_arc_1 = { create_node_ptr(0,0), create_node_ptr(1,0) };
-        arc_t sink_arc_1 = { flag(create_node_ptr(0,0)), create_sink_ptr(false) };
-
-        arc_t sink_arc_2 = { create_node_ptr(1,0), create_sink_ptr(true) };
-        arc_t sink_arc_3 = { flag(create_node_ptr(1,0)), create_sink_ptr(false) };
-
-        describe("file_writer", [&]() {
-            describe("simple_file_writer", [&]() {
-                it("can hook into and write to test_file_simple", [&]() {
-                  AssertThat(test_file_simple.is_read_only(), Is().False());
-
-                  simple_file_writer<int> fw(test_file_simple);
-
-                  fw.unsafe_push(21);
-                  fw.unsafe_push(42);
-
-                  AssertThat(test_file_simple.is_read_only(), Is().False());
-                });
-
-                it("can sort after pushing out-of-order", [&]() {
-                  AssertThat(test_file_simple_sorted.is_read_only(), Is().False());
-
-                  simple_file_writer<int, std::less<int>> fw(test_file_simple_sorted);
-
-                  fw.unsafe_push(5);
-                  fw.unsafe_push(3);
-                  fw.unsafe_push(4);
-                  fw.unsafe_push(1);
-                  fw.unsafe_push(2);
-
-                  fw.sort();
-
-                  AssertThat(test_file_simple_sorted.is_read_only(), Is().False());
-                });
-
-                it("does not break when source file is destructed early [simple_file]", [&]() {
-                  simple_file<int>* f = new simple_file<int>();
-                  simple_file_writer<int> fw(*f);
-
-                  fw.unsafe_push(21);
-
-                  delete f;
-
-                  fw.unsafe_push(42);
-                });
-            });
-
-            describe("meta_file_writer", [&]() {
-                it("can hook into and write to test_file_meta_1", [&]() {
-                  AssertThat(test_file_meta_1.is_read_only(), Is().False());
-
-                  meta_file_writer<int,1> fw(test_file_meta_1);
-
-                  fw.unsafe_push(21);
-                  fw.unsafe_push(42);
-
-                  fw.unsafe_push(create_level_info(0,2u));
-
-                  AssertThat(test_file_meta_1.is_read_only(), Is().False());
-                });
-
-
-                it("can hook into and write to test_file_meta_2", [&]() {
-                  meta_file_writer<int,2> fw(test_file_meta_2);
-
-                  fw.unsafe_push(create_level_info(5,1u));
-                  fw.unsafe_push(create_level_info(4,1u));
-
-                  fw.unsafe_push(1); // Check idx argument is defaulted to 0
-                  fw.unsafe_push(2, 0);
-                  fw.unsafe_push(4, 1);
-                  fw.unsafe_push(5, 1);
-                  fw.unsafe_push(3, 0);
-
-                  AssertThat(test_file_meta_2.is_read_only(), Is().False());
-                });
-
-                it("does not break when source file is destructed early [simple_file]", [&]() {
-                  meta_file<int, 1>* f = new meta_file<int, 1>();
-                  meta_file_writer fw(*f);
-
-                  fw.unsafe_push(21);
-
-                  delete f;
-
-                  fw.unsafe_push(42);
-                  fw.unsafe_push(create_level_info(0,1u));
-                });
-
-                describe("node_writer", [&]() {
-                    it("can hook into and write to node_test_file", [&]() {
-                      AssertThat(node_test_file.is_read_only(), Is().False());
-
-                      node_writer nw(node_test_file);
-                      nw << n2 << n1 << n0;
-
-                      AssertThat(node_test_file.is_read_only(), Is().False());
-                    });
-
-                    it("can derive whether it is on canonical form [1]", [&]() {
-                       node_file nf;
-                       {
-                         node_writer nw(nf);
-                         nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
-                       }
-
-                       AssertThat(is_canonical(nf), Is().True());
-                     });
-
-                    it("can derive whether it is on canonical form [2]", [&]() {
-                        node_file nf;
-                        {
-                          node_writer nw(nf);
-                          nw << create_node(21, 42, create_sink_ptr(false), create_sink_ptr(true));
-                        }
-
-                        AssertThat(is_canonical(nf), Is().False());
-                      });
-
-                    it("can derive whether it is on canonical form [3]", [&]() {
-                        node_file nf;
-                        {
-                          node_writer nw(nf);
-                          nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
-                             << create_node(42, MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false))
-                             << create_node(21, MAX_ID, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-1));
-                        }
-
-                        AssertThat(is_canonical(nf), Is().True());
-                      });
-
-                    it("can derive whether it is on canonical form [4]", [&]() {
-                        node_file nf;
-                        {
-                          node_writer nw(nf);
-                          nw << create_node(42, MAX_ID, create_sink_ptr(true), create_sink_ptr(false))
-                             << create_node(42, MAX_ID-1, create_sink_ptr(false), create_sink_ptr(true))
-                             << create_node(21, MAX_ID, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-1));
-                        }
-
-                        AssertThat(is_canonical(nf), Is().False());
-                      });
-
-                    it("can derive whether it is on canonical form [5]", [&]() {
-                        node_file nf;
-                        {
-                          node_writer nw(nf);
-                          nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
-                             << create_node(42, MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false))
-                             << create_node(21, MAX_ID-1, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-1));
-                        }
-
-                        AssertThat(is_canonical(nf), Is().False());
-                      });
-
-                    it("can derive whether it is on canonical form [6]", [&]() {
-                        node_file nf;
-                        {
-                          node_writer nw(nf);
-                          nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
-                             << create_node(42, MAX_ID-2, create_sink_ptr(true), create_sink_ptr(false))
-                             << create_node(21, MAX_ID, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-2));
-                        }
-
-                        AssertThat(is_canonical(nf), Is().False());
-                      });
-                });
-
-                describe("arc_writer", [&]() {
-                    arc_writer aw(arc_test_file);
-
-                    it("can hook into arc_test_file and write node arcs", [&]() {
-                      AssertThat(arc_test_file.is_read_only(), Is().False());
-
-                      aw.unsafe_push_node(node_arc_1);
-                    });
-
-                    it("can hook into arc_test_file and write level_info", [&]() {
-                        aw.unsafe_push(create_level_info(0,1u));
-                        aw.unsafe_push(create_level_info(1,1u));
-                      });
-
-                    it("can hook into arc_test_file and  write sink arcs out of order", [&]() {
-                      aw.unsafe_push_sink(sink_arc_3);
-                      aw.unsafe_push_sink(sink_arc_1);
-                      aw.unsafe_push_sink(sink_arc_2);
-                    });
-                });
-            });
+          AssertThat(test_file_simple_sorted.is_read_only(), Is().False());
         });
 
-        describe("file_stream", [&]() {
-            describe("simple_file_stream", [&]() {
-                it("locks the file to be read-only on attachment", [&]() {
-                  AssertThat(test_file_simple.is_read_only(), Is().False());
+        it("does not break when source file is destructed early [simple_file]", [&]() {
+          simple_file<int>* f = new simple_file<int>();
+          simple_file_writer<int> fw(*f);
 
-                  file_stream<int, false> fs(test_file_simple);
+          fw.unsafe_push(21);
 
-                  AssertThat(test_file_simple.is_read_only(), Is().True());
-                });
+          delete f;
 
-                it("can read test_file_simple [forwards]", [&]() {
-                  file_stream<int, false> fs(test_file_simple);
+          fw.unsafe_push(42);
+        });
+      });
 
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
+      describe("meta_file_writer", [&]() {
+        it("can hook into and write to test_file_meta_1", [&]() {
+          AssertThat(test_file_meta_1.is_read_only(), Is().False());
 
-                it("can peek test_file_simple [forwards]", [&]() {
-                  file_stream<int, false> fs(test_file_simple);
+          meta_file_writer<int,1> fw(test_file_meta_1);
 
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.peek(), Is().EqualTo(21));
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.peek(), Is().EqualTo(42));
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
+          fw.unsafe_push(21);
+          fw.unsafe_push(42);
 
-                it("can read test_file_simple_sorted [reverse]", [&]() {
-                  file_stream<int, true> fs(test_file_simple_sorted);
+          fw.unsafe_push(create_level_info(0,2u));
 
-                  // This also tests, whether test_file_simple_sorted actually
-                  // ended up being sorted.
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(5));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(4));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(3));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(2));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(1));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("does not break when source simple_file is destructed early", [&]() {
-                  simple_file<int>* f = new simple_file<int>();
-
-                  { // Garbage collect the writer early, releasing it's reference counter
-                    simple_file_writer<int> fw(*f);
-                    fw.unsafe_push(21);
-                  }
-
-                  file_stream<int, false> fs(*f);
-
-                  delete f;
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                });
-            });
-
-            describe("meta_file_stream", [&]() {
-                it("locks the file to be read-only on attachment", [&]() {
-                  AssertThat(test_file_meta_1.is_read_only(), Is().False());
-                  meta_file_stream<int, 1, 0, false> fs1(test_file_meta_1);
-
-                  AssertThat(test_file_meta_1.is_read_only(), Is().True());
-
-                  AssertThat(test_file_meta_2.is_read_only(), Is().False());
-                  meta_file_stream<int, 2, 0, false> fs2(test_file_meta_2);
-
-                  AssertThat(test_file_meta_2.is_read_only(), Is().True());
-                });
-
-                it("can read test_file_meta_1 [forwards]", [&]() {
-                  meta_file_stream<int, 1, 0, false> fs(test_file_meta_1);
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can peek test_file_meta_1 [forwards]", [&]() {
-                  meta_file_stream<int, 1, 0, false> fs(test_file_meta_1);
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.peek(), Is().EqualTo(21));
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.peek(), Is().EqualTo(42));
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can read test_file_meta_1 [reverse]", [&]() {
-                  meta_file_stream<int, 1, 0, true> fs(test_file_meta_1);
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can peek test_file_1 [reverse]", [&]() {
-                  meta_file_stream<int, 1, 0, true> fs(test_file_meta_1);
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.peek(), Is().EqualTo(42));
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.peek(), Is().EqualTo(21));
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can read test_file_meta_2 [forwards]", [&]() {
-                  meta_file_stream<int, 2, 0, false> fs1(test_file_meta_2);
-
-                  AssertThat(fs1.can_pull(), Is().True());
-                  AssertThat(fs1.pull(), Is().EqualTo(1));
-                  AssertThat(fs1.can_pull(), Is().True());
-                  AssertThat(fs1.pull(), Is().EqualTo(2));
-                  AssertThat(fs1.can_pull(), Is().True());
-                  AssertThat(fs1.pull(), Is().EqualTo(3));
-                  AssertThat(fs1.can_pull(), Is().False());
-
-                  meta_file_stream<int, 2, 1, false> fs2(test_file_meta_2);
-
-                  AssertThat(fs2.can_pull(), Is().True());
-                  AssertThat(fs2.pull(), Is().EqualTo(4));
-                  AssertThat(fs2.can_pull(), Is().True());
-                  AssertThat(fs2.pull(), Is().EqualTo(5));
-                  AssertThat(fs2.can_pull(), Is().False());
-                });
-
-                it("can peek test_file_meta_2 [forwards]", [&]() {
-                  meta_file_stream<int, 2, 0, false> fs1(test_file_meta_2);
-
-                  AssertThat(fs1.can_pull(), Is().True());
-                  AssertThat(fs1.peek(), Is().EqualTo(1));
-                  AssertThat(fs1.pull(), Is().EqualTo(1));
-                  AssertThat(fs1.can_pull(), Is().True());
-                  AssertThat(fs1.peek(), Is().EqualTo(2));
-                  AssertThat(fs1.pull(), Is().EqualTo(2));
-                  AssertThat(fs1.can_pull(), Is().True());
-                  AssertThat(fs1.peek(), Is().EqualTo(3));
-                  AssertThat(fs1.pull(), Is().EqualTo(3));
-                  AssertThat(fs1.can_pull(), Is().False());
-
-                  meta_file_stream<int, 2, 1, false> fs2(test_file_meta_2);
-
-                  AssertThat(fs2.can_pull(), Is().True());
-                  AssertThat(fs2.peek(), Is().EqualTo(4));
-                  AssertThat(fs2.pull(), Is().EqualTo(4));
-                  AssertThat(fs2.can_pull(), Is().True());
-                  AssertThat(fs2.peek(), Is().EqualTo(5));
-                  AssertThat(fs2.pull(), Is().EqualTo(5));
-                  AssertThat(fs2.can_pull(), Is().False());
-                });
-
-                it("can read test_file_1 forwards via fresh proxy object", [&]() {
-                  meta_file<int, 1> proxy(test_file_meta_1);
-                  meta_file_stream<int, 1, 0, false> fs(proxy);
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("does not break when source meta_file is destructed early", [&]() {
-                  meta_file<int,1>* f = new meta_file<int, 1>();
-
-                  { // Garbage collect the writer early, releasing it's reference counter
-                    meta_file_writer<int,1> fw(*f);
-                    fw.unsafe_push(21, 0);
-                  }
-
-                  meta_file_stream<int, 1, 0, false> fs(*f);
-
-                  delete f;
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(21));
-                });
-
-                describe("level_info_stream", [&]() {
-                     it("can read level_info stream of test_file_meta_1", [&]() {
-                       level_info_stream ms(test_file_meta_1);
-
-                       AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,2u)));
-                       AssertThat(ms.can_pull(), Is().False());
-                     });
-
-                     it("can read level_info stream of node_test_file", [&]() {
-                       level_info_stream ms(node_test_file);
-
-                       AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                       AssertThat(ms.can_pull(), Is().True());
-                       AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
-                       AssertThat(ms.can_pull(), Is().False());
-                     });
-                });
-
-                describe("node_stream", [&]() {
-                    it("can read node stream of node_test_file", [&]() {
-                      node_stream<> ns(node_test_file);
-
-                      AssertThat(ns.can_pull(), Is().True());
-                      AssertThat(ns.pull(), Is().EqualTo(n0));
-                      AssertThat(ns.can_pull(), Is().True());
-                      AssertThat(ns.pull(), Is().EqualTo(n1));
-                      AssertThat(ns.can_pull(), Is().True());
-                      AssertThat(ns.pull(), Is().EqualTo(n2));
-                      AssertThat(ns.can_pull(), Is().False());
-                    });
-
-                    it("can read negated node stream of node_test_file", [&]() {
-                      node_stream<> ns(node_test_file, true);
-
-                      AssertThat(ns.can_pull(), Is().True());
-                      AssertThat(ns.pull(), Is().EqualTo(!n0));
-                      AssertThat(ns.can_pull(), Is().True());
-                      AssertThat(ns.pull(), Is().EqualTo(!n1));
-                      AssertThat(ns.can_pull(), Is().True());
-                      AssertThat(ns.pull(), Is().EqualTo(!n2));
-                      AssertThat(ns.can_pull(), Is().False());
-                    });
-                });
-
-                describe("arc_streams", [&]() {
-                    it("can read node arcs of arc_test_file", [&]() {
-                      node_arc_stream<> as(arc_test_file);
-
-                      AssertThat(as.can_pull(), Is().True());
-                      AssertThat(as.pull(), Is().EqualTo(node_arc_1));
-                      AssertThat(as.can_pull(), Is().False());
-                    });
-
-                    it("can read sink arcs of arc_test_file", [&]() {
-                      sink_arc_stream<> as(arc_test_file);
-
-                      // The stream has been sorted 1, 2, 3 yet the
-                      // sink_arc_stream is per default in reverse, so we will
-                      // expect 3, 2, 1.
-                      AssertThat(as.can_pull(), Is().True());
-                      AssertThat(as.pull(), Is().EqualTo(sink_arc_3));
-                      AssertThat(as.can_pull(), Is().True());
-                      AssertThat(as.pull(), Is().EqualTo(sink_arc_2));
-                      AssertThat(as.can_pull(), Is().True());
-                      AssertThat(as.pull(), Is().EqualTo(sink_arc_1));
-                      AssertThat(as.can_pull(), Is().False());
-                    });
-                });
-            });
+          AssertThat(test_file_meta_1.is_read_only(), Is().False());
         });
 
-        describe("shared_file", [&]() {
-            describe("simple_file", [&]() {
-                it("can return a written to simple_file, that then can be read", [&]() {
-                  auto t = []() {
-                             simple_file<int> f;
 
-                             simple_file_writer<int> fw(f);
-                             fw.unsafe_push(42);
-                             fw.unsafe_push(7);
+        it("can hook into and write to test_file_meta_2", [&]() {
+          meta_file_writer<int,2> fw(test_file_meta_2);
 
-                             return f;
-                           };
+          fw.unsafe_push(create_level_info(5,1u));
+          fw.unsafe_push(create_level_info(4,1u));
 
-                  simple_file<int> f = t();
-                  file_stream<int> fs(f);
+          fw.unsafe_push(1); // Check idx argument is defaulted to 0
+          fw.unsafe_push(2, 0);
+          fw.unsafe_push(4, 1);
+          fw.unsafe_push(5, 1);
+          fw.unsafe_push(3, 0);
 
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(7));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can construct a new named simple_file", [&]() {
-                  simple_file<int> file("simple_file_test.adiar");
-
-                  AssertThat(std::filesystem::exists("simple_file_test.adiar"), Is().True());
-
-                  {
-                    simple_file_writer<int> fw(file);
-                    fw.push(1);
-                    fw.push(2);
-                    fw.push(3);
-                  }
-                  AssertThat(file.is_read_only(), Is().False());
-
-                  {
-                    file_stream<int, false> fs(file);
-                    AssertThat(file.is_read_only(), Is().True());
-                    AssertThat(fs.pull(), Is().EqualTo(1));
-                    AssertThat(fs.pull(), Is().EqualTo(2));
-                    AssertThat(fs.pull(), Is().EqualTo(3));
-                    AssertThat(fs.can_pull(), Is().False());
-                  }
-                  AssertThat(file.is_read_only(), Is().True());
-                });
-
-                it("should have two temporary simple_files be two different files", [&]() {
-                  simple_file<int> file1;
-                  simple_file<int> file2;
-
-                  AssertThat(file1._file_ptr, Is().Not().EqualTo(file2._file_ptr));
-                });
-
-                it("can construct a copy of a simple_file", [&]() {
-                  simple_file<int> file1;
-
-                  { // Garbage collect the writer to detach it before the reader
-                    simple_file_writer<int> fw(file1);
-                    fw.push(42);
-                  }
-
-                  simple_file<int> file2(file1);
-
-                  file_stream<int, false> fs(file2);
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can construct a prior named simple_file (i.e. reopen a stored file)", [&]() {
-                  AssertThat(std::filesystem::exists("simple_file_test.adiar"), Is().True());
-                  simple_file<int> file("simple_file_test.adiar");
-                  AssertThat(file.is_read_only(), Is().True());
-
-                  file_stream<int, false> fs(file);
-                  AssertThat(file.is_read_only(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(1));
-                  AssertThat(fs.pull(), Is().EqualTo(2));
-                  AssertThat(fs.pull(), Is().EqualTo(3));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can compute sizes of test_file_simple", [&]() {
-                  AssertThat(test_file_simple.size(), Is().EqualTo(2u));
-                  AssertThat(test_file_simple.file_size(), Is().EqualTo(2u * sizeof(int)));
-                });
-
-                it("can sort a yet unread simple_file", [&]() {
-                    simple_file<int> file;
-
-                    { // Garbage collect the writer to detach it before the reader
-                      simple_file_writer<int> fw(file);
-                      fw.push(42);
-                      fw.push(7);
-                      fw.push(21);
-                    }
-
-                    sort(file, std::less<>());
-
-                    file_stream<int, false> fs(file);
-
-                    AssertThat(fs.pull(), Is().EqualTo(7));
-                    AssertThat(fs.pull(), Is().EqualTo(21));
-                    AssertThat(fs.pull(), Is().EqualTo(42));
-                    AssertThat(fs.can_pull(), Is().False());
-                  });
-            });
-
-            describe("meta_file", [&]() {
-                it("can return a written to meta_file, that then can be read", [&]() {
-                  auto t = []() {
-                    meta_file<int, 1> f;
-
-                    meta_file_writer<int, 1> fw(f);
-                    fw.unsafe_push(42);
-                    fw.unsafe_push(7);
-
-                    return f;
-                  };
-
-                  meta_file<int, 1> f = t();
-                  meta_file_stream<int, 1, 0, false> fs(f);
-
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().True());
-                  AssertThat(fs.pull(), Is().EqualTo(7));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("should have two temporary meta_files be two different files", [&]() {
-                  meta_file<int, 1> file1;
-                  meta_file<int, 1> file2;
-
-                  AssertThat(file1._file_ptr, Is().Not().EqualTo(file2._file_ptr));
-                });
-
-                it("can construct a copy of a meta_file", [&]() {
-                  meta_file<int,1> file1;
-
-                  { // Garbage collect the writer to detach it before the reader
-                    meta_file_writer<int, 1> fw(file1);
-                    fw.unsafe_push(42);
-                  }
-
-                  meta_file<int,1> file2(file1);
-
-                  meta_file_stream<int, 1, 0, false> fs(file2);
-                  AssertThat(fs.pull(), Is().EqualTo(42));
-                  AssertThat(fs.can_pull(), Is().False());
-                });
-
-                it("can compute sizes of test_file_meta_1", [&]() {
-                  AssertThat(test_file_meta_1.size(), Is().EqualTo(2u));
-                  AssertThat(test_file_meta_1.file_size(), Is().EqualTo(2u * sizeof(int) + 1u * sizeof(level_info_t)));
-                });
-
-                it("can compute size of test_file_meta_2", [&]() {
-                  test_file_meta_2.make_read_only();
-                  AssertThat(test_file_meta_2.size(), Is().EqualTo(5u));
-                  AssertThat(test_file_meta_2.file_size(), Is().EqualTo(5u * sizeof(int) + 2u * sizeof(level_info_t)));
-                });
-
-                describe("node_file", [&]() {
-                    node_file x0;
-
-                    {
-                      node_writer nw_0(x0);
-                      nw_0 << create_node(0,MAX_ID,
-                                          create_sink_ptr(false),
-                                          create_sink_ptr(true));
-                    }
-
-                    node_file x0_and_x1;
-
-                    {
-                      node_writer nw_01(x0_and_x1);
-
-                      nw_01 << create_node(1, MAX_ID,
-                                           create_sink_ptr(false),
-                                           create_sink_ptr(true));
-
-                      nw_01 << create_node(0, MAX_ID,
-                                           create_sink_ptr(false),
-                                           create_node_ptr(1, MAX_ID));
-                    }
-
-                    node_file sink_T;
-
-                    {
-                      node_writer nw_T(sink_T);
-                      nw_T << create_sink(true);
-                    }
-
-                    node_file sink_F;
-
-                    {
-                      node_writer nw_F(sink_F);
-                      nw_F << create_sink(false);
-                    }
-
-                    describe("size computation", [&]() {
-                        it("can compute size of node_test_file", [&]() {
-                          AssertThat(node_test_file.size(), Is().EqualTo(3u));
-                          AssertThat(node_test_file.meta_size(), Is().EqualTo(2u));
-                          AssertThat(node_test_file.file_size(), Is().EqualTo(3u * sizeof(node_t) + 2u * sizeof(level_info_t)));
-                        });
-
-                        it("can compute size of x0", [&]() {
-                          AssertThat(x0.size(), Is().EqualTo(1u));
-                          AssertThat(x0.meta_size(), Is().EqualTo(1u));
-                          AssertThat(x0.file_size(), Is().EqualTo(1u * sizeof(node_t) + 1u * sizeof(level_info_t)));
-                        });
-
-                        it("can compute size of x0 & x1", [&]() {
-                          AssertThat(x0_and_x1.size(), Is().EqualTo(2u));
-                          AssertThat(x0_and_x1.meta_size(), Is().EqualTo(2u));
-                          AssertThat(x0_and_x1.file_size(), Is().EqualTo(2u * sizeof(node_t) + 2u * sizeof(level_info_t)));
-                        });
-
-                        it("can compute size of sink_T", [&]() {
-                          AssertThat(sink_T.size(), Is().EqualTo(1u));
-                          AssertThat(sink_T.meta_size(), Is().EqualTo(0u));
-                          AssertThat(sink_T.file_size(), Is().EqualTo(1u * sizeof(node_t) + 0u * sizeof(level_info_t)));
-                        });
-                    });
-
-                    describe("is_sink predicate", [&]() {
-                        it("should reject x0 as a sink file", [&]() {
-                            AssertThat(is_sink(x0, is_true), Is().False());
-                            AssertThat(is_sink(x0, is_false), Is().False());
-                            AssertThat(is_sink(x0), Is().False());
-                        });
-
-                        it("should reject x0 & x1 as a sink file", [&]() {
-                             AssertThat(is_sink(x0_and_x1, is_true), Is().False());
-                             AssertThat(is_sink(x0_and_x1, is_false), Is().False());
-                             AssertThat(is_sink(x0_and_x1), Is().False());
-                        });
-
-                        it("should recognise a true sink", [&]() {
-                            AssertThat(is_sink(sink_T, is_true), Is().True());
-                        });
-
-                        it("should recognise a false sink", [&]() {
-                            AssertThat(is_sink(sink_F, is_false), Is().True());
-                        });
-
-                        it("should not recognise sink file as the other sink", [&]() {
-                            AssertThat(is_sink(sink_T, is_false), Is().False());
-                            AssertThat(is_sink(sink_F, is_true), Is().False());
-                        });
-
-                        it("should have any sink as default", [&]() {
-                            AssertThat(is_sink(sink_T), Is().True());
-                            AssertThat(is_sink(sink_F), Is().True());
-                        });
-                      });
-
-                    describe("min_label and max_label", [&]() {
-                        it("should extract labels from x0", [&]() {
-                            AssertThat(min_label(x0), Is().EqualTo(0u));
-                            AssertThat(max_label(x0), Is().EqualTo(0u));
-                        });
-
-                        it("should extract labels from x0_and_x1", [&]() {
-                            AssertThat(min_label(x0_and_x1), Is().EqualTo(0u));
-                            AssertThat(max_label(x0_and_x1), Is().EqualTo(1u));
-                        });
-
-                        it("should extract labels from node_test_file", [&]() {
-                            AssertThat(min_label(node_test_file), Is().EqualTo(0u));
-                            AssertThat(max_label(node_test_file), Is().EqualTo(1u));
-                        });
-                    });
-                });
-            });
+          AssertThat(test_file_meta_2.is_read_only(), Is().False());
         });
+
+        it("does not break when source file is destructed early [simple_file]", [&]() {
+          meta_file<int, 1>* f = new meta_file<int, 1>();
+          meta_file_writer fw(*f);
+
+          fw.unsafe_push(21);
+
+          delete f;
+
+          fw.unsafe_push(42);
+          fw.unsafe_push(create_level_info(0,1u));
+        });
+
+        describe("node_writer", [&]() {
+          it("can hook into and write to node_test_file", [&]() {
+            AssertThat(node_test_file.is_read_only(), Is().False());
+
+            node_writer nw(node_test_file);
+            nw << n2 << n1 << n0;
+
+            AssertThat(node_test_file.is_read_only(), Is().False());
+          });
+
+          it("can derive whether it is on canonical form [1]", [&]() {
+            node_file nf;
+            {
+              node_writer nw(nf);
+              nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true));
+            }
+
+            AssertThat(is_canonical(nf), Is().True());
+          });
+
+          it("can derive whether it is on canonical form [2]", [&]() {
+            node_file nf;
+            {
+              node_writer nw(nf);
+              nw << create_node(21, 42, create_sink_ptr(false), create_sink_ptr(true));
+            }
+
+            AssertThat(is_canonical(nf), Is().False());
+          });
+
+          it("can derive whether it is on canonical form [3]", [&]() {
+            node_file nf;
+            {
+              node_writer nw(nf);
+              nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
+                 << create_node(42, MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false))
+                 << create_node(21, MAX_ID, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-1));
+            }
+
+            AssertThat(is_canonical(nf), Is().True());
+          });
+
+          it("can derive whether it is on canonical form [4]", [&]() {
+            node_file nf;
+            {
+              node_writer nw(nf);
+              nw << create_node(42, MAX_ID, create_sink_ptr(true), create_sink_ptr(false))
+                 << create_node(42, MAX_ID-1, create_sink_ptr(false), create_sink_ptr(true))
+                 << create_node(21, MAX_ID, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-1));
+            }
+
+            AssertThat(is_canonical(nf), Is().False());
+          });
+
+          it("can derive whether it is on canonical form [5]", [&]() {
+            node_file nf;
+            {
+              node_writer nw(nf);
+              nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
+                 << create_node(42, MAX_ID-1, create_sink_ptr(true), create_sink_ptr(false))
+                 << create_node(21, MAX_ID-1, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-1));
+            }
+
+            AssertThat(is_canonical(nf), Is().False());
+          });
+
+          it("can derive whether it is on canonical form [6]", [&]() {
+            node_file nf;
+            {
+              node_writer nw(nf);
+              nw << create_node(42, MAX_ID, create_sink_ptr(false), create_sink_ptr(true))
+                 << create_node(42, MAX_ID-2, create_sink_ptr(true), create_sink_ptr(false))
+                 << create_node(21, MAX_ID, create_node_ptr(42, MAX_ID), create_node_ptr(42, MAX_ID-2));
+            }
+
+            AssertThat(is_canonical(nf), Is().False());
+          });
+        });
+
+        describe("arc_writer", [&]() {
+          arc_writer aw(arc_test_file);
+
+          it("can hook into arc_test_file and write node arcs", [&]() {
+            AssertThat(arc_test_file.is_read_only(), Is().False());
+
+            aw.unsafe_push_node(node_arc_1);
+          });
+
+          it("can hook into arc_test_file and write level_info", [&]() {
+            aw.unsafe_push(create_level_info(0,1u));
+            aw.unsafe_push(create_level_info(1,1u));
+          });
+
+          it("can hook into arc_test_file and  write sink arcs out of order", [&]() {
+            aw.unsafe_push_sink(sink_arc_3);
+            aw.unsafe_push_sink(sink_arc_1);
+            aw.unsafe_push_sink(sink_arc_2);
+          });
+        });
+      });
+    });
+
+    describe("file_stream", [&]() {
+      describe("simple_file_stream", [&]() {
+        it("locks the file to be read-only on attachment", [&]() {
+          AssertThat(test_file_simple.is_read_only(), Is().False());
+
+          file_stream<int, false> fs(test_file_simple);
+
+          AssertThat(test_file_simple.is_read_only(), Is().True());
+        });
+
+        it("can read test_file_simple [forwards]", [&]() {
+          file_stream<int, false> fs(test_file_simple);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can peek test_file_simple [forwards]", [&]() {
+          file_stream<int, false> fs(test_file_simple);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.peek(), Is().EqualTo(21));
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.peek(), Is().EqualTo(42));
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can read test_file_simple_sorted [reverse]", [&]() {
+          file_stream<int, true> fs(test_file_simple_sorted);
+
+          // This also tests, whether test_file_simple_sorted actually
+          // ended up being sorted.
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(5));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(4));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(3));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(2));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(1));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("does not break when source simple_file is destructed early", [&]() {
+          simple_file<int>* f = new simple_file<int>();
+
+          { // Garbage collect the writer early, releasing it's reference counter
+            simple_file_writer<int> fw(*f);
+            fw.unsafe_push(21);
+          }
+
+          file_stream<int, false> fs(*f);
+
+          delete f;
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(21));
+        });
+      });
+
+      describe("meta_file_stream", [&]() {
+        it("locks the file to be read-only on attachment", [&]() {
+          AssertThat(test_file_meta_1.is_read_only(), Is().False());
+          meta_file_stream<int, 1, 0, false> fs1(test_file_meta_1);
+
+          AssertThat(test_file_meta_1.is_read_only(), Is().True());
+
+          AssertThat(test_file_meta_2.is_read_only(), Is().False());
+          meta_file_stream<int, 2, 0, false> fs2(test_file_meta_2);
+
+          AssertThat(test_file_meta_2.is_read_only(), Is().True());
+        });
+
+        it("can read test_file_meta_1 [forwards]", [&]() {
+          meta_file_stream<int, 1, 0, false> fs(test_file_meta_1);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can peek test_file_meta_1 [forwards]", [&]() {
+          meta_file_stream<int, 1, 0, false> fs(test_file_meta_1);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.peek(), Is().EqualTo(21));
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.peek(), Is().EqualTo(42));
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can read test_file_meta_1 [reverse]", [&]() {
+          meta_file_stream<int, 1, 0, true> fs(test_file_meta_1);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can peek test_file_1 [reverse]", [&]() {
+          meta_file_stream<int, 1, 0, true> fs(test_file_meta_1);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.peek(), Is().EqualTo(42));
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.peek(), Is().EqualTo(21));
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can read test_file_meta_2 [forwards]", [&]() {
+          meta_file_stream<int, 2, 0, false> fs1(test_file_meta_2);
+
+          AssertThat(fs1.can_pull(), Is().True());
+          AssertThat(fs1.pull(), Is().EqualTo(1));
+          AssertThat(fs1.can_pull(), Is().True());
+          AssertThat(fs1.pull(), Is().EqualTo(2));
+          AssertThat(fs1.can_pull(), Is().True());
+          AssertThat(fs1.pull(), Is().EqualTo(3));
+          AssertThat(fs1.can_pull(), Is().False());
+
+          meta_file_stream<int, 2, 1, false> fs2(test_file_meta_2);
+
+          AssertThat(fs2.can_pull(), Is().True());
+          AssertThat(fs2.pull(), Is().EqualTo(4));
+          AssertThat(fs2.can_pull(), Is().True());
+          AssertThat(fs2.pull(), Is().EqualTo(5));
+          AssertThat(fs2.can_pull(), Is().False());
+        });
+
+        it("can peek test_file_meta_2 [forwards]", [&]() {
+          meta_file_stream<int, 2, 0, false> fs1(test_file_meta_2);
+
+          AssertThat(fs1.can_pull(), Is().True());
+          AssertThat(fs1.peek(), Is().EqualTo(1));
+          AssertThat(fs1.pull(), Is().EqualTo(1));
+          AssertThat(fs1.can_pull(), Is().True());
+          AssertThat(fs1.peek(), Is().EqualTo(2));
+          AssertThat(fs1.pull(), Is().EqualTo(2));
+          AssertThat(fs1.can_pull(), Is().True());
+          AssertThat(fs1.peek(), Is().EqualTo(3));
+          AssertThat(fs1.pull(), Is().EqualTo(3));
+          AssertThat(fs1.can_pull(), Is().False());
+
+          meta_file_stream<int, 2, 1, false> fs2(test_file_meta_2);
+
+          AssertThat(fs2.can_pull(), Is().True());
+          AssertThat(fs2.peek(), Is().EqualTo(4));
+          AssertThat(fs2.pull(), Is().EqualTo(4));
+          AssertThat(fs2.can_pull(), Is().True());
+          AssertThat(fs2.peek(), Is().EqualTo(5));
+          AssertThat(fs2.pull(), Is().EqualTo(5));
+          AssertThat(fs2.can_pull(), Is().False());
+        });
+
+        it("can read test_file_1 forwards via fresh proxy object", [&]() {
+          meta_file<int, 1> proxy(test_file_meta_1);
+          meta_file_stream<int, 1, 0, false> fs(proxy);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("does not break when source meta_file is destructed early", [&]() {
+          meta_file<int,1>* f = new meta_file<int, 1>();
+
+          { // Garbage collect the writer early, releasing it's reference counter
+            meta_file_writer<int,1> fw(*f);
+            fw.unsafe_push(21, 0);
+          }
+
+          meta_file_stream<int, 1, 0, false> fs(*f);
+
+          delete f;
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(21));
+        });
+
+        describe("level_info_stream", [&]() {
+          it("can read level_info stream of test_file_meta_1", [&]() {
+            level_info_stream ms(test_file_meta_1);
+
+            AssertThat(ms.can_pull(), Is().True());
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,2u)));
+            AssertThat(ms.can_pull(), Is().False());
+          });
+
+          it("can read level_info stream of node_test_file", [&]() {
+            level_info_stream ms(node_test_file);
+
+            AssertThat(ms.can_pull(), Is().True());
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+            AssertThat(ms.can_pull(), Is().True());
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
+            AssertThat(ms.can_pull(), Is().False());
+          });
+        });
+
+        describe("node_stream", [&]() {
+          it("can read node stream of node_test_file", [&]() {
+            node_stream<> ns(node_test_file);
+
+            AssertThat(ns.can_pull(), Is().True());
+            AssertThat(ns.pull(), Is().EqualTo(n0));
+            AssertThat(ns.can_pull(), Is().True());
+            AssertThat(ns.pull(), Is().EqualTo(n1));
+            AssertThat(ns.can_pull(), Is().True());
+            AssertThat(ns.pull(), Is().EqualTo(n2));
+            AssertThat(ns.can_pull(), Is().False());
+          });
+
+          it("can read negated node stream of node_test_file", [&]() {
+            node_stream<> ns(node_test_file, true);
+
+            AssertThat(ns.can_pull(), Is().True());
+            AssertThat(ns.pull(), Is().EqualTo(!n0));
+            AssertThat(ns.can_pull(), Is().True());
+            AssertThat(ns.pull(), Is().EqualTo(!n1));
+            AssertThat(ns.can_pull(), Is().True());
+            AssertThat(ns.pull(), Is().EqualTo(!n2));
+            AssertThat(ns.can_pull(), Is().False());
+          });
+        });
+
+        describe("arc_streams", [&]() {
+          it("can read node arcs of arc_test_file", [&]() {
+            node_arc_stream<> as(arc_test_file);
+
+            AssertThat(as.can_pull(), Is().True());
+            AssertThat(as.pull(), Is().EqualTo(node_arc_1));
+            AssertThat(as.can_pull(), Is().False());
+          });
+
+          it("can read sink arcs of arc_test_file", [&]() {
+            sink_arc_stream<> as(arc_test_file);
+
+            // The stream has been sorted 1, 2, 3 yet the
+            // sink_arc_stream is per default in reverse, so we will
+            // expect 3, 2, 1.
+            AssertThat(as.can_pull(), Is().True());
+            AssertThat(as.pull(), Is().EqualTo(sink_arc_3));
+            AssertThat(as.can_pull(), Is().True());
+            AssertThat(as.pull(), Is().EqualTo(sink_arc_2));
+            AssertThat(as.can_pull(), Is().True());
+            AssertThat(as.pull(), Is().EqualTo(sink_arc_1));
+            AssertThat(as.can_pull(), Is().False());
+          });
+        });
+      });
+    });
+
+    describe("shared_file", [&]() {
+      describe("simple_file", [&]() {
+        it("can return a written to simple_file, that then can be read", [&]() {
+          auto t = []() {
+            simple_file<int> f;
+
+            simple_file_writer<int> fw(f);
+            fw.unsafe_push(42);
+            fw.unsafe_push(7);
+
+            return f;
+          };
+
+          simple_file<int> f = t();
+          file_stream<int> fs(f);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(7));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can construct a new named simple_file", [&]() {
+          simple_file<int> file("simple_file_test.adiar");
+
+          AssertThat(std::filesystem::exists("simple_file_test.adiar"), Is().True());
+
+          {
+            simple_file_writer<int> fw(file);
+            fw.push(1);
+            fw.push(2);
+            fw.push(3);
+          }
+          AssertThat(file.is_read_only(), Is().False());
+
+          {
+            file_stream<int, false> fs(file);
+            AssertThat(file.is_read_only(), Is().True());
+            AssertThat(fs.pull(), Is().EqualTo(1));
+            AssertThat(fs.pull(), Is().EqualTo(2));
+            AssertThat(fs.pull(), Is().EqualTo(3));
+            AssertThat(fs.can_pull(), Is().False());
+          }
+          AssertThat(file.is_read_only(), Is().True());
+        });
+
+        it("should have two temporary simple_files be two different files", [&]() {
+          simple_file<int> file1;
+          simple_file<int> file2;
+
+          AssertThat(file1._file_ptr, Is().Not().EqualTo(file2._file_ptr));
+        });
+
+        it("can construct a copy of a simple_file", [&]() {
+          simple_file<int> file1;
+
+          { // Garbage collect the writer to detach it before the reader
+            simple_file_writer<int> fw(file1);
+            fw.push(42);
+          }
+
+          simple_file<int> file2(file1);
+
+          file_stream<int, false> fs(file2);
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can construct a prior named simple_file (i.e. reopen a stored file)", [&]() {
+          AssertThat(std::filesystem::exists("simple_file_test.adiar"), Is().True());
+          simple_file<int> file("simple_file_test.adiar");
+          AssertThat(file.is_read_only(), Is().True());
+
+          file_stream<int, false> fs(file);
+          AssertThat(file.is_read_only(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(1));
+          AssertThat(fs.pull(), Is().EqualTo(2));
+          AssertThat(fs.pull(), Is().EqualTo(3));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can compute sizes of test_file_simple", [&]() {
+          AssertThat(test_file_simple.size(), Is().EqualTo(2u));
+          AssertThat(test_file_simple.file_size(), Is().EqualTo(2u * sizeof(int)));
+        });
+
+        it("can sort a yet unread simple_file", [&]() {
+          simple_file<int> file;
+
+          { // Garbage collect the writer to detach it before the reader
+            simple_file_writer<int> fw(file);
+            fw.push(42);
+            fw.push(7);
+            fw.push(21);
+          }
+
+          sort(file, std::less<>());
+
+          file_stream<int, false> fs(file);
+
+          AssertThat(fs.pull(), Is().EqualTo(7));
+          AssertThat(fs.pull(), Is().EqualTo(21));
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+      });
+
+      describe("meta_file", [&]() {
+        it("can return a written to meta_file, that then can be read", [&]() {
+          auto t = []() {
+            meta_file<int, 1> f;
+
+            meta_file_writer<int, 1> fw(f);
+            fw.unsafe_push(42);
+            fw.unsafe_push(7);
+
+            return f;
+          };
+
+          meta_file<int, 1> f = t();
+          meta_file_stream<int, 1, 0, false> fs(f);
+
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().True());
+          AssertThat(fs.pull(), Is().EqualTo(7));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("should have two temporary meta_files be two different files", [&]() {
+          meta_file<int, 1> file1;
+          meta_file<int, 1> file2;
+
+          AssertThat(file1._file_ptr, Is().Not().EqualTo(file2._file_ptr));
+        });
+
+        it("can construct a copy of a meta_file", [&]() {
+          meta_file<int,1> file1;
+
+          { // Garbage collect the writer to detach it before the reader
+            meta_file_writer<int, 1> fw(file1);
+            fw.unsafe_push(42);
+          }
+
+          meta_file<int,1> file2(file1);
+
+          meta_file_stream<int, 1, 0, false> fs(file2);
+          AssertThat(fs.pull(), Is().EqualTo(42));
+          AssertThat(fs.can_pull(), Is().False());
+        });
+
+        it("can compute sizes of test_file_meta_1", [&]() {
+          AssertThat(test_file_meta_1.size(), Is().EqualTo(2u));
+          AssertThat(test_file_meta_1.file_size(), Is().EqualTo(2u * sizeof(int) + 1u * sizeof(level_info_t)));
+        });
+
+        it("can compute size of test_file_meta_2", [&]() {
+          test_file_meta_2.make_read_only();
+          AssertThat(test_file_meta_2.size(), Is().EqualTo(5u));
+          AssertThat(test_file_meta_2.file_size(), Is().EqualTo(5u * sizeof(int) + 2u * sizeof(level_info_t)));
+        });
+
+        describe("node_file", [&]() {
+          node_file x0;
+
+          {
+            node_writer nw_0(x0);
+            nw_0 << create_node(0,MAX_ID,
+                                create_sink_ptr(false),
+                                create_sink_ptr(true));
+          }
+
+          node_file x0_and_x1;
+
+          {
+            node_writer nw_01(x0_and_x1);
+
+            nw_01 << create_node(1, MAX_ID,
+                                 create_sink_ptr(false),
+                                 create_sink_ptr(true));
+
+            nw_01 << create_node(0, MAX_ID,
+                                 create_sink_ptr(false),
+                                 create_node_ptr(1, MAX_ID));
+          }
+
+          node_file sink_T;
+
+          {
+            node_writer nw_T(sink_T);
+            nw_T << create_sink(true);
+          }
+
+          node_file sink_F;
+
+          {
+            node_writer nw_F(sink_F);
+            nw_F << create_sink(false);
+          }
+
+          describe("size computation", [&]() {
+            it("can compute size of node_test_file", [&]() {
+              AssertThat(node_test_file.size(), Is().EqualTo(3u));
+              AssertThat(node_test_file.meta_size(), Is().EqualTo(2u));
+              AssertThat(node_test_file.file_size(), Is().EqualTo(3u * sizeof(node_t) + 2u * sizeof(level_info_t)));
+            });
+
+            it("can compute size of x0", [&]() {
+              AssertThat(x0.size(), Is().EqualTo(1u));
+              AssertThat(x0.meta_size(), Is().EqualTo(1u));
+              AssertThat(x0.file_size(), Is().EqualTo(1u * sizeof(node_t) + 1u * sizeof(level_info_t)));
+            });
+
+            it("can compute size of x0 & x1", [&]() {
+              AssertThat(x0_and_x1.size(), Is().EqualTo(2u));
+              AssertThat(x0_and_x1.meta_size(), Is().EqualTo(2u));
+              AssertThat(x0_and_x1.file_size(), Is().EqualTo(2u * sizeof(node_t) + 2u * sizeof(level_info_t)));
+            });
+
+            it("can compute size of sink_T", [&]() {
+              AssertThat(sink_T.size(), Is().EqualTo(1u));
+              AssertThat(sink_T.meta_size(), Is().EqualTo(0u));
+              AssertThat(sink_T.file_size(), Is().EqualTo(1u * sizeof(node_t) + 0u * sizeof(level_info_t)));
+            });
+          });
+
+          describe("is_sink predicate", [&]() {
+            it("should reject x0 as a sink file", [&]() {
+              AssertThat(is_sink(x0, is_true), Is().False());
+              AssertThat(is_sink(x0, is_false), Is().False());
+              AssertThat(is_sink(x0), Is().False());
+            });
+
+            it("should reject x0 & x1 as a sink file", [&]() {
+              AssertThat(is_sink(x0_and_x1, is_true), Is().False());
+              AssertThat(is_sink(x0_and_x1, is_false), Is().False());
+              AssertThat(is_sink(x0_and_x1), Is().False());
+            });
+
+            it("should recognise a true sink", [&]() {
+              AssertThat(is_sink(sink_T, is_true), Is().True());
+            });
+
+            it("should recognise a false sink", [&]() {
+              AssertThat(is_sink(sink_F, is_false), Is().True());
+            });
+
+            it("should not recognise sink file as the other sink", [&]() {
+              AssertThat(is_sink(sink_T, is_false), Is().False());
+              AssertThat(is_sink(sink_F, is_true), Is().False());
+            });
+
+            it("should have any sink as default", [&]() {
+              AssertThat(is_sink(sink_T), Is().True());
+              AssertThat(is_sink(sink_F), Is().True());
+            });
+          });
+
+          describe("min_label and max_label", [&]() {
+            it("should extract labels from x0", [&]() {
+              AssertThat(min_label(x0), Is().EqualTo(0u));
+              AssertThat(max_label(x0), Is().EqualTo(0u));
+            });
+
+            it("should extract labels from x0_and_x1", [&]() {
+              AssertThat(min_label(x0_and_x1), Is().EqualTo(0u));
+              AssertThat(max_label(x0_and_x1), Is().EqualTo(1u));
+            });
+
+            it("should extract labels from node_test_file", [&]() {
+              AssertThat(min_label(node_test_file), Is().EqualTo(0u));
+              AssertThat(max_label(node_test_file), Is().EqualTo(1u));
+            });
+          });
+        });
+      });
     });
   });
+ });

--- a/test/adiar/zdd/test_binop.cpp
+++ b/test/adiar/zdd/test_binop.cpp
@@ -1,170 +1,170 @@
 go_bandit([]() {
-    describe("ZDD: Binary operators on set", [&]() {
-        // == CREATE SINK-ONLY BDD FOR UNIT TESTS ==
-        //                  START
-        node_file zdd_F;
-        node_file zdd_T;
+  describe("ZDD: Binary operators on set", [&]() {
+    // == CREATE SINK-ONLY BDD FOR UNIT TESTS ==
+    //                  START
+    node_file zdd_F;
+    node_file zdd_T;
 
-        { // Garbage collect writers to free write-lock
-          node_writer nw_F(zdd_F);
-          nw_F << create_sink(false);
+    { // Garbage collect writers to free write-lock
+      node_writer nw_F(zdd_F);
+      nw_F << create_sink(false);
 
-          node_writer nw_T(zdd_T);
-          nw_T << create_sink(true);
-        }
+      node_writer nw_T(zdd_T);
+      nw_T << create_sink(true);
+    }
 
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        // == CREATE SINGLE VARIABLE BDDs FOR UNIT TESTS ==
-        //                    START
-        node_file zdd_x0;
-        node_file zdd_x1;
+    // == CREATE SINGLE VARIABLE BDDs FOR UNIT TESTS ==
+    //                    START
+    node_file zdd_x0;
+    node_file zdd_x1;
 
-        { // Garbage collect writers early
-          node_writer nw_x0(zdd_x0);
-          nw_x0 << create_node(0,MAX_ID, sink_F, sink_T);
+    { // Garbage collect writers early
+      node_writer nw_x0(zdd_x0);
+      nw_x0 << create_node(0,MAX_ID, sink_F, sink_T);
 
-          node_writer nw_x1(zdd_x1);
-          nw_x1 << create_node(1,MAX_ID, sink_F, sink_T);
-        }
+      node_writer nw_x1(zdd_x1);
+      nw_x1 << create_node(1,MAX_ID, sink_F, sink_T);
+    }
 
-        //                     END
-        // == CREATE SINGLE VARIABLE FOR UNIT TESTS ==
+    //                     END
+    // == CREATE SINGLE VARIABLE FOR UNIT TESTS ==
 
-        describe("zdd_union", [&]() {
-            it("should shortcut Ø on same file", [&]() {
-              __zdd out = zdd_union(zdd_F, zdd_F);
-              AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_F._file_ptr));
-            });
+    describe("zdd_union", [&]() {
+      it("should shortcut Ø on same file", [&]() {
+        __zdd out = zdd_union(zdd_F, zdd_F);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_F._file_ptr));
+      });
 
-            it("should shortcut { Ø } on same file", [&]() {
-              __zdd out = zdd_union(zdd_T, zdd_T);
-              AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_T._file_ptr));
-            });
+      it("should shortcut { Ø } on same file", [&]() {
+        __zdd out = zdd_union(zdd_T, zdd_T);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_T._file_ptr));
+      });
 
-            it("should shortcut { {0} } on same file", [&]() {
-              __zdd out = zdd_union(zdd_x0, zdd_x0);
-              AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
-            });
+      it("should shortcut { {0} } on same file", [&]() {
+        __zdd out = zdd_union(zdd_x0, zdd_x0);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
+      });
 
-            it("should shortcut { {1} } on same file", [&]() {
-              __zdd out = zdd_union(zdd_x1, zdd_x1);
-              AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_x1._file_ptr));
-            });
+      it("should shortcut { {1} } on same file", [&]() {
+        __zdd out = zdd_union(zdd_x1, zdd_x1);
+        AssertThat(out.get<node_file>()._file_ptr, Is().EqualTo(zdd_x1._file_ptr));
+      });
 
-            it("computes Ø U { {Ø} }", [&]() {
-                __zdd out = zdd_union(zdd_F, zdd_T);
+      it("computes Ø U { {Ø} }", [&]() {
+        __zdd out = zdd_union(zdd_F, zdd_T);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { Ø } U Ø", [&]() {
-                __zdd out = zdd_union(zdd_T, zdd_F);
+      it("computes { Ø } U Ø", [&]() {
+        __zdd out = zdd_union(zdd_T, zdd_F);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-               });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("should shortcut on irrelevance for { {0} } U Ø", [&]() {
-                /*
+      it("should shortcut on irrelevance for { {0} } U Ø", [&]() {
+        /*
                    1     ---- x0
                   / \
                   F T
-                */
+        */
 
-                __zdd out_1 = zdd_union(zdd_x0, zdd_F);
-                AssertThat(out_1.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
+        __zdd out_1 = zdd_union(zdd_x0, zdd_F);
+        AssertThat(out_1.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
 
-                __zdd out_2 = zdd_union(zdd_F, zdd_x0);
-                AssertThat(out_2.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
-              });
+        __zdd out_2 = zdd_union(zdd_F, zdd_x0);
+        AssertThat(out_2.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
+      });
 
-            it("computes { {0} } U { Ø }", [&]() {
-                /*
+      it("computes { {0} } U { Ø }", [&]() {
+        /*
                    1     ---- x0
                   / \
                   T T
-                */
+        */
 
-                __zdd out = zdd_union(zdd_x0, zdd_T);
+        __zdd out = zdd_union(zdd_x0, zdd_T);
 
-                node_arc_test_stream node_arcs(out);
-                AssertThat(node_arcs.can_pull(), Is().False());
+        node_arc_test_stream node_arcs(out);
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0} } U { {1} }", [&]() {
-                /*
+      it("computes { {0} } U { {1} }", [&]() {
+        /*
                      1     ---- x0
                     / \
                     2 T    ---- x1
                    / \
                    F T
-                */
+        */
 
-                __zdd out = zdd_union(zdd_x0, zdd_x1);
+        __zdd out = zdd_union(zdd_x0, zdd_x1);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0,1}, {0,3} } U { {0,2}, {2} }", [&]() {
-                /*
+      it("computes { {0,1}, {0,3} } U { {0,2}, {2} }", [&]() {
+        /*
                     1           1                (1,1)         ---- x0
                    / \         / \                 X
                    F 2         | |            (2,2) \          ---- x1
@@ -174,82 +174,82 @@ go_bandit([]() {
                     3          F T       (3,F) T     F T       ---- x3
                    / \                    / \
                    F T                    F T
-                */
-                node_file zdd_a;
-                node_file zdd_b;
+        */
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(3,MAX_ID, sink_F, sink_T)
-                       << create_node(1,MAX_ID, create_node_ptr(3,MAX_ID), sink_T)
-                       << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(3,MAX_ID, sink_F, sink_T)
+               << create_node(1,MAX_ID, create_node_ptr(3,MAX_ID), sink_T)
+               << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_union(zdd_a, zdd_b);
+        __zdd out = zdd_union(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,1) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,1) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0,1}, {1} } U { {0,2}, {2} }", [&]() {
-                /*
+      it("computes { {0,1}, {1} } U { {0,2}, {2} }", [&]() {
+        /*
                    1           1             (1,1)
                    ||         / \             | |
                    2          | |            (2,2)
@@ -257,66 +257,66 @@ go_bandit([]() {
                   F T          2          (F,2) (T,F) <-- since 2nd (2) skipped level
                               / \          / \
                               F T          F T
-                */
-                node_file zdd_a;
-                node_file zdd_b;
+        */
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_union(zdd_a, zdd_b);
+        __zdd out = zdd_union(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0}, {1,3}, {2,3}, {1} } U { {0,3}, {3} }", [&]() {
-                /*
+      it("computes { {0}, {1,3}, {2,3}, {1} } U { {0,3}, {3} }", [&]() {
+        /*
                         1        1                        (1,1)         ---- x0
                        / \      / \                       /   \
                        2 T      | |                    (2,2)   \        ---- x1
@@ -329,314 +329,314 @@ go_bandit([]() {
 
                    The high arc on (2) and (3) on the left is shortcutting the
                    second ZDD, to compensate for the omitted nodes.
-                 */
-                node_file zdd_a;
-                node_file zdd_b;
+        */
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(3,MAX_ID, sink_F, sink_T)
-                       << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID))
-                       << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(3,MAX_ID))
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(3,MAX_ID, sink_F, sink_T)
+               << create_node(2,MAX_ID, create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID))
+               << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(3,MAX_ID))
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(3,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(3,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(3,MAX_ID), create_node_ptr(3,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_union(zdd_a, zdd_b);
+        __zdd out = zdd_union(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), create_node_ptr(2,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), create_node_ptr(3,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(3,1) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(3,1) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), create_node_ptr(3,1) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,2) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(3,2) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,1), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,1)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_T }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(3,2), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,2)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-          });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+    });
 
-        describe("zdd_intsec", [&]() {
-            it("should shortcut on same file", [&]() {
-                __zdd out_1 = zdd_intsec(zdd_x0, zdd_x0);
-                AssertThat(out_1.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
+    describe("zdd_intsec", [&]() {
+      it("should shortcut on same file", [&]() {
+        __zdd out_1 = zdd_intsec(zdd_x0, zdd_x0);
+        AssertThat(out_1.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
 
-                __zdd out_2 = zdd_intsec(zdd_x1, zdd_x1);
-                AssertThat(out_2.get<node_file>()._file_ptr, Is().EqualTo(zdd_x1._file_ptr));
-              });
+        __zdd out_2 = zdd_intsec(zdd_x1, zdd_x1);
+        AssertThat(out_2.get<node_file>()._file_ptr, Is().EqualTo(zdd_x1._file_ptr));
+      });
 
-            it("computes Ø /\\ { {Ø} }", [&]() {
-                __zdd out = zdd_intsec(zdd_F, zdd_T);
+      it("computes Ø /\\ { {Ø} }", [&]() {
+        __zdd out = zdd_intsec(zdd_F, zdd_T);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { Ø } /\\ Ø", [&]() {
-                __zdd out = zdd_intsec(zdd_T, zdd_F);
+      it("computes { Ø } /\\ Ø", [&]() {
+        __zdd out = zdd_intsec(zdd_T, zdd_F);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes (and shortcut) { {0} } /\\ Ø", [&]() {
-                /*
+      it("computes (and shortcut) { {0} } /\\ Ø", [&]() {
+        /*
                    1       F              F          ---- x0
                   / \           ==>
                   F T
-                */
+        */
 
-                __zdd out = zdd_intsec(zdd_x0, zdd_F);
+        __zdd out = zdd_intsec(zdd_x0, zdd_F);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes (and shortcut) Ø /\\ { {0} }", [&]() {
-                __zdd out = zdd_intsec(zdd_F, zdd_x0);
+      it("computes (and shortcut) Ø /\\ { {0} }", [&]() {
+        __zdd out = zdd_intsec(zdd_F, zdd_x0);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { {0} } /\\ { Ø }", [&]() {
-                /*
+      it("computes { {0} } /\\ { Ø }", [&]() {
+        /*
                    1       T              F       ---- x0
                   / \           ==>
                   F T
-                */
+        */
 
-                __zdd out = zdd_intsec(zdd_x0, zdd_T);
+        __zdd out = zdd_intsec(zdd_x0, zdd_T);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { Ø, {0} } /\\ { Ø }", [&]() {
-                /*
+      it("computes { Ø, {0} } /\\ { Ø }", [&]() {
+        /*
                    1       T              T       ---- x0
                   / \           ==>
                   T T
-                */
-                node_file zdd_a;
+        */
+        node_file zdd_a;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(0,MAX_ID, sink_T, sink_T);
-                }
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(0,MAX_ID, sink_T, sink_T);
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_T);
+        __zdd out = zdd_intsec(zdd_a, zdd_T);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { {0}, {1} } /\\ { Ø }", [&]() {
-                /*
+      it("computes { {0}, {1} } /\\ { Ø }", [&]() {
+        /*
                        1        T             F          ---- x0
                       / \
                       2 T             ==>                ---- x1
                      / \
                      F T
-                */
+        */
 
-                node_file zdd_a;
+        node_file zdd_a;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
-                    ;
-                }
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_T);
+        __zdd out = zdd_intsec(zdd_a, zdd_T);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes (and shortcut) { {0,1}, {1} } /\\ { {0,1} }", [&]() {
-                /*
+      it("computes (and shortcut) { {0,1}, {1} } /\\ { {0,1} }", [&]() {
+        /*
                     _1_        1            1        ---- x0
                    /   \      / \          / \
                    2   3      F 2    ==>   F 2       ---- x1
                   / \ / \      / \          / \
                   T T F T      F T          F T
-                */
+        */
 
-                node_file zdd_a;
-                node_file zdd_b;
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(1,MAX_ID-1, sink_T, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(1,MAX_ID-1, sink_T, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes (and skip to sink) { {0}, {1}, {0,1} } /\\ { Ø }", [&]() {
-                /*
+      it("computes (and skip to sink) { {0}, {1}, {0,1} } /\\ { Ø }", [&]() {
+        /*
                     1        T          F     ---- x0
                    / \
                    \ /            ==>
                     2                         ---- x1
                    / \
                    F T
-                 */
+        */
 
-                node_file zdd_a;
+        node_file zdd_a;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID))
-                    ;
-                }
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_T);
+        __zdd out = zdd_intsec(zdd_a, zdd_T);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes (and skip to sink) { {0,2}, {0}, {2} } \\ { {1}, {2}, Ø }", [&]() {
-                /*
+      it("computes (and skip to sink) { {0,2}, {0}, {2} } \\ { {1}, {2}, Ø }", [&]() {
+        /*
                         1                             F       ---- x0
                        / \
                       /   \         _1_                         ---- x1
@@ -649,42 +649,42 @@ go_bandit([]() {
                      that (2) on the right technically is illegal, but it makes
                      for a much simpler counter-example that catches
                      prod_pq_1.peek() throwing an error on being empty.
-                 */
+        */
 
-                node_file zdd_a;
+        node_file zdd_a;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(2,MAX_ID, sink_T, sink_T)
-                       << create_node(2,MAX_ID-1, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
-                    ;
-                }
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(2,MAX_ID, sink_T, sink_T)
+               << create_node(2,MAX_ID-1, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
+            ;
+        }
 
-                node_file zdd_b;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID, sink_T, sink_F)
-                       << create_node(2,MAX_ID-1, sink_F, sink_T)
-                       << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
-                    ;
-                }
+        { // Garbage collect writers early
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID, sink_T, sink_F)
+               << create_node(2,MAX_ID-1, sink_F, sink_T)
+               << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes (and skips in) { {0,1,2}, {0,2}, {0}, {2} } } /\\ { {0,2}, {0}, {1}, {2} }", [&]() {
-                /*
+      it("computes (and skips in) { {0,1,2}, {0,2}, {0}, {2} } } /\\ { {0,2}, {0}, {1}, {2} }", [&]() {
+        /*
                         1             1                 (1,1)      ---- x0
                        / \           / \                /   \
                        | _2_        2   \              /     \
@@ -698,115 +698,115 @@ go_bandit([]() {
                        (3,3) : ((2,1), (2,0))   ,   (3,4) : ((2,1), (2,1))
 
                        so (3,3) is forwarded while (3,4) is not and hence (3,3) is output first.
-                */
-                node_file zdd_a;
+        */
+        node_file zdd_a;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(2,MAX_ID, sink_T, sink_T)
-                       << create_node(2,MAX_ID-1, sink_F, sink_T)
-                       << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
-                       << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID))
-                    ;
-                }
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(2,MAX_ID, sink_T, sink_T)
+               << create_node(2,MAX_ID-1, sink_F, sink_T)
+               << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID-1))
+               << create_node(0,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(1,MAX_ID))
+            ;
+        }
 
-                node_file zdd_b;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID, sink_T, sink_T)
-                       << create_node(2,MAX_ID-1, sink_F, sink_T)
-                       << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID-1), sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
-                    ;
-                }
+        { // Garbage collect writers early
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID, sink_T, sink_T)
+               << create_node(2,MAX_ID-1, sink_F, sink_T)
+               << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID-1), sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
 
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0}, {1} } /\\ { {0,1} }", [&]() {
-                /*
+      it("computes { {0}, {1} } /\\ { {0,1} }", [&]() {
+        /*
                     1          1                  (1,1)         ---- x0
                    / \        / \                 /   \
                    2 T        F 2                 F (T,2)       ---- x1
                   / \          / \       ==>         / \
                   F T          F T                   F F
-                 */
+        */
 
-                node_file zdd_a;
-                node_file zdd_b;
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, sink_F, create_node_ptr(1,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes (and skip) { {0}, {1}, {2}, {1,2}, {0,2} } /\\ { {0}, {2}, {0,2}, {0,1,2} }", [&]() {
-                /*
+      it("computes (and skip) { {0}, {1}, {2}, {1,2}, {0,2} } /\\ { {0}, {2}, {0,2}, {0,1,2} }", [&]() {
+        /*
                       1          1                 (1,1)         ---- x0
                      / \        / \                /   \
                      2 |        | 2               /     \        ---- x1
@@ -816,66 +816,66 @@ go_bandit([]() {
                    F T  T      F T  T            F T   F T
 
                    Notice, how (2,3) and (4,2) was skipped on the low and high of (1,1)
-                 */
+        */
 
-                node_file zdd_a;
-                node_file zdd_b;
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(2,MAX_ID,   sink_T, sink_T)
-                       << create_node(2,MAX_ID-1, sink_F, sink_T)
-                       << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
-                       << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(2,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(2,MAX_ID,   sink_T, sink_T)
+               << create_node(2,MAX_ID-1, sink_F, sink_T)
+               << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
+               << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID),   create_node_ptr(2,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID,   sink_T, sink_T)
-                       << create_node(2,MAX_ID-1, sink_F, sink_T)
-                       << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
-                       << create_node(0,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(1,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID,   sink_T, sink_T)
+               << create_node(2,MAX_ID-1, sink_F, sink_T)
+               << create_node(1,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(2,MAX_ID))
+               << create_node(0,MAX_ID,   create_node_ptr(2,MAX_ID-1), create_node_ptr(1,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,1) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,1), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,1)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes (and skip) { {0}, {1} } /\\ { {1}, {0,2} }", [&]() {
-                /*
+      it("computes (and skip) { {0}, {1} } /\\ { {1}, {0,2} }", [&]() {
+        /*
                      1         1                (1,1)      ---- x0
                     / \       / \               /   \
                     2 T       2  \            (2,2) F      ---- x1
@@ -883,59 +883,59 @@ go_bandit([]() {
                    F T       F T 3             F T         ---- x2
                                 / \
                                 F T
-                 */
+        */
 
-                node_file zdd_a;
-                node_file zdd_b;
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID, sink_F, sink_T)
-                       << create_node(1,MAX_ID, sink_F, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID, sink_F, sink_T)
+               << create_node(1,MAX_ID, sink_F, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes (and skip) { {0,2}, {1,2}, Ø } /\\ { {0,1}, {0}, {1} }", [&]() {
-                /*
+      it("computes (and skip) { {0,2}, {1,2}, Ø } /\\ { {0,1}, {0}, {1} }", [&]() {
+        /*
                      1         1                    (1,1)    ---- x0
                     / \       / \                   /   \
                     2  \      2 T                 (2,2) |    ---- x1
@@ -945,59 +945,59 @@ go_bandit([]() {
                      F T
 
                    This shortcuts the (3,T) tuple twice.
-                 */
+        */
 
-                node_file zdd_a;
-                node_file zdd_b;
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(2,MAX_ID, sink_F, sink_T)
-                       << create_node(1,MAX_ID, sink_T, create_node_ptr(2,MAX_ID))
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(2,MAX_ID, sink_F, sink_T)
+               << create_node(1,MAX_ID, sink_T, create_node_ptr(2,MAX_ID))
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(1,MAX_ID, sink_T, sink_T)
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(1,MAX_ID, sink_T, sink_T)
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), sink_T)
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes (and shortcut) { {0,2}, {1,2}, Ø } /\\ { {0,2}, {0} }", [&]() {
-                /*
+      it("computes (and shortcut) { {0,2}, {1,2}, Ø } /\\ { {0,2}, {0} }", [&]() {
+        /*
                      1            1               (1,1)     ---- x0
                     / \          / \               / \
                     2  \         F |               F |      ---- x1
@@ -1007,262 +1007,262 @@ go_bandit([]() {
                      F T          T T               F T
 
                    This shortcuts the (3,T) tuple twice.
-                 */
+        */
 
-                node_file zdd_a;
-                node_file zdd_b;
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(2,MAX_ID, sink_F, sink_T)
-                       << create_node(1,MAX_ID, sink_T, create_node_ptr(2,MAX_ID))
-                       << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(2,MAX_ID, sink_F, sink_T)
+               << create_node(1,MAX_ID, sink_T, create_node_ptr(2,MAX_ID))
+               << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(2,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(2,MAX_ID, sink_T, sink_T)
-                       << create_node(0,MAX_ID, sink_F, create_node_ptr(2,MAX_ID))
-                    ;
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(2,MAX_ID, sink_T, sink_T)
+               << create_node(0,MAX_ID, sink_F, create_node_ptr(2,MAX_ID))
+            ;
+        }
 
-                __zdd out = zdd_intsec(zdd_a, zdd_b);
+        __zdd out = zdd_intsec(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-          });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
+    });
 
-        describe("zdd_diff", [&]() {
-            it("should shortcut to Ø on same file for { {x0} }", [&]() {
-                __zdd out = zdd_diff(zdd_x0, zdd_x0);
+    describe("zdd_diff", [&]() {
+      it("should shortcut to Ø on same file for { {x0} }", [&]() {
+        __zdd out = zdd_diff(zdd_x0, zdd_x0);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("should shortcut to Ø on same file for { {x1} }", [&]() {
-                __zdd out = zdd_diff(zdd_x1, zdd_x1);
+      it("should shortcut to Ø on same file for { {x1} }", [&]() {
+        __zdd out = zdd_diff(zdd_x1, zdd_x1);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { Ø } \\ Ø", [&]() {
-                __zdd out = zdd_diff(zdd_T, zdd_F);
+      it("computes { Ø } \\ Ø", [&]() {
+        __zdd out = zdd_diff(zdd_T, zdd_F);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes Ø \\ { Ø }", [&]() {
-                __zdd out = zdd_diff(zdd_F, zdd_T);
+      it("computes Ø \\ { Ø }", [&]() {
+        __zdd out = zdd_diff(zdd_F, zdd_T);
 
-                node_test_stream out_nodes(out);
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        node_test_stream out_nodes(out);
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("should shortcut on irrelevance on { {x0} } \\ Ø", [&]() {
-                __zdd out_1 = zdd_diff(zdd_x0, zdd_F);
-                AssertThat(out_1.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
-              });
+      it("should shortcut on irrelevance on { {x0} } \\ Ø", [&]() {
+        __zdd out_1 = zdd_diff(zdd_x0, zdd_F);
+        AssertThat(out_1.get<node_file>()._file_ptr, Is().EqualTo(zdd_x0._file_ptr));
+      });
 
-            it("should shortcut on irrelevance on { {x1} } \\ Ø", [&]() {
-                __zdd out_2 = zdd_diff(zdd_x1, zdd_F);
-                AssertThat(out_2.get<node_file>()._file_ptr, Is().EqualTo(zdd_x1._file_ptr));
-              });
+      it("should shortcut on irrelevance on { {x1} } \\ Ø", [&]() {
+        __zdd out_2 = zdd_diff(zdd_x1, zdd_F);
+        AssertThat(out_2.get<node_file>()._file_ptr, Is().EqualTo(zdd_x1._file_ptr));
+      });
 
-            it("computes (and shortcut) Ø  \\ { {0} }", [&]() {
-                __zdd out = zdd_intsec(zdd_F, zdd_x0);
+      it("computes (and shortcut) Ø  \\ { {0} }", [&]() {
+        __zdd out = zdd_intsec(zdd_F, zdd_x0);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { {Ø} } \\ { {0} }", [&]() {
-                __zdd out = zdd_diff(zdd_T, zdd_x0);
+      it("computes { {Ø} } \\ { {0} }", [&]() {
+        __zdd out = zdd_diff(zdd_T, zdd_x0);
 
-                node_test_stream out_nodes(out);
+        node_test_stream out_nodes(out);
 
-                AssertThat(out_nodes.can_pull(), Is().True());
-                AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-                AssertThat(out_nodes.can_pull(), Is().False());
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-                AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
-              });
+        AssertThat(out.get<node_file>().meta_size(), Is().EqualTo(0u));
+      });
 
-            it("computes { {0} } \\ { Ø }", [&]() {
-                /*
+      it("computes { {0} } \\ { Ø }", [&]() {
+        /*
                    1      T            1       ---- x0
                   / \          ==>    / \
                   F T                 F T
-                */
-                __zdd out = zdd_diff(zdd_x0, zdd_T);
+        */
+        __zdd out = zdd_diff(zdd_x0, zdd_T);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0}, Ø } \\ { Ø }", [&]() {
-                /*
+      it("computes { {0}, Ø } \\ { Ø }", [&]() {
+        /*
                    1      T            1       ---- x0
                   / \          ==>    / \
                   T T                 F T
-                */
-                node_file zdd_a;
+        */
+        node_file zdd_a;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a << create_node(0,MAX_ID, sink_T, sink_T);
-                }
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a << create_node(0,MAX_ID, sink_T, sink_T);
+        }
 
-                __zdd out = zdd_diff(zdd_a, zdd_T);
+        __zdd out = zdd_diff(zdd_a, zdd_T);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0,1}, {1} } \\ { {1}, Ø }", [&]() {
-                /*
+      it("computes { {0,1}, {1} } \\ { {1}, Ø }", [&]() {
+        /*
                      1                      (1,1)       ---- x0
                      ||                     /   \
                      2      1     ==>    (2,1) (2,F)    ---- x1
                     / \    / \            / \   / \
                     F T    T T            F F   F T
-                */
-                node_file zdd_a;
-                node_file zdd_b;
+        */
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a  << create_node(1,MAX_ID, sink_F, sink_T)
-                        << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a  << create_node(1,MAX_ID, sink_F, sink_T)
+                << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID), create_node_ptr(1,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(1,MAX_ID, sink_T, sink_T);
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(1,MAX_ID, sink_T, sink_T);
+        }
 
-                __zdd out = zdd_diff(zdd_a, zdd_b);
+        __zdd out = zdd_diff(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
+        AssertThat(level_info.can_pull(), Is().False());
+      });
 
-            it("computes { {0,1}, {1,2}, {1} } \\ { {1}, Ø }", [&]() {
-                /*
+      it("computes { {0,1}, {1,2}, {1} } \\ { {1}, Ø }", [&]() {
+        /*
                      _1_                        (1,1)       ---- x0
                     /   \                       /   \
                     3   2      1     ==>    (3,1)   (2,F)    ---- x1
@@ -1270,67 +1270,67 @@ go_bandit([]() {
                    F 4 F T    T T           F (3,T)  F T    ---- x2
                     / \                        / \
                     T T                        F T
-                */
-                node_file zdd_a;
-                node_file zdd_b;
+        */
+        node_file zdd_a;
+        node_file zdd_b;
 
-                { // Garbage collect writers early
-                  node_writer nw_a(zdd_a);
-                  nw_a  << create_node(2,MAX_ID, sink_T, sink_T)
-                        << create_node(1,MAX_ID, sink_F, sink_T)
-                        << create_node(1,MAX_ID-1, sink_F, create_node_ptr(2,MAX_ID))
-                        << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
-                    ;
+        { // Garbage collect writers early
+          node_writer nw_a(zdd_a);
+          nw_a  << create_node(2,MAX_ID, sink_T, sink_T)
+                << create_node(1,MAX_ID, sink_F, sink_T)
+                << create_node(1,MAX_ID-1, sink_F, create_node_ptr(2,MAX_ID))
+                << create_node(0,MAX_ID, create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
+            ;
 
-                  node_writer nw_b(zdd_b);
-                  nw_b << create_node(1,MAX_ID, sink_T, sink_T);
-                }
+          node_writer nw_b(zdd_b);
+          nw_b << create_node(1,MAX_ID, sink_T, sink_T);
+        }
 
-                __zdd out = zdd_diff(zdd_a, zdd_b);
+        __zdd out = zdd_diff(zdd_a, zdd_b);
 
-                node_arc_test_stream node_arcs(out);
+        node_arc_test_stream node_arcs(out);
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(1,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(1,1) }));
 
-                AssertThat(node_arcs.can_pull(), Is().True());
-                AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,0) }));
+        AssertThat(node_arcs.can_pull(), Is().True());
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,0)), create_node_ptr(2,0) }));
 
-                AssertThat(node_arcs.can_pull(), Is().False());
+        AssertThat(node_arcs.can_pull(), Is().False());
 
-                sink_arc_test_stream sink_arcs(out);
+        sink_arc_test_stream sink_arcs(out);
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,0), sink_F }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(1,1), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(1,1)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
-                AssertThat(sink_arcs.can_pull(), Is().True());
-                AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { create_node_ptr(2,0), sink_F }));
+        AssertThat(sink_arcs.can_pull(), Is().True());
+        AssertThat(sink_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(2,0)), sink_T }));
 
-                AssertThat(sink_arcs.can_pull(), Is().False());
+        AssertThat(sink_arcs.can_pull(), Is().False());
 
-                level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
+        level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
-                AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(level_info.can_pull(), Is().True());
+        AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-                AssertThat(level_info.can_pull(), Is().False());
-              });
-          });
+        AssertThat(level_info.can_pull(), Is().False());
       });
+    });
   });
+ });

--- a/test/adiar/zdd/test_binop.cpp
+++ b/test/adiar/zdd/test_binop.cpp
@@ -116,7 +116,7 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -155,10 +155,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -234,16 +234,16 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -304,13 +304,13 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -393,16 +393,16 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,3u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,3u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -596,10 +596,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -750,10 +750,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -800,7 +800,7 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -866,10 +866,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -926,10 +926,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -988,10 +988,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1049,10 +1049,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1167,7 +1167,7 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1203,7 +1203,7 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1253,10 +1253,10 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });
@@ -1321,13 +1321,13 @@ go_bandit([]() {
                 level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
                 AssertThat(level_info.can_pull(), Is().True());
-                AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
                 AssertThat(level_info.can_pull(), Is().False());
               });

--- a/test/adiar/zdd/test_build.cpp
+++ b/test/adiar/zdd/test_build.cpp
@@ -65,7 +65,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -80,7 +80,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(42,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -118,7 +118,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(42,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -145,11 +145,11 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -187,7 +187,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(42,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -214,11 +214,11 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -256,7 +256,7 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(42,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -287,11 +287,11 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });
@@ -396,13 +396,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -454,11 +454,11 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -491,11 +491,11 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -575,11 +575,11 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -638,15 +638,15 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -711,15 +711,15 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -785,17 +785,17 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -860,15 +860,15 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -913,15 +913,15 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -969,13 +969,13 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -1100,23 +1100,23 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(9,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(9,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(7,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,4u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,4u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,4u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -1171,15 +1171,15 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,1u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
 
@@ -1357,25 +1357,25 @@ go_bandit([]() {
                 level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
 
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(9,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(9,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(8,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,4u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(7,5u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,5u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(6,6u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,6u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(5,6u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,6u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(4,5u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,5u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(3,4u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,4u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(2,3u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(1,2u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
                 AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
                 AssertThat(ms.can_pull(), Is().False());
               });
           });

--- a/test/adiar/zdd/test_build.cpp
+++ b/test/adiar/zdd/test_build.cpp
@@ -1,1383 +1,1383 @@
 go_bandit([]() {
-    describe("ZDD: Build", [&]() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
-
-        describe("zdd_sink", [&]() {
-            it("can create { Ø } [zdd_sink]", [&]() {
-                zdd res = zdd_sink(true);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { Ø } [zdd_null]", [&]() {
-                zdd res = zdd_null();
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create Ø [zdd_sink]", [&]() {
-                zdd res = zdd_sink(false);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create Ø [zdd_empty]", [&]() {
-                zdd res = zdd_empty();
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("zdd_ithvar", [&]() {
-            it("can create { {0} }", [&]() {
-                zdd res = zdd_ithvar(0);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { {42} }", [&]() {
-                zdd res = zdd_ithvar(42);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("zdd_vars", [&]() {
-            it("can create { Ø } on empty list", [&]() {
-                label_file labels;
-
-                zdd res = zdd_vars(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { {42} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 42;
-                }
-
-                zdd res = zdd_vars(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { {1,2,5} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 5;
-                }
-
-                zdd res = zdd_vars(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, create_node_ptr(5,MAX_ID))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID, sink_F, create_node_ptr(2,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("zdd_singletons", [&]() {
-            it("can create Ø on empty list", [&]() {
-                label_file labels;
-
-                zdd res = zdd_singletons(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { {42} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 42;
-                }
-
-                zdd res = zdd_singletons(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { {1}, {2}, {5} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 5;
-                }
-
-                zdd res = zdd_singletons(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID, sink_F, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, create_node_ptr(5,MAX_ID), sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID, create_node_ptr(2,MAX_ID), sink_T)));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("zdd_powerset", [&]() {
-            it("can create { Ø } on empty list", [&]() {
-                label_file labels;
-
-                zdd res = zdd_powerset(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { Ø, {42} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 42;
-                }
-
-                zdd res = zdd_powerset(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_T, sink_T)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { Ø, {1}, {2}, {5}, {1,2}, {1,5}, {2,5}, {1,2,5} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 5;
-                }
-
-                zdd res = zdd_powerset(labels);
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID, sink_T, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                               create_node_ptr(5,MAX_ID),
-                                                               create_node_ptr(5,MAX_ID))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                               create_node_ptr(2,MAX_ID),
-                                                               create_node_ptr(2,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
-
-        describe("zdd_sized_sets", [&]() {
-            // Edge cases
-            it("can compute { s <= Ø | |s| <= 0 } to be { Ø }", [&]() {
-                label_file labels;
-                zdd res = zdd_sized_sets(labels, 0, std::less_equal<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= Ø | |s| > 0 } to be Ø", [&]() {
-                label_file labels;
-                zdd res = zdd_sized_sets(labels, 0, std::greater<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {1,2,3} | |s| < 0 } to be Ø", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 3;
-                }
-
-                zdd res = zdd_sized_sets(labels, 0, std::less<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,2,4,6} | |s| <= 0 } to be { Ø }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6;
-                }
-
-                zdd res = zdd_sized_sets(labels, 0, std::less_equal<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,2,4,6} | |s| < 42 } to be the powerset", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6;
-                }
-
-                zdd res = zdd_sized_sets(labels, 42, std::less<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, MAX_ID, sink_T, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, MAX_ID,
-                                                               create_node_ptr(6,MAX_ID),
-                                                               create_node_ptr(6,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                               create_node_ptr(4,MAX_ID),
-                                                               create_node_ptr(4,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                               create_node_ptr(2,MAX_ID),
-                                                               create_node_ptr(2,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,2,4,6} | |s| > 42 } to be Ø", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6;
-                }
-
-                zdd res = zdd_sized_sets(labels, 42, std::greater<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,1,2} | |s| <= 3 } to be the powerset", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 1 << 2;
-                }
-
-                zdd res = zdd_sized_sets(labels, 3, std::less_equal<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_T, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                               create_node_ptr(2,MAX_ID),
-                                                               create_node_ptr(2,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                               create_node_ptr(1,MAX_ID),
-                                                               create_node_ptr(1,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,1,2} | |s| == 3 } to be the { {0,1,2} }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 1 << 2;
-                }
-
-                zdd res = zdd_sized_sets(labels, 3, std::equal_to<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
-                                                               sink_F,
-                                                               create_node_ptr(2,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                               sink_F,
-                                                               create_node_ptr(1,MAX_ID))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,2,3} | |s| > 3 } to be Ø", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 3;
-                }
-
-                zdd res = zdd_sized_sets(labels, 3, std::greater<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can compute { s <= {0,1,2} | |s| < 1 } to be { Ø }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 1 << 2;
-                }
-
-                zdd res = zdd_sized_sets(labels, 1, std::less<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            // TODO: More edge cases
-            //  - Always true predicate
-            //  - always false predicate
-
-            // General case
-            it("can create { s <= {1,3,5} | |s| == 2 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 3 << 5;
-                }
-
-                zdd res = zdd_sized_sets(labels, 2, std::equal_to<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(5,1),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               sink_F,
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {1,2,3,4,6} | |s| == 3 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 3 << 4 << 6;
-                }
-
-                zdd res = zdd_sized_sets(labels, 3, std::equal_to<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
-                                                               create_node_ptr(6,2),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               sink_F,
-                                                               create_node_ptr(6,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
-                                                               create_node_ptr(4,2),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               sink_F,
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(3,1),
-                                                               create_node_ptr(3,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,2,4,6,8} | |s| >= 2 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6 << 8;
-                }
-
-                zdd res = zdd_sized_sets(labels, 2, std::greater_equal<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2, sink_T, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 1, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
-                                                               create_node_ptr(8,2),
-                                                               create_node_ptr(8,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
-                                                               create_node_ptr(8,1),
-                                                               create_node_ptr(8,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
-                                                               sink_F,
-                                                               create_node_ptr(8,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
-                                                               create_node_ptr(6,2),
-                                                               create_node_ptr(6,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(6,1),
-                                                               create_node_ptr(6,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(6,0),
-                                                               create_node_ptr(6,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,1,2,3,4,5} | |s| > 0 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 1 << 2 << 3 << 4 << 5;
-                }
-
-                zdd res = zdd_sized_sets(labels, 0, std::greater<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1, sink_T, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(5,1),
-                                                               create_node_ptr(5,1))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(5,0),
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,1))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(3,1),
-                                                               create_node_ptr(3,1))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
-                                                               create_node_ptr(2,1),
-                                                               create_node_ptr(2,1))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(1,0),
-                                                               create_node_ptr(1,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,1,2,3,5} | |s| > 1 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 1 << 2 << 3 << 5;
-                }
-
-                zdd res = zdd_sized_sets(labels, 1, std::greater<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2, sink_T, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
-                                                               create_node_ptr(5,2),
-                                                               create_node_ptr(5,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(5,1),
-                                                               create_node_ptr(5,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               sink_F,
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 2,
-                                                               create_node_ptr(3,2),
-                                                               create_node_ptr(3,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(3,1),
-                                                               create_node_ptr(3,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
-                                                               create_node_ptr(2,1),
-                                                               create_node_ptr(2,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(1,0),
-                                                               create_node_ptr(1,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,2,4,6,8} | |s| < 2 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6 << 8;
-                }
-
-                zdd res = zdd_sized_sets(labels, 2, std::less<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 0,
-                                                               sink_T,
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
-                                                               create_node_ptr(8,0),
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(6,0),
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(4,0),
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(2,0),
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,2,4,6} | |s| < 3 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6;
-                }
-
-                zdd res = zdd_sized_sets(labels, 3, std::less<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
-                                                               sink_T,
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(6,1),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(6,1),
-                                                               create_node_ptr(6,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(4,1),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {1,2,3,4,5,6,7,8,9} | |s| < 5 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9;
-                }
-
-                zdd res = zdd_sized_sets(labels, 5, std::less<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(9, 3,
-                                                               sink_T,
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 3,
-                                                               create_node_ptr(9,3),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2,
-                                                               create_node_ptr(9,3),
-                                                               create_node_ptr(9,3))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 3,
-                                                               create_node_ptr(8,3),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 2,
-                                                               create_node_ptr(8,2),
-                                                               create_node_ptr(8,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 1,
-                                                               create_node_ptr(8,2),
-                                                               create_node_ptr(8,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 3,
-                                                               create_node_ptr(7,3),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
-                                                               create_node_ptr(7,2),
-                                                               create_node_ptr(7,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
-                                                               create_node_ptr(7,1),
-                                                               create_node_ptr(7,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
-                                                               create_node_ptr(7,1),
-                                                               create_node_ptr(7,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 3,
-                                                               create_node_ptr(6,3),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
-                                                               create_node_ptr(6,2),
-                                                               create_node_ptr(6,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
-                                                               create_node_ptr(6,1),
-                                                               create_node_ptr(6,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
-                                                               create_node_ptr(6,0),
-                                                               create_node_ptr(6,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 3,
-                                                               create_node_ptr(5,3),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
-                                                               create_node_ptr(5,2),
-                                                               create_node_ptr(5,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(5,1),
-                                                               create_node_ptr(5,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(5,0),
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
-                                                               create_node_ptr(4,2),
-                                                               create_node_ptr(4,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(3,1),
-                                                               create_node_ptr(3,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(9,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,4u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,4u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,4u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,2,4,6,8} | |s| <= 2 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 2 << 4 << 6 << 8;
-                }
-
-                zdd res = zdd_sized_sets(labels, 2, std::less_equal<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 1, sink_T, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
-                                                               create_node_ptr(8,1),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
-                                                               create_node_ptr(8,1),
-                                                               create_node_ptr(8,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(6,1),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(6,0),
-                                                               create_node_ptr(6,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(4,1),
-                                                               sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,1u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-
-            it("can create { s <= {0,2,4,6,8} | |s| != 4 }", [&]() {
-                label_file labels;
-
-                { // Garbage collect writer to free write-lock
-                  label_writer lw(labels);
-                  lw << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9;
-                }
-
-                zdd res = zdd_sized_sets(labels, 4, std::not_equal_to<label_t>());
-                node_test_stream ns(res);
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(9, 5, sink_T, sink_T)));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(9, 4, sink_F, sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 5,
-                                                               create_node_ptr(9,5),
-                                                               create_node_ptr(9,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 4,
-                                                               create_node_ptr(9,4),
-                                                               create_node_ptr(9,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 3,
-                                                               sink_T,
-                                                               create_node_ptr(9,4))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2,
-                                                               create_node_ptr(9,5),
-                                                               sink_T)));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 5,
-                                                               create_node_ptr(8,5),
-                                                               create_node_ptr(8,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 4,
-                                                               create_node_ptr(8,4),
-                                                               create_node_ptr(8,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 3,
-                                                               create_node_ptr(8,3),
-                                                               create_node_ptr(8,4))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 2,
-                                                               create_node_ptr(8,2),
-                                                               create_node_ptr(8,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(7, 1,
-                                                               create_node_ptr(8,5),
-                                                               create_node_ptr(8,2))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 5,
-                                                               create_node_ptr(7,5),
-                                                               create_node_ptr(7,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 4,
-                                                               create_node_ptr(7,4),
-                                                               create_node_ptr(7,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 3,
-                                                               create_node_ptr(7,3),
-                                                               create_node_ptr(7,4))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
-                                                               create_node_ptr(7,2),
-                                                               create_node_ptr(7,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
-                                                               create_node_ptr(7,1),
-                                                               create_node_ptr(7,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
-                                                               create_node_ptr(7,5),
-                                                               create_node_ptr(7,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 5,
-                                                               create_node_ptr(6,5),
-                                                               create_node_ptr(6,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 4,
-                                                               create_node_ptr(6,4),
-                                                               create_node_ptr(6,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 3,
-                                                               create_node_ptr(6,3),
-                                                               create_node_ptr(6,4))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
-                                                               create_node_ptr(6,2),
-                                                               create_node_ptr(6,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
-                                                               create_node_ptr(6,1),
-                                                               create_node_ptr(6,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
-                                                               create_node_ptr(6,0),
-                                                               create_node_ptr(6,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 4,
-                                                               create_node_ptr(5,4),
-                                                               create_node_ptr(5,5))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 3,
-                                                               create_node_ptr(5,3),
-                                                               create_node_ptr(5,4))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
-                                                               create_node_ptr(5,2),
-                                                               create_node_ptr(5,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
-                                                               create_node_ptr(5,1),
-                                                               create_node_ptr(5,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
-                                                               create_node_ptr(5,0),
-                                                               create_node_ptr(5,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 3,
-                                                               create_node_ptr(4,3),
-                                                               create_node_ptr(4,4))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
-                                                               create_node_ptr(4,2),
-                                                               create_node_ptr(4,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
-                                                               create_node_ptr(4,1),
-                                                               create_node_ptr(4,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
-                                                               create_node_ptr(4,0),
-                                                               create_node_ptr(4,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 2,
-                                                               create_node_ptr(3,2),
-                                                               create_node_ptr(3,3))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
-                                                               create_node_ptr(3,1),
-                                                               create_node_ptr(3,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
-                                                               create_node_ptr(3,0),
-                                                               create_node_ptr(3,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
-                                                               create_node_ptr(2,1),
-                                                               create_node_ptr(2,2))));
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
-                                                               create_node_ptr(2,0),
-                                                               create_node_ptr(2,1))));
-
-                AssertThat(ns.can_pull(), Is().True());
-                AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
-                                                               create_node_ptr(1,0),
-                                                               create_node_ptr(1,1))));
-
-                AssertThat(ns.can_pull(), Is().False());
-
-                level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
-
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(9,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,4u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,5u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,6u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,6u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,5u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,4u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
-                AssertThat(ms.can_pull(), Is().True());
-                AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
-                AssertThat(ms.can_pull(), Is().False());
-              });
-          });
+  describe("ZDD: Build", [&]() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
+
+    describe("zdd_sink", [&]() {
+      it("can create { Ø } [zdd_sink]", [&]() {
+        zdd res = zdd_sink(true);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
       });
+
+      it("can create { Ø } [zdd_null]", [&]() {
+        zdd res = zdd_null();
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create Ø [zdd_sink]", [&]() {
+        zdd res = zdd_sink(false);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create Ø [zdd_empty]", [&]() {
+        zdd res = zdd_empty();
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("zdd_ithvar", [&]() {
+      it("can create { {0} }", [&]() {
+        zdd res = zdd_ithvar(0);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { {42} }", [&]() {
+        zdd res = zdd_ithvar(42);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("zdd_vars", [&]() {
+      it("can create { Ø } on empty list", [&]() {
+        label_file labels;
+
+        zdd res = zdd_vars(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { {42} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 42;
+        }
+
+        zdd res = zdd_vars(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { {1,2,5} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 5;
+        }
+
+        zdd res = zdd_vars(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, create_node_ptr(5,MAX_ID))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID, sink_F, create_node_ptr(2,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("zdd_singletons", [&]() {
+      it("can create Ø on empty list", [&]() {
+        label_file labels;
+
+        zdd res = zdd_singletons(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { {42} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 42;
+        }
+
+        zdd res = zdd_singletons(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { {1}, {2}, {5} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 5;
+        }
+
+        zdd res = zdd_singletons(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID, sink_F, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, create_node_ptr(5,MAX_ID), sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID, create_node_ptr(2,MAX_ID), sink_T)));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("zdd_powerset", [&]() {
+      it("can create { Ø } on empty list", [&]() {
+        label_file labels;
+
+        zdd res = zdd_powerset(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { Ø, {42} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 42;
+        }
+
+        zdd res = zdd_powerset(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(42, MAX_ID, sink_T, sink_T)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(42,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { Ø, {1}, {2}, {5}, {1,2}, {1,5}, {2,5}, {1,2,5} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 5;
+        }
+
+        zdd res = zdd_powerset(labels);
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, MAX_ID, sink_T, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                       create_node_ptr(5,MAX_ID),
+                                                       create_node_ptr(5,MAX_ID))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                       create_node_ptr(2,MAX_ID),
+                                                       create_node_ptr(2,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
+
+    describe("zdd_sized_sets", [&]() {
+      // Edge cases
+      it("can compute { s <= Ø | |s| <= 0 } to be { Ø }", [&]() {
+        label_file labels;
+        zdd res = zdd_sized_sets(labels, 0, std::less_equal<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= Ø | |s| > 0 } to be Ø", [&]() {
+        label_file labels;
+        zdd res = zdd_sized_sets(labels, 0, std::greater<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {1,2,3} | |s| < 0 } to be Ø", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 3;
+        }
+
+        zdd res = zdd_sized_sets(labels, 0, std::less<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,2,4,6} | |s| <= 0 } to be { Ø }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6;
+        }
+
+        zdd res = zdd_sized_sets(labels, 0, std::less_equal<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,2,4,6} | |s| < 42 } to be the powerset", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6;
+        }
+
+        zdd res = zdd_sized_sets(labels, 42, std::less<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, MAX_ID, sink_T, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, MAX_ID,
+                                                       create_node_ptr(6,MAX_ID),
+                                                       create_node_ptr(6,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                       create_node_ptr(4,MAX_ID),
+                                                       create_node_ptr(4,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                       create_node_ptr(2,MAX_ID),
+                                                       create_node_ptr(2,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,2,4,6} | |s| > 42 } to be Ø", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6;
+        }
+
+        zdd res = zdd_sized_sets(labels, 42, std::greater<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,1,2} | |s| <= 3 } to be the powerset", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 1 << 2;
+        }
+
+        zdd res = zdd_sized_sets(labels, 3, std::less_equal<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_T, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                       create_node_ptr(2,MAX_ID),
+                                                       create_node_ptr(2,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                       create_node_ptr(1,MAX_ID),
+                                                       create_node_ptr(1,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,1,2} | |s| == 3 } to be the { {0,1,2} }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 1 << 2;
+        }
+
+        zdd res = zdd_sized_sets(labels, 3, std::equal_to<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, MAX_ID, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, MAX_ID,
+                                                       sink_F,
+                                                       create_node_ptr(2,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                       sink_F,
+                                                       create_node_ptr(1,MAX_ID))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,2,3} | |s| > 3 } to be Ø", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 3;
+        }
+
+        zdd res = zdd_sized_sets(labels, 3, std::greater<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(false)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can compute { s <= {0,1,2} | |s| < 1 } to be { Ø }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 1 << 2;
+        }
+
+        zdd res = zdd_sized_sets(labels, 1, std::less<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_sink(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      // TODO: More edge cases
+      //  - Always true predicate
+      //  - always false predicate
+
+      // General case
+      it("can create { s <= {1,3,5} | |s| == 2 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 3 << 5;
+        }
+
+        zdd res = zdd_sized_sets(labels, 2, std::equal_to<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(5,1),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       sink_F,
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {1,2,3,4,6} | |s| == 3 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 3 << 4 << 6;
+        }
+
+        zdd res = zdd_sized_sets(labels, 3, std::equal_to<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
+                                                       create_node_ptr(6,2),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       sink_F,
+                                                       create_node_ptr(6,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
+                                                       create_node_ptr(4,2),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       sink_F,
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(3,1),
+                                                       create_node_ptr(3,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,2,4,6,8} | |s| >= 2 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6 << 8;
+        }
+
+        zdd res = zdd_sized_sets(labels, 2, std::greater_equal<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2, sink_T, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 1, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
+                                                       create_node_ptr(8,2),
+                                                       create_node_ptr(8,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
+                                                       create_node_ptr(8,1),
+                                                       create_node_ptr(8,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
+                                                       sink_F,
+                                                       create_node_ptr(8,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
+                                                       create_node_ptr(6,2),
+                                                       create_node_ptr(6,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(6,1),
+                                                       create_node_ptr(6,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(6,0),
+                                                       create_node_ptr(6,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,1,2,3,4,5} | |s| > 0 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 1 << 2 << 3 << 4 << 5;
+        }
+
+        zdd res = zdd_sized_sets(labels, 0, std::greater<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1, sink_T, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(5,1),
+                                                       create_node_ptr(5,1))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(5,0),
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,1))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(3,1),
+                                                       create_node_ptr(3,1))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
+                                                       create_node_ptr(2,1),
+                                                       create_node_ptr(2,1))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(1,0),
+                                                       create_node_ptr(1,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,1,2,3,5} | |s| > 1 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 1 << 2 << 3 << 5;
+        }
+
+        zdd res = zdd_sized_sets(labels, 1, std::greater<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2, sink_T, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
+                                                       create_node_ptr(5,2),
+                                                       create_node_ptr(5,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(5,1),
+                                                       create_node_ptr(5,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       sink_F,
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 2,
+                                                       create_node_ptr(3,2),
+                                                       create_node_ptr(3,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(3,1),
+                                                       create_node_ptr(3,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
+                                                       create_node_ptr(2,1),
+                                                       create_node_ptr(2,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(1,0),
+                                                       create_node_ptr(1,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,2,4,6,8} | |s| < 2 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6 << 8;
+        }
+
+        zdd res = zdd_sized_sets(labels, 2, std::less<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 0,
+                                                       sink_T,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
+                                                       create_node_ptr(8,0),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(6,0),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(4,0),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(2,0),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,2,4,6} | |s| < 3 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6;
+        }
+
+        zdd res = zdd_sized_sets(labels, 3, std::less<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
+                                                       sink_T,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(6,1),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(6,1),
+                                                       create_node_ptr(6,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(4,1),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {1,2,3,4,5,6,7,8,9} | |s| < 5 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9;
+        }
+
+        zdd res = zdd_sized_sets(labels, 5, std::less<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(9, 3,
+                                                       sink_T,
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 3,
+                                                       create_node_ptr(9,3),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2,
+                                                       create_node_ptr(9,3),
+                                                       create_node_ptr(9,3))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 3,
+                                                       create_node_ptr(8,3),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 2,
+                                                       create_node_ptr(8,2),
+                                                       create_node_ptr(8,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 1,
+                                                       create_node_ptr(8,2),
+                                                       create_node_ptr(8,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 3,
+                                                       create_node_ptr(7,3),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
+                                                       create_node_ptr(7,2),
+                                                       create_node_ptr(7,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
+                                                       create_node_ptr(7,1),
+                                                       create_node_ptr(7,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
+                                                       create_node_ptr(7,1),
+                                                       create_node_ptr(7,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 3,
+                                                       create_node_ptr(6,3),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
+                                                       create_node_ptr(6,2),
+                                                       create_node_ptr(6,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
+                                                       create_node_ptr(6,1),
+                                                       create_node_ptr(6,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
+                                                       create_node_ptr(6,0),
+                                                       create_node_ptr(6,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 3,
+                                                       create_node_ptr(5,3),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
+                                                       create_node_ptr(5,2),
+                                                       create_node_ptr(5,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(5,1),
+                                                       create_node_ptr(5,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(5,0),
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
+                                                       create_node_ptr(4,2),
+                                                       create_node_ptr(4,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(3,1),
+                                                       create_node_ptr(3,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(9,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,4u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,4u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,4u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,2,4,6,8} | |s| <= 2 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 2 << 4 << 6 << 8;
+        }
+
+        zdd res = zdd_sized_sets(labels, 2, std::less_equal<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 1, sink_T, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
+                                                       create_node_ptr(8,1),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
+                                                       create_node_ptr(8,1),
+                                                       create_node_ptr(8,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(6,1),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(6,0),
+                                                       create_node_ptr(6,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(4,1),
+                                                       sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,1u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+
+      it("can create { s <= {0,2,4,6,8} | |s| != 4 }", [&]() {
+        label_file labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9;
+        }
+
+        zdd res = zdd_sized_sets(labels, 4, std::not_equal_to<label_t>());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(9, 5, sink_T, sink_T)));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(9, 4, sink_F, sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 5,
+                                                       create_node_ptr(9,5),
+                                                       create_node_ptr(9,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 4,
+                                                       create_node_ptr(9,4),
+                                                       create_node_ptr(9,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 3,
+                                                       sink_T,
+                                                       create_node_ptr(9,4))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(8, 2,
+                                                       create_node_ptr(9,5),
+                                                       sink_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 5,
+                                                       create_node_ptr(8,5),
+                                                       create_node_ptr(8,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 4,
+                                                       create_node_ptr(8,4),
+                                                       create_node_ptr(8,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 3,
+                                                       create_node_ptr(8,3),
+                                                       create_node_ptr(8,4))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 2,
+                                                       create_node_ptr(8,2),
+                                                       create_node_ptr(8,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(7, 1,
+                                                       create_node_ptr(8,5),
+                                                       create_node_ptr(8,2))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 5,
+                                                       create_node_ptr(7,5),
+                                                       create_node_ptr(7,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 4,
+                                                       create_node_ptr(7,4),
+                                                       create_node_ptr(7,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 3,
+                                                       create_node_ptr(7,3),
+                                                       create_node_ptr(7,4))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 2,
+                                                       create_node_ptr(7,2),
+                                                       create_node_ptr(7,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 1,
+                                                       create_node_ptr(7,1),
+                                                       create_node_ptr(7,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(6, 0,
+                                                       create_node_ptr(7,5),
+                                                       create_node_ptr(7,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 5,
+                                                       create_node_ptr(6,5),
+                                                       create_node_ptr(6,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 4,
+                                                       create_node_ptr(6,4),
+                                                       create_node_ptr(6,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 3,
+                                                       create_node_ptr(6,3),
+                                                       create_node_ptr(6,4))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 2,
+                                                       create_node_ptr(6,2),
+                                                       create_node_ptr(6,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 1,
+                                                       create_node_ptr(6,1),
+                                                       create_node_ptr(6,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(5, 0,
+                                                       create_node_ptr(6,0),
+                                                       create_node_ptr(6,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 4,
+                                                       create_node_ptr(5,4),
+                                                       create_node_ptr(5,5))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 3,
+                                                       create_node_ptr(5,3),
+                                                       create_node_ptr(5,4))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 2,
+                                                       create_node_ptr(5,2),
+                                                       create_node_ptr(5,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 1,
+                                                       create_node_ptr(5,1),
+                                                       create_node_ptr(5,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(4, 0,
+                                                       create_node_ptr(5,0),
+                                                       create_node_ptr(5,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 3,
+                                                       create_node_ptr(4,3),
+                                                       create_node_ptr(4,4))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 2,
+                                                       create_node_ptr(4,2),
+                                                       create_node_ptr(4,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 1,
+                                                       create_node_ptr(4,1),
+                                                       create_node_ptr(4,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(3, 0,
+                                                       create_node_ptr(4,0),
+                                                       create_node_ptr(4,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 2,
+                                                       create_node_ptr(3,2),
+                                                       create_node_ptr(3,3))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 1,
+                                                       create_node_ptr(3,1),
+                                                       create_node_ptr(3,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(2, 0,
+                                                       create_node_ptr(3,0),
+                                                       create_node_ptr(3,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 1,
+                                                       create_node_ptr(2,1),
+                                                       create_node_ptr(2,2))));
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(1, 0,
+                                                       create_node_ptr(2,0),
+                                                       create_node_ptr(2,1))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(create_node(0, 0,
+                                                       create_node_ptr(1,0),
+                                                       create_node_ptr(1,1))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream<node_t, NODE_FILE_COUNT> ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(9,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(8,4u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(7,5u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(6,6u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(5,6u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,5u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,4u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,3u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(1,2u)));
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+        AssertThat(ms.can_pull(), Is().False());
+      });
+    });
   });
+ });

--- a/test/adiar/zdd/test_change.cpp
+++ b/test/adiar/zdd/test_change.cpp
@@ -107,10 +107,10 @@ go_bandit([]() {
       level_info_test_stream<node_t, NODE_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -148,10 +148,10 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -202,13 +202,13 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -252,13 +252,13 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -302,13 +302,13 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -358,16 +358,16 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(4,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(4,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -426,13 +426,13 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -516,7 +516,7 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -562,10 +562,10 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -606,7 +606,7 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -645,7 +645,7 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -691,10 +691,10 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -750,16 +750,16 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -818,13 +818,13 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -886,16 +886,16 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,2u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,2u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -973,10 +973,10 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -1024,10 +1024,10 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -1080,13 +1080,13 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -1145,10 +1145,10 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });
@@ -1218,16 +1218,16 @@ go_bandit([]() {
       level_info_test_stream<arc_t, ARC_FILE_COUNT> level_info(out);
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(0,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(0,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(1,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(1,1u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(2,2u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(2,2u)));
 
       AssertThat(level_info.can_pull(), Is().True());
-      AssertThat(level_info.pull(), Is().EqualTo(create_meta(3,1u)));
+      AssertThat(level_info.pull(), Is().EqualTo(create_level_info(3,1u)));
 
       AssertThat(level_info.can_pull(), Is().False());
     });

--- a/test/adiar/zdd/test_count.cpp
+++ b/test/adiar/zdd/test_count.cpp
@@ -1,10 +1,10 @@
 go_bandit([]() {
-    describe("ZDD: Count", [&]() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+  describe("ZDD: Count", [&]() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        node_file zdd_1;
-        /*
+    node_file zdd_1;
+    /*
              1       ---- x0
             / \
             | 2      ---- x1
@@ -14,19 +14,19 @@ go_bandit([]() {
            F  4      ---- x3
              / \
              F T
-        */
-        { // Garbage collect writer to free write-lock
-          node_t n4 = create_node(3,0, sink_F, sink_T);
-          node_t n3 = create_node(2,0, sink_F, n4.uid);
-          node_t n2 = create_node(1,0, n3.uid, n4.uid);
-          node_t n1 = create_node(0,0, n3.uid, n2.uid);
+    */
+    { // Garbage collect writer to free write-lock
+      node_t n4 = create_node(3,0, sink_F, sink_T);
+      node_t n3 = create_node(2,0, sink_F, n4.uid);
+      node_t n2 = create_node(1,0, n3.uid, n4.uid);
+      node_t n1 = create_node(0,0, n3.uid, n2.uid);
 
-          node_writer nw_1(zdd_1);
-          nw_1 << n4 << n3 << n2 << n1;
-        }
+      node_writer nw_1(zdd_1);
+      nw_1 << n4 << n3 << n2 << n1;
+    }
 
-        node_file zdd_2;
-        /*
+    node_file zdd_2;
+    /*
                      ---- x0
 
               1      ---- x1
@@ -34,90 +34,90 @@ go_bandit([]() {
             2  |     ---- x2
            / \ /
            F  T
-        */
-        { // Garbage collect writer to free write-lock
-          node_t n2 = create_node(2,0, sink_F, sink_T);
-          node_t n1 = create_node(1,0, n2.uid, sink_T);
+    */
+    { // Garbage collect writer to free write-lock
+      node_t n2 = create_node(2,0, sink_F, sink_T);
+      node_t n1 = create_node(1,0, n2.uid, sink_T);
 
-          node_writer nw_2(zdd_2);
-          nw_2 << n2 << n1;
-        }
+      node_writer nw_2(zdd_2);
+      nw_2 << n2 << n1;
+    }
 
-        node_file zdd_T;
-        /*
+    node_file zdd_T;
+    /*
           T
-        */
-        // This describes the set {}
+    */
+    // This describes the set {}
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw_T(zdd_T);
-          nw_T << create_sink(true);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw_T(zdd_T);
+      nw_T << create_sink(true);
+    }
 
-        node_file zdd_F;
-        /*
+    node_file zdd_F;
+    /*
           F
-        */
-        // This describes no set
+    */
+    // This describes no set
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw_F(zdd_F);
-          nw_F << create_sink(false);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw_F(zdd_F);
+      nw_F << create_sink(false);
+    }
 
-        node_file zdd_root_1;
-        /*
+    node_file zdd_root_1;
+    /*
            1    ---- x1
           / \
           F T
-        */
-        // This describes the set { 1 }
+    */
+    // This describes the set { 1 }
 
-        { // Garbage collect writer to free write-lock
-          node_writer nw_root_1(zdd_root_1);
-          nw_root_1 << create_node(1,0, sink_F, sink_T);
-        }
+    { // Garbage collect writer to free write-lock
+      node_writer nw_root_1(zdd_root_1);
+      nw_root_1 << create_node(1,0, sink_F, sink_T);
+    }
 
-        describe("nodecount", [&]() {
-            it("can count number of nodes", [&]() {
-                AssertThat(zdd_nodecount(zdd_1), Is().EqualTo(4u));
-                AssertThat(zdd_nodecount(zdd_2), Is().EqualTo(2u));
-                AssertThat(zdd_nodecount(zdd_T), Is().EqualTo(0u));
-                AssertThat(zdd_nodecount(zdd_F), Is().EqualTo(0u));
-                AssertThat(zdd_nodecount(zdd_root_1), Is().EqualTo(1u));
-              });
-          });
-
-        describe("varcount", [&]() {
-            it("can count number of variables", [&]() {
-                AssertThat(zdd_varcount(zdd_1), Is().EqualTo(4u));
-                AssertThat(zdd_varcount(zdd_2), Is().EqualTo(2u));
-                AssertThat(zdd_varcount(zdd_T), Is().EqualTo(0u));
-                AssertThat(zdd_varcount(zdd_F), Is().EqualTo(0u));
-                AssertThat(zdd_varcount(zdd_root_1), Is().EqualTo(1u));
-              });
-          });
-
-        describe("size", [&]() {
-            it("can count family { {x2, x3}, {x0, x2, x3}, {x0, x1, x3} } [1]", [&]() {
-                AssertThat(zdd_size(zdd_1), Is().EqualTo(3u));
-              });
-
-            it("can count family { {x1}, {x2} } [2]", [&]() {
-                AssertThat(zdd_size(zdd_2), Is().EqualTo(2u));
-              });
-
-            it("can count family { Ø } [T]", [&]() {
-                AssertThat(zdd_size(zdd_T), Is().EqualTo(1u));
-              });
-
-            it("can count family Ø [F]", [&]() {
-                AssertThat(zdd_size(zdd_F), Is().EqualTo(0u));
-              });
-
-            it("can count family { 1 } [root_1]", [&]() {
-                AssertThat(zdd_size(zdd_root_1), Is().EqualTo(1u));
-              });
-          });
+    describe("nodecount", [&]() {
+      it("can count number of nodes", [&]() {
+        AssertThat(zdd_nodecount(zdd_1), Is().EqualTo(4u));
+        AssertThat(zdd_nodecount(zdd_2), Is().EqualTo(2u));
+        AssertThat(zdd_nodecount(zdd_T), Is().EqualTo(0u));
+        AssertThat(zdd_nodecount(zdd_F), Is().EqualTo(0u));
+        AssertThat(zdd_nodecount(zdd_root_1), Is().EqualTo(1u));
       });
+    });
+
+    describe("varcount", [&]() {
+      it("can count number of variables", [&]() {
+        AssertThat(zdd_varcount(zdd_1), Is().EqualTo(4u));
+        AssertThat(zdd_varcount(zdd_2), Is().EqualTo(2u));
+        AssertThat(zdd_varcount(zdd_T), Is().EqualTo(0u));
+        AssertThat(zdd_varcount(zdd_F), Is().EqualTo(0u));
+        AssertThat(zdd_varcount(zdd_root_1), Is().EqualTo(1u));
+      });
+    });
+
+    describe("size", [&]() {
+      it("can count family { {x2, x3}, {x0, x2, x3}, {x0, x1, x3} } [1]", [&]() {
+        AssertThat(zdd_size(zdd_1), Is().EqualTo(3u));
+      });
+
+      it("can count family { {x1}, {x2} } [2]", [&]() {
+        AssertThat(zdd_size(zdd_2), Is().EqualTo(2u));
+      });
+
+      it("can count family { Ø } [T]", [&]() {
+        AssertThat(zdd_size(zdd_T), Is().EqualTo(1u));
+      });
+
+      it("can count family Ø [F]", [&]() {
+        AssertThat(zdd_size(zdd_F), Is().EqualTo(0u));
+      });
+
+      it("can count family { 1 } [root_1]", [&]() {
+        AssertThat(zdd_size(zdd_root_1), Is().EqualTo(1u));
+      });
+    });
   });
+ });

--- a/test/adiar/zdd/test_pred.cpp
+++ b/test/adiar/zdd/test_pred.cpp
@@ -1,334 +1,334 @@
 go_bandit([]() {
-    describe("ZDD: Predicates", [&]() {
-        ptr_t sink_T = create_sink_ptr(true);
-        ptr_t sink_F = create_sink_ptr(false);
+  describe("ZDD: Predicates", [&]() {
+    ptr_t sink_T = create_sink_ptr(true);
+    ptr_t sink_F = create_sink_ptr(false);
 
-        // Ø
-        node_file zdd_empty_nf;
-        { node_writer nw(zdd_empty_nf);
-          nw << create_sink(false);
-        }
+    // Ø
+    node_file zdd_empty_nf;
+    { node_writer nw(zdd_empty_nf);
+      nw << create_sink(false);
+    }
 
-        node_file zdd_empty_nf_copy;
-        { node_writer nw(zdd_empty_nf_copy);
-          nw << create_sink(false);
-        }
+    node_file zdd_empty_nf_copy;
+    { node_writer nw(zdd_empty_nf_copy);
+      nw << create_sink(false);
+    }
 
-        // { Ø }
-        node_file zdd_null_nf;
-        { node_writer nw(zdd_null_nf);
-          nw << create_sink(true);
-        }
+    // { Ø }
+    node_file zdd_null_nf;
+    { node_writer nw(zdd_null_nf);
+      nw << create_sink(true);
+    }
 
-        node_file zdd_null_nf_copy;
-        { node_writer nw(zdd_null_nf_copy);
-          nw << create_sink(true);
-        }
+    node_file zdd_null_nf_copy;
+    { node_writer nw(zdd_null_nf_copy);
+      nw << create_sink(true);
+    }
 
-        // { {1} }
-        node_file zdd_A_nf;
-        { node_writer nw(zdd_A_nf);
-          nw << create_node(1,MAX_ID, sink_F, sink_T);
-        }
+    // { {1} }
+    node_file zdd_A_nf;
+    { node_writer nw(zdd_A_nf);
+      nw << create_node(1,MAX_ID, sink_F, sink_T);
+    }
 
-        node_file zdd_A_nf_copy;
-        { node_writer nw(zdd_A_nf_copy);
-          nw << create_node(1,MAX_ID, sink_F, sink_T);
-        }
+    node_file zdd_A_nf_copy;
+    { node_writer nw(zdd_A_nf_copy);
+      nw << create_node(1,MAX_ID, sink_F, sink_T);
+    }
 
-        // { {1}, {1,2} }
-        node_file zdd_B_nf;
-        { node_writer nw(zdd_B_nf);
-          nw << create_node(2,MAX_ID, sink_T, sink_T)
-             << create_node(1,MAX_ID, sink_F, create_node_ptr(2,MAX_ID))
-            ;
-        }
+    // { {1}, {1,2} }
+    node_file zdd_B_nf;
+    { node_writer nw(zdd_B_nf);
+      nw << create_node(2,MAX_ID, sink_T, sink_T)
+         << create_node(1,MAX_ID, sink_F, create_node_ptr(2,MAX_ID))
+        ;
+    }
 
-        // { Ø, {1}, {2}, {1,2} }
-        node_file zdd_C_nf;
-        { node_writer nw(zdd_C_nf);
-          nw << create_node(2,MAX_ID, sink_T,                    sink_T)
-             << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
-            ;
-        }
+    // { Ø, {1}, {2}, {1,2} }
+    node_file zdd_C_nf;
+    { node_writer nw(zdd_C_nf);
+      nw << create_node(2,MAX_ID, sink_T,                    sink_T)
+         << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
+        ;
+    }
 
-        node_file zdd_C_nf_copy;
-        { node_writer nw(zdd_C_nf_copy);
-          nw << create_node(2,MAX_ID, sink_T,                    sink_T)
-             << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
-            ;
-        }
+    node_file zdd_C_nf_copy;
+    { node_writer nw(zdd_C_nf_copy);
+      nw << create_node(2,MAX_ID, sink_T,                    sink_T)
+         << create_node(1,MAX_ID, create_node_ptr(2,MAX_ID), create_node_ptr(2,MAX_ID))
+        ;
+    }
 
-        // { {1}, {1,2}, {0,1,3} }
-        node_file zdd_D_nf;
-        { node_writer nw(zdd_D_nf);
-          nw << create_node(3,MAX_ID,   sink_F,                      sink_T)
-             << create_node(2,MAX_ID,   sink_T,                      sink_T)
-             << create_node(1,MAX_ID,   sink_F,                      create_node_ptr(3,MAX_ID))
-             << create_node(1,MAX_ID-1, sink_F,                      create_node_ptr(2,MAX_ID))
-             << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
-            ;
-        }
+    // { {1}, {1,2}, {0,1,3} }
+    node_file zdd_D_nf;
+    { node_writer nw(zdd_D_nf);
+      nw << create_node(3,MAX_ID,   sink_F,                      sink_T)
+         << create_node(2,MAX_ID,   sink_T,                      sink_T)
+         << create_node(1,MAX_ID,   sink_F,                      create_node_ptr(3,MAX_ID))
+         << create_node(1,MAX_ID-1, sink_F,                      create_node_ptr(2,MAX_ID))
+         << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
+        ;
+    }
 
-        node_file zdd_D_nf_copy;
-        { node_writer nw(zdd_D_nf_copy);
-          nw << create_node(3,MAX_ID,   sink_F,                      sink_T)
-             << create_node(2,MAX_ID,   sink_T,                      sink_T)
-             << create_node(1,MAX_ID,   sink_F,                      create_node_ptr(3,MAX_ID))
-             << create_node(1,MAX_ID-1, sink_F,                      create_node_ptr(2,MAX_ID))
-             << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
-            ;
-        }
+    node_file zdd_D_nf_copy;
+    { node_writer nw(zdd_D_nf_copy);
+      nw << create_node(3,MAX_ID,   sink_F,                      sink_T)
+         << create_node(2,MAX_ID,   sink_T,                      sink_T)
+         << create_node(1,MAX_ID,   sink_F,                      create_node_ptr(3,MAX_ID))
+         << create_node(1,MAX_ID-1, sink_F,                      create_node_ptr(2,MAX_ID))
+         << create_node(0,MAX_ID,   create_node_ptr(1,MAX_ID-1), create_node_ptr(1,MAX_ID))
+        ;
+    }
 
-        // { Ø, {0,3} }
-        node_file zdd_E_nf;
-        { node_writer nw(zdd_E_nf);
-          nw << create_node(3,MAX_ID, sink_F, sink_T)
-             << create_node(0,MAX_ID, sink_T, create_node_ptr(3,MAX_ID))
-            ;
-        }
+    // { Ø, {0,3} }
+    node_file zdd_E_nf;
+    { node_writer nw(zdd_E_nf);
+      nw << create_node(3,MAX_ID, sink_F, sink_T)
+         << create_node(0,MAX_ID, sink_T, create_node_ptr(3,MAX_ID))
+        ;
+    }
 
-        node_file zdd_E_nf_copy;
-        { node_writer nw(zdd_E_nf_copy);
-          nw << create_node(3,MAX_ID, sink_F, sink_T)
-             << create_node(0,MAX_ID, sink_T, create_node_ptr(3,MAX_ID))
-            ;
-        }
+    node_file zdd_E_nf_copy;
+    { node_writer nw(zdd_E_nf_copy);
+      nw << create_node(3,MAX_ID, sink_F, sink_T)
+         << create_node(0,MAX_ID, sink_T, create_node_ptr(3,MAX_ID))
+        ;
+    }
 
-        // { {2} }
-        node_file zdd_F_nf;
-        { node_writer nw(zdd_F_nf);
-          nw << create_node(2,MAX_ID, sink_F, sink_T);
-        }
+    // { {2} }
+    node_file zdd_F_nf;
+    { node_writer nw(zdd_F_nf);
+      nw << create_node(2,MAX_ID, sink_F, sink_T);
+    }
 
-        // Equal and unequal will not be tested, since it merely is a call to
-        // is_isomorphic.
+    // Equal and unequal will not be tested, since it merely is a call to
+    // is_isomorphic.
 
-        describe("zdd_subseteq", [&]() {
-            it("accepts same file", [&]() {
-                AssertThat(zdd_subseteq(zdd_A_nf, zdd_A_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_B_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_C_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_D_nf, zdd_D_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_E_nf, zdd_E_nf), Is().True());
-              });
-
-            it("accepts on equal ZDDs", [&]() {
-                AssertThat(zdd_subseteq(zdd_A_nf, zdd_A_nf_copy), Is().True());
-                AssertThat(zdd_subseteq(zdd_C_nf, zdd_C_nf_copy), Is().True());
-                AssertThat(zdd_subseteq(zdd_D_nf, zdd_D_nf_copy), Is().True());
-                AssertThat(zdd_subseteq(zdd_E_nf, zdd_E_nf_copy), Is().True());
-              });
-
-            it("can compare Ø and { Ø }", [&]() {
-                AssertThat(zdd_subseteq(zdd_empty_nf, zdd_null_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_null_nf, zdd_empty_nf), Is().False());
-              });
-
-            it("can compare { {1} } and { {2} }", [&]() {
-                AssertThat(zdd_subseteq(zdd_A_nf, zdd_F_nf), Is().False());
-                AssertThat(zdd_subseteq(zdd_F_nf, zdd_A_nf), Is().False());
-              });
-
-            it("can compare { {1} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_subseteq(zdd_A_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_B_nf, zdd_A_nf), Is().False());
-              });
-
-            it("can compare { Ø } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_subseteq(zdd_null_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_subseteq(zdd_B_nf, zdd_null_nf), Is().False());
-              });
-
-            it("can compare { Ø, {0,3} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_subseteq(zdd_E_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_subseteq(zdd_B_nf, zdd_E_nf), Is().False());
-              });
-
-            it("can identify subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
-                // Positive cases
-                AssertThat(zdd_subseteq(zdd_empty_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_null_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_A_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_B_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_C_nf_copy, zdd_C_nf), Is().True());
-
-                // Negative cases
-                AssertThat(zdd_subseteq(zdd_D_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_subseteq(zdd_E_nf, zdd_C_nf), Is().False());
-              });
-
-            it("can identify subsets of { {1}, {1,2}, {0,1,3} } and ", [&]() {
-                // Positive cases
-                AssertThat(zdd_subseteq(zdd_empty_nf, zdd_D_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_A_nf, zdd_D_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_B_nf, zdd_D_nf), Is().True());
-                AssertThat(zdd_subseteq(zdd_D_nf_copy, zdd_D_nf), Is().True());
-
-                // Negative cases
-                AssertThat(zdd_subseteq(zdd_null_nf, zdd_D_nf), Is().False());
-                AssertThat(zdd_subseteq(zdd_C_nf, zdd_D_nf), Is().False());
-                AssertThat(zdd_subseteq(zdd_E_nf, zdd_D_nf), Is().False());
-              });
-          });
-
-        describe("zdd_subset", [&]() {
-            it("rejects same file", [&]() {
-                AssertThat(zdd_subset(zdd_A_nf, zdd_A_nf), Is().False());
-                AssertThat(zdd_subset(zdd_B_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_subset(zdd_C_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_subset(zdd_D_nf, zdd_D_nf), Is().False());
-                AssertThat(zdd_subset(zdd_E_nf, zdd_E_nf), Is().False());
-              });
-
-            it("rejects on equal ZDDs", [&]() {
-                AssertThat(zdd_subset(zdd_A_nf, zdd_A_nf_copy), Is().False());
-                AssertThat(zdd_subset(zdd_C_nf, zdd_C_nf_copy), Is().False());
-                AssertThat(zdd_subset(zdd_D_nf, zdd_D_nf_copy), Is().False());
-                AssertThat(zdd_subset(zdd_E_nf, zdd_E_nf_copy), Is().False());
-              });
-
-            it("can compare Ø and { Ø }", [&]() {
-                AssertThat(zdd_subset(zdd_empty_nf, zdd_null_nf), Is().True());
-                AssertThat(zdd_subset(zdd_null_nf, zdd_empty_nf), Is().False());
-              });
-
-            it("can compare { {1} } and { {2} }", [&]() {
-                AssertThat(zdd_subset(zdd_A_nf, zdd_F_nf), Is().False());
-                AssertThat(zdd_subset(zdd_F_nf, zdd_A_nf), Is().False());
-              });
-
-            it("can compare { {1} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_subset(zdd_A_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_subset(zdd_B_nf, zdd_A_nf), Is().False());
-              });
-
-            it("can compare { Ø } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_subset(zdd_null_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_subset(zdd_B_nf, zdd_null_nf), Is().False());
-              });
-
-            it("can compare { Ø, {0,3} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_subset(zdd_E_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_subset(zdd_B_nf, zdd_E_nf), Is().False());
-              });
-
-            it("can identify subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
-                // Positive cases
-                AssertThat(zdd_subset(zdd_empty_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subset(zdd_null_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subset(zdd_A_nf, zdd_C_nf), Is().True());
-                AssertThat(zdd_subset(zdd_B_nf, zdd_C_nf), Is().True());
-
-                // Equality case
-                AssertThat(zdd_subset(zdd_C_nf_copy, zdd_C_nf), Is().False());
-
-                // Negative cases
-                AssertThat(zdd_subset(zdd_D_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_subset(zdd_E_nf, zdd_C_nf), Is().False());
-              });
-
-            it("can identify subsets of { {1}, {1,2}, {0,1,3} } and ", [&]() {
-                // Positive cases
-                AssertThat(zdd_subset(zdd_empty_nf, zdd_D_nf), Is().True());
-                AssertThat(zdd_subset(zdd_A_nf, zdd_D_nf), Is().True());
-                AssertThat(zdd_subset(zdd_B_nf, zdd_D_nf), Is().True());
-
-                // Equality case
-                AssertThat(zdd_subset(zdd_D_nf_copy, zdd_D_nf), Is().False());
-
-                // Negative cases
-                AssertThat(zdd_subset(zdd_null_nf, zdd_D_nf), Is().False());
-                AssertThat(zdd_subset(zdd_C_nf, zdd_D_nf), Is().False());
-                AssertThat(zdd_subset(zdd_E_nf, zdd_D_nf), Is().False());
-              });
-          });
-
-        describe("zdd_disjoint", [&]() {
-            it("rejects same file", [&]() {
-                AssertThat(zdd_disjoint(zdd_A_nf, zdd_A_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_C_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_D_nf, zdd_D_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_E_nf, zdd_E_nf), Is().False());
-              });
-
-            it("accepts same file for Ø", [&]() {
-                AssertThat(zdd_disjoint(zdd_empty_nf, zdd_empty_nf), Is().True());
-              });
-
-            it("rejects same file for { Ø }", [&]() {
-                AssertThat(zdd_disjoint(zdd_null_nf, zdd_null_nf), Is().False());
-              });
-
-            it("rejects on equal ZDDs", [&]() {
-                AssertThat(zdd_disjoint(zdd_A_nf, zdd_A_nf_copy), Is().False());
-                AssertThat(zdd_disjoint(zdd_C_nf, zdd_C_nf_copy), Is().False());
-                AssertThat(zdd_disjoint(zdd_D_nf, zdd_D_nf_copy), Is().False());
-                AssertThat(zdd_disjoint(zdd_E_nf, zdd_E_nf_copy), Is().False());
-              });
-
-            it("can compare Ø and { Ø }", [&]() {
-                AssertThat(zdd_disjoint(zdd_empty_nf, zdd_null_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_null_nf, zdd_empty_nf), Is().True());
-              });
-
-            it("accepts Ø and Ø", [&]() {
-                AssertThat(zdd_disjoint(zdd_empty_nf, zdd_empty_nf_copy), Is().True());
-              });
-
-            it("rejects { Ø } and { Ø }", [&]() {
-                AssertThat(zdd_disjoint(zdd_empty_nf, zdd_null_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_null_nf, zdd_empty_nf), Is().True());
-              });
-
-            it("accepts Ø and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_empty_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_empty_nf), Is().True());
-              });
-
-            it("accepts { {1} } and { {2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_A_nf, zdd_F_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_F_nf, zdd_A_nf), Is().True());
-              });
-
-            it("rejects { {1} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_A_nf, zdd_B_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_A_nf), Is().False());
-              });
-
-            it("accepts { Ø } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_null_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_null_nf), Is().True());
-              });
-
-            it("accepts { Ø, {0,3} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_E_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_E_nf), Is().True());
-              });
-
-            it("rejects subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_D_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_C_nf, zdd_D_nf), Is().False());
-              });
-
-            it("rejects subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_null_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_A_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_C_nf_copy, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_E_nf, zdd_C_nf), Is().False());
-                AssertThat(zdd_disjoint(zdd_F_nf, zdd_C_nf), Is().False());
-              });
-
-            it("accepts non-subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_empty_nf, zdd_C_nf), Is().True());
-              });
-
-            it("accepts { {2} } and { {1}, {1,2} }", [&]() {
-                AssertThat(zdd_disjoint(zdd_F_nf, zdd_B_nf), Is().True());
-                AssertThat(zdd_disjoint(zdd_B_nf, zdd_F_nf), Is().True());
-              });
-          });
+    describe("zdd_subseteq", [&]() {
+      it("accepts same file", [&]() {
+        AssertThat(zdd_subseteq(zdd_A_nf, zdd_A_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_B_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_C_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_D_nf, zdd_D_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_E_nf, zdd_E_nf), Is().True());
       });
+
+      it("accepts on equal ZDDs", [&]() {
+        AssertThat(zdd_subseteq(zdd_A_nf, zdd_A_nf_copy), Is().True());
+        AssertThat(zdd_subseteq(zdd_C_nf, zdd_C_nf_copy), Is().True());
+        AssertThat(zdd_subseteq(zdd_D_nf, zdd_D_nf_copy), Is().True());
+        AssertThat(zdd_subseteq(zdd_E_nf, zdd_E_nf_copy), Is().True());
+      });
+
+      it("can compare Ø and { Ø }", [&]() {
+        AssertThat(zdd_subseteq(zdd_empty_nf, zdd_null_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_null_nf, zdd_empty_nf), Is().False());
+      });
+
+      it("can compare { {1} } and { {2} }", [&]() {
+        AssertThat(zdd_subseteq(zdd_A_nf, zdd_F_nf), Is().False());
+        AssertThat(zdd_subseteq(zdd_F_nf, zdd_A_nf), Is().False());
+      });
+
+      it("can compare { {1} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_subseteq(zdd_A_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_B_nf, zdd_A_nf), Is().False());
+      });
+
+      it("can compare { Ø } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_subseteq(zdd_null_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_subseteq(zdd_B_nf, zdd_null_nf), Is().False());
+      });
+
+      it("can compare { Ø, {0,3} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_subseteq(zdd_E_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_subseteq(zdd_B_nf, zdd_E_nf), Is().False());
+      });
+
+      it("can identify subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
+        // Positive cases
+        AssertThat(zdd_subseteq(zdd_empty_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_null_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_A_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_B_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_C_nf_copy, zdd_C_nf), Is().True());
+
+        // Negative cases
+        AssertThat(zdd_subseteq(zdd_D_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_subseteq(zdd_E_nf, zdd_C_nf), Is().False());
+      });
+
+      it("can identify subsets of { {1}, {1,2}, {0,1,3} } and ", [&]() {
+        // Positive cases
+        AssertThat(zdd_subseteq(zdd_empty_nf, zdd_D_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_A_nf, zdd_D_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_B_nf, zdd_D_nf), Is().True());
+        AssertThat(zdd_subseteq(zdd_D_nf_copy, zdd_D_nf), Is().True());
+
+        // Negative cases
+        AssertThat(zdd_subseteq(zdd_null_nf, zdd_D_nf), Is().False());
+        AssertThat(zdd_subseteq(zdd_C_nf, zdd_D_nf), Is().False());
+        AssertThat(zdd_subseteq(zdd_E_nf, zdd_D_nf), Is().False());
+      });
+    });
+
+    describe("zdd_subset", [&]() {
+      it("rejects same file", [&]() {
+        AssertThat(zdd_subset(zdd_A_nf, zdd_A_nf), Is().False());
+        AssertThat(zdd_subset(zdd_B_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_subset(zdd_C_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_subset(zdd_D_nf, zdd_D_nf), Is().False());
+        AssertThat(zdd_subset(zdd_E_nf, zdd_E_nf), Is().False());
+      });
+
+      it("rejects on equal ZDDs", [&]() {
+        AssertThat(zdd_subset(zdd_A_nf, zdd_A_nf_copy), Is().False());
+        AssertThat(zdd_subset(zdd_C_nf, zdd_C_nf_copy), Is().False());
+        AssertThat(zdd_subset(zdd_D_nf, zdd_D_nf_copy), Is().False());
+        AssertThat(zdd_subset(zdd_E_nf, zdd_E_nf_copy), Is().False());
+      });
+
+      it("can compare Ø and { Ø }", [&]() {
+        AssertThat(zdd_subset(zdd_empty_nf, zdd_null_nf), Is().True());
+        AssertThat(zdd_subset(zdd_null_nf, zdd_empty_nf), Is().False());
+      });
+
+      it("can compare { {1} } and { {2} }", [&]() {
+        AssertThat(zdd_subset(zdd_A_nf, zdd_F_nf), Is().False());
+        AssertThat(zdd_subset(zdd_F_nf, zdd_A_nf), Is().False());
+      });
+
+      it("can compare { {1} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_subset(zdd_A_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_subset(zdd_B_nf, zdd_A_nf), Is().False());
+      });
+
+      it("can compare { Ø } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_subset(zdd_null_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_subset(zdd_B_nf, zdd_null_nf), Is().False());
+      });
+
+      it("can compare { Ø, {0,3} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_subset(zdd_E_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_subset(zdd_B_nf, zdd_E_nf), Is().False());
+      });
+
+      it("can identify subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
+        // Positive cases
+        AssertThat(zdd_subset(zdd_empty_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subset(zdd_null_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subset(zdd_A_nf, zdd_C_nf), Is().True());
+        AssertThat(zdd_subset(zdd_B_nf, zdd_C_nf), Is().True());
+
+        // Equality case
+        AssertThat(zdd_subset(zdd_C_nf_copy, zdd_C_nf), Is().False());
+
+        // Negative cases
+        AssertThat(zdd_subset(zdd_D_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_subset(zdd_E_nf, zdd_C_nf), Is().False());
+      });
+
+      it("can identify subsets of { {1}, {1,2}, {0,1,3} } and ", [&]() {
+        // Positive cases
+        AssertThat(zdd_subset(zdd_empty_nf, zdd_D_nf), Is().True());
+        AssertThat(zdd_subset(zdd_A_nf, zdd_D_nf), Is().True());
+        AssertThat(zdd_subset(zdd_B_nf, zdd_D_nf), Is().True());
+
+        // Equality case
+        AssertThat(zdd_subset(zdd_D_nf_copy, zdd_D_nf), Is().False());
+
+        // Negative cases
+        AssertThat(zdd_subset(zdd_null_nf, zdd_D_nf), Is().False());
+        AssertThat(zdd_subset(zdd_C_nf, zdd_D_nf), Is().False());
+        AssertThat(zdd_subset(zdd_E_nf, zdd_D_nf), Is().False());
+      });
+    });
+
+    describe("zdd_disjoint", [&]() {
+      it("rejects same file", [&]() {
+        AssertThat(zdd_disjoint(zdd_A_nf, zdd_A_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_C_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_D_nf, zdd_D_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_E_nf, zdd_E_nf), Is().False());
+      });
+
+      it("accepts same file for Ø", [&]() {
+        AssertThat(zdd_disjoint(zdd_empty_nf, zdd_empty_nf), Is().True());
+      });
+
+      it("rejects same file for { Ø }", [&]() {
+        AssertThat(zdd_disjoint(zdd_null_nf, zdd_null_nf), Is().False());
+      });
+
+      it("rejects on equal ZDDs", [&]() {
+        AssertThat(zdd_disjoint(zdd_A_nf, zdd_A_nf_copy), Is().False());
+        AssertThat(zdd_disjoint(zdd_C_nf, zdd_C_nf_copy), Is().False());
+        AssertThat(zdd_disjoint(zdd_D_nf, zdd_D_nf_copy), Is().False());
+        AssertThat(zdd_disjoint(zdd_E_nf, zdd_E_nf_copy), Is().False());
+      });
+
+      it("can compare Ø and { Ø }", [&]() {
+        AssertThat(zdd_disjoint(zdd_empty_nf, zdd_null_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_null_nf, zdd_empty_nf), Is().True());
+      });
+
+      it("accepts Ø and Ø", [&]() {
+        AssertThat(zdd_disjoint(zdd_empty_nf, zdd_empty_nf_copy), Is().True());
+      });
+
+      it("rejects { Ø } and { Ø }", [&]() {
+        AssertThat(zdd_disjoint(zdd_empty_nf, zdd_null_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_null_nf, zdd_empty_nf), Is().True());
+      });
+
+      it("accepts Ø and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_empty_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_empty_nf), Is().True());
+      });
+
+      it("accepts { {1} } and { {2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_A_nf, zdd_F_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_F_nf, zdd_A_nf), Is().True());
+      });
+
+      it("rejects { {1} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_A_nf, zdd_B_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_A_nf), Is().False());
+      });
+
+      it("accepts { Ø } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_null_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_null_nf), Is().True());
+      });
+
+      it("accepts { Ø, {0,3} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_E_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_E_nf), Is().True());
+      });
+
+      it("rejects subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_D_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_C_nf, zdd_D_nf), Is().False());
+      });
+
+      it("rejects subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_null_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_A_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_C_nf_copy, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_E_nf, zdd_C_nf), Is().False());
+        AssertThat(zdd_disjoint(zdd_F_nf, zdd_C_nf), Is().False());
+      });
+
+      it("accepts non-subsets of { Ø, {1}, {2}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_empty_nf, zdd_C_nf), Is().True());
+      });
+
+      it("accepts { {2} } and { {1}, {1,2} }", [&]() {
+        AssertThat(zdd_disjoint(zdd_F_nf, zdd_B_nf), Is().True());
+        AssertThat(zdd_disjoint(zdd_B_nf, zdd_F_nf), Is().True());
+      });
+    });
   });
+ });

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -306,14 +306,14 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(ms.can_pull(), Is().False());
           });
@@ -360,14 +360,14 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(3,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(ms.can_pull(), Is().False());
           });
@@ -408,10 +408,10 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(ms.can_pull(), Is().False());
           });
@@ -457,10 +457,10 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(4,2u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(0,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
 
             AssertThat(ms.can_pull(), Is().False());
           });
@@ -499,10 +499,10 @@ go_bandit([]() {
             level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(4,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
             AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_meta(2,1u)));
+            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
             AssertThat(ms.can_pull(), Is().False());
           });

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -1,97 +1,97 @@
 go_bandit([]() {
-    describe("ZDD: Projection", [&]() {
-        //////////////////////
-        // Sink cases
+  describe("ZDD: Projection", [&]() {
+    //////////////////////
+    // Sink cases
 
-        // Ø
-        node_file zdd_empty;
-        {
-          node_writer nw(zdd_empty);
-          nw << create_sink(false);
-        }
+    // Ø
+    node_file zdd_empty;
+    {
+      node_writer nw(zdd_empty);
+      nw << create_sink(false);
+    }
 
-        // { Ø }
-        node_file zdd_null;
-        {
-          node_writer nw(zdd_null);
-          nw << create_sink(true);
-        }
+    // { Ø }
+    node_file zdd_null;
+    {
+      node_writer nw(zdd_null);
+      nw << create_sink(true);
+    }
 
-        it("computes Ø with dom = {2,4,6} [const &]", [&](){
-            label_file dom;
-            {
-              label_writer lw(dom);
-              lw << 2 << 4 << 6;
-            }
+    it("computes Ø with dom = {2,4,6} [const &]", [&](){
+      label_file dom;
+      {
+        label_writer lw(dom);
+        lw << 2 << 4 << 6;
+      }
 
-            zdd out = zdd_project(zdd_empty, dom);
+      zdd out = zdd_project(zdd_empty, dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-           });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes { Ø } with dom = {1,3,5} [&&]", [&](){
-            label_file dom;
-            {
-              label_writer lw(dom);
-              lw << 1 << 3 << 5;
-            }
+    it("computes { Ø } with dom = {1,3,5} [&&]", [&](){
+      label_file dom;
+      {
+        label_writer lw(dom);
+        lw << 1 << 3 << 5;
+      }
 
-            zdd out = zdd_project(zdd(zdd_null), dom);
+      zdd out = zdd_project(zdd(zdd_null), dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes with dom = Ø to be Ø for Ø as input [&&]", [&](){
-            label_file dom;
+    it("computes with dom = Ø to be Ø for Ø as input [&&]", [&](){
+      label_file dom;
 
-            zdd out = zdd_project(zdd(zdd_empty), dom);
+      zdd out = zdd_project(zdd(zdd_empty), dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(false)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes with dom = Ø to be { Ø } for { Ø } as input [const &]", [&](){
-            label_file dom;
+    it("computes with dom = Ø to be { Ø } for { Ø } as input [const &]", [&](){
+      label_file dom;
 
-            zdd out = zdd_project(zdd_null, dom);
+      zdd out = zdd_project(zdd_null, dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        //////////////////////
-        // Non-sink edge cases
-        ptr_t sink_F = create_sink_ptr(false);
-        ptr_t sink_T = create_sink_ptr(true);
+    //////////////////////
+    // Non-sink edge cases
+    ptr_t sink_F = create_sink_ptr(false);
+    ptr_t sink_T = create_sink_ptr(true);
 
-        // { Ø, {0}, {1}, {1,2}, {1,3}, {1,3,4} }
-        /*
+    // { Ø, {0}, {1}, {1,2}, {1,3}, {1,3,4} }
+    /*
                      1         ---- x0
                     / \
                     2 T        ---- x1
@@ -103,20 +103,20 @@ go_bandit([]() {
                   F 5          ---- x4
                    / \
                    T T
-         */
-        node_file zdd_1;
-        {
-          node_writer nw(zdd_1);
-          nw << create_node(4, MAX_ID, sink_T, sink_T)
-             << create_node(3, MAX_ID, sink_F, create_node_ptr(4, MAX_ID))
-             << create_node(2, MAX_ID, create_node_ptr(3, MAX_ID), sink_T)
-             << create_node(1, MAX_ID, create_node_ptr(2, MAX_ID), create_node_ptr(2, MAX_ID))
-             << create_node(0, MAX_ID, create_node_ptr(1, MAX_ID), sink_T)
-            ;
-        }
+    */
+    node_file zdd_1;
+    {
+      node_writer nw(zdd_1);
+      nw << create_node(4, MAX_ID, sink_T, sink_T)
+         << create_node(3, MAX_ID, sink_F, create_node_ptr(4, MAX_ID))
+         << create_node(2, MAX_ID, create_node_ptr(3, MAX_ID), sink_T)
+         << create_node(1, MAX_ID, create_node_ptr(2, MAX_ID), create_node_ptr(2, MAX_ID))
+         << create_node(0, MAX_ID, create_node_ptr(1, MAX_ID), sink_T)
+        ;
+    }
 
-        // { {0}, {2}, {0,3}, {2,4} }
-        /*
+    // { {0}, {2}, {0,3}, {2,4} }
+    /*
                     1         ---- x0
                    / \
                    |  \       ---- x1
@@ -128,19 +128,19 @@ go_bandit([]() {
                     4 T T     ---- x4
                    / \
                    T T
-         */
-        node_file zdd_2;
-        {
-          node_writer nw(zdd_2);
-          nw << create_node(4, MAX_ID, sink_T, sink_T)
-             << create_node(3, MAX_ID, sink_T, sink_T)
-             << create_node(2, MAX_ID, sink_F, create_node_ptr(4, MAX_ID))
-             << create_node(0, MAX_ID, create_node_ptr(2, MAX_ID), create_node_ptr(3, MAX_ID))
-            ;
-        }
+    */
+    node_file zdd_2;
+    {
+      node_writer nw(zdd_2);
+      nw << create_node(4, MAX_ID, sink_T, sink_T)
+         << create_node(3, MAX_ID, sink_T, sink_T)
+         << create_node(2, MAX_ID, sink_F, create_node_ptr(4, MAX_ID))
+         << create_node(0, MAX_ID, create_node_ptr(2, MAX_ID), create_node_ptr(3, MAX_ID))
+        ;
+    }
 
-        // { {0}, {2}, {1,2}, {0,2} }
-        /*
+    // { {0}, {2}, {1,2}, {0,2} }
+    /*
                     1      ---- x0
                    / \
                    2 |     ---- x1
@@ -148,19 +148,19 @@ go_bandit([]() {
                   3  4     ---- x2
                  / \/ \
                  F T  T
-         */
-        node_file zdd_3;
-        {
-          node_writer nw(zdd_3);
-          nw << create_node(2, MAX_ID,   sink_T, sink_T)
-             << create_node(2, MAX_ID-1, sink_F, sink_T)
-             << create_node(1, MAX_ID,   create_node_ptr(2, MAX_ID-1), create_node_ptr(2, MAX_ID))
-             << create_node(0, MAX_ID,   create_node_ptr(1, MAX_ID), create_node_ptr(2, MAX_ID))
-            ;
-        }
+    */
+    node_file zdd_3;
+    {
+      node_writer nw(zdd_3);
+      nw << create_node(2, MAX_ID,   sink_T, sink_T)
+         << create_node(2, MAX_ID-1, sink_F, sink_T)
+         << create_node(1, MAX_ID,   create_node_ptr(2, MAX_ID-1), create_node_ptr(2, MAX_ID))
+         << create_node(0, MAX_ID,   create_node_ptr(1, MAX_ID), create_node_ptr(2, MAX_ID))
+        ;
+    }
 
-        // { {4}, {0,2}, {0,4}, {2,4}, {0,2,4} }
-        /*
+    // { {4}, {0,2}, {0,4}, {2,4}, {0,2,4} }
+    /*
                     _1_      ---- x0
                    /   \
                    2   3     ---- x2
@@ -168,110 +168,110 @@ go_bandit([]() {
                      4  5    ---- x4
                     / \/ \
                     F  T T
-         */
-        node_file zdd_4;
-        {
-          node_writer nw(zdd_4);
-          nw << create_node(4, MAX_ID,   sink_T, sink_T)
-             << create_node(4, MAX_ID-1, sink_F, sink_T)
-             << create_node(2, MAX_ID,   create_node_ptr(4, MAX_ID-1), create_node_ptr(4, MAX_ID))
-             << create_node(2, MAX_ID-1, create_node_ptr(4, MAX_ID-1), create_node_ptr(4, MAX_ID-1))
-             << create_node(0, MAX_ID,   create_node_ptr(2, MAX_ID-1), create_node_ptr(2, MAX_ID))
-            ;
-        }
+    */
+    node_file zdd_4;
+    {
+      node_writer nw(zdd_4);
+      nw << create_node(4, MAX_ID,   sink_T, sink_T)
+         << create_node(4, MAX_ID-1, sink_F, sink_T)
+         << create_node(2, MAX_ID,   create_node_ptr(4, MAX_ID-1), create_node_ptr(4, MAX_ID))
+         << create_node(2, MAX_ID-1, create_node_ptr(4, MAX_ID-1), create_node_ptr(4, MAX_ID-1))
+         << create_node(0, MAX_ID,   create_node_ptr(2, MAX_ID-1), create_node_ptr(2, MAX_ID))
+        ;
+    }
 
-        it("computes with dom = Ø to be { Ø } for non-empty input [zdd_1] [const &]", [&](){
-            label_file dom;
+    it("computes with dom = Ø to be { Ø } for non-empty input [zdd_1] [const &]", [&](){
+      label_file dom;
 
-            zdd out = zdd_project(zdd_1, dom);
+      zdd out = zdd_project(zdd_1, dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes with dom = Ø to be { Ø } for non-empty input [zdd_2] [&&]", [&](){
-            label_file dom;
+    it("computes with dom = Ø to be { Ø } for non-empty input [zdd_2] [&&]", [&](){
+      label_file dom;
 
-            zdd out = zdd_project(zdd(zdd_2), dom);
+      zdd out = zdd_project(zdd(zdd_2), dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes with dom = Ø to be { Ø } for non-empty input [zdd_3] [const &]", [&](){
-            label_file dom;
+    it("computes with dom = Ø to be { Ø } for non-empty input [zdd_3] [const &]", [&](){
+      label_file dom;
 
-            zdd out = zdd_project(zdd_3, dom);
+      zdd out = zdd_project(zdd_3, dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes with disjoint dom to be { Ø } [zdd_2] [const &]", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 1;
-            }
+    it("computes with disjoint dom to be { Ø } [zdd_2] [const &]", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 1;
+      }
 
-            zdd out = zdd_project(zdd_2, dom);
+      zdd out = zdd_project(zdd_2, dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes with disjoint dom to be { Ø } [zdd_3] [&&]", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 3 << 4 << 5;
-            }
+    it("computes with disjoint dom to be { Ø } [zdd_3] [&&]", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 3 << 4 << 5;
+      }
 
-            zdd out = zdd_project(zdd(zdd_3), dom);
+      zdd out = zdd_project(zdd(zdd_3), dom);
 
-            node_test_stream out_nodes(out);
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
+      node_test_stream out_nodes(out);
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_sink(true)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        // TODO: Shortcut on nothing to doa
+    // TODO: Shortcut on nothing to doa
 
-        //////////////////////
-        // Non-sink general case
-        it("computes zdd_1 with dom = {2,3,4} [const &]", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 2 << 3 << 4;
-            }
+    //////////////////////
+    // Non-sink general case
+    it("computes zdd_1 with dom = {2,3,4} [const &]", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 2 << 3 << 4;
+      }
 
-            /* Expected: { Ø, {2}, {3}, {3,4} }
+      /* Expected: { Ø, {2}, {3}, {3,4} }
 
                            1    ---- x2
                           / \
@@ -280,51 +280,51 @@ go_bandit([]() {
                          T 3    ---- x4
                           / \
                           T T
-             */
+      */
 
-            zdd out = zdd_project(zdd_1, dom);
+      zdd out = zdd_project(zdd_1, dom);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
-                                                                  sink_T,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
+                                                            sink_T,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
-                                                                  sink_T,
-                                                                  create_node_ptr(4, MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
+                                                            sink_T,
+                                                            create_node_ptr(4, MAX_ID))));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                  create_node_ptr(3, MAX_ID),
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                            create_node_ptr(3, MAX_ID),
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes zdd_2 with dom = {2,3,4} [&&]", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 2 << 3 << 4;
-            }
+    it("computes zdd_2 with dom = {2,3,4} [&&]", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 2 << 3 << 4;
+      }
 
-            /* Expected: { Ø, {2}, {3}, {2,4} }
+      /* Expected: { Ø, {2}, {3}, {2,4} }
 
                         1      ---- x2
                        / \
@@ -334,51 +334,51 @@ go_bandit([]() {
                          / \
                          T T
 
-             */
+      */
 
-            zdd out = zdd_project(zdd_2, dom);
+      zdd out = zdd_project(zdd_2, dom);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
-                                                                  sink_T,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
+                                                            sink_T,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
-                                                                  sink_T,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(3, MAX_ID,
+                                                            sink_T,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                  create_node_ptr(3, MAX_ID),
-                                                                  create_node_ptr(4, MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                            create_node_ptr(3, MAX_ID),
+                                                            create_node_ptr(4, MAX_ID))));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(3,1u)));
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes zdd_3 with dom = {0,2,4}", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 0 << 2 << 4;
-            }
+    it("computes zdd_3 with dom = {0,2,4}", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 0 << 2 << 4;
+      }
 
-            /* Expected: { {0}, {2}, {0,2} }
+      /* Expected: { {0}, {2}, {0,2} }
 
                            1    ---- x0
                           / \
@@ -387,42 +387,42 @@ go_bandit([]() {
                            2    ---- x2
                           / \
                           T T
-             */
+      */
 
-            zdd out = zdd_project(zdd_3, dom);
+      zdd out = zdd_project(zdd_3, dom);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                  sink_T,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                            sink_T,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                  create_node_ptr(2, MAX_ID),
-                                                                  create_node_ptr(2, MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                            create_node_ptr(2, MAX_ID),
+                                                            create_node_ptr(2, MAX_ID))));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes zdd_4 with dom = {0,4}", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 0 << 4;
-            }
+    it("computes zdd_4 with dom = {0,4}", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 0 << 4;
+      }
 
-            /* Expected: { {0}, {4}, {0,4} }
+      /* Expected: { {0}, {4}, {0,4} }
 
                          1     ---- x0
                         / \
@@ -431,80 +431,80 @@ go_bandit([]() {
                        2   3   ---- x4
                       / \ / \
                       F T T T
-             */
+      */
 
-            zdd out = zdd_project(zdd_4, dom);
+      zdd out = zdd_project(zdd_4, dom);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
-                                                                  sink_T,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
+                                                            sink_T,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID-1,
-                                                                  sink_F,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID-1,
+                                                            sink_F,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
-                                                                  create_node_ptr(4, MAX_ID-1),
-                                                                  create_node_ptr(4, MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(0, MAX_ID,
+                                                            create_node_ptr(4, MAX_ID-1),
+                                                            create_node_ptr(4, MAX_ID))));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,2u)));
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(0,1u)));
 
-            AssertThat(ms.can_pull(), Is().False());
-          });
+      AssertThat(ms.can_pull(), Is().False());
+    });
 
-        it("computes zdd_4 with dom = {2,4}", [&](){
-            label_file dom;
-            { label_writer lw(dom);
-              lw << 2 << 4;
-            }
+    it("computes zdd_4 with dom = {2,4}", [&](){
+      label_file dom;
+      { label_writer lw(dom);
+        lw << 2 << 4;
+      }
 
-            /* Expected: { {2}, {4}, {2,4} }
+      /* Expected: { {2}, {4}, {2,4} }
 
                          1     ---- x2
                          ||
                          2     ---- x4
                         / \
                         F T
-             */
+      */
 
-            zdd out = zdd_project(zdd_4, dom);
+      zdd out = zdd_project(zdd_4, dom);
 
-            node_test_stream out_nodes(out);
+      node_test_stream out_nodes(out);
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
-                                                                  sink_F,
-                                                                  sink_T)));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(4, MAX_ID,
+                                                            sink_F,
+                                                            sink_T)));
 
-            AssertThat(out_nodes.can_pull(), Is().True());
-            AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
-                                                                  create_node_ptr(4, MAX_ID),
-                                                                  create_node_ptr(4, MAX_ID))));
+      AssertThat(out_nodes.can_pull(), Is().True());
+      AssertThat(out_nodes.pull(), Is().EqualTo(create_node(2, MAX_ID,
+                                                            create_node_ptr(4, MAX_ID),
+                                                            create_node_ptr(4, MAX_ID))));
 
-            AssertThat(out_nodes.can_pull(), Is().False());
+      AssertThat(out_nodes.can_pull(), Is().False());
 
-            level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
+      level_info_test_stream<node_t, NODE_FILE_COUNT> ms(out);
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(4,1u)));
 
-            AssertThat(ms.can_pull(), Is().True());
-            AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
+      AssertThat(ms.can_pull(), Is().True());
+      AssertThat(ms.pull(), Is().EqualTo(create_level_info(2,1u)));
 
-            AssertThat(ms.can_pull(), Is().False());
-          });
-      });
+      AssertThat(ms.can_pull(), Is().False());
+    });
   });
+ });

--- a/test/adiar/zdd/test_subset.cpp
+++ b/test/adiar/zdd/test_subset.cpp
@@ -156,7 +156,7 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -197,7 +197,7 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -238,7 +238,7 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -295,16 +295,16 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,2u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,2u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(4,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(4,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -349,13 +349,13 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(4,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(4,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -493,13 +493,13 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -627,7 +627,7 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -701,13 +701,13 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -753,10 +753,10 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -819,19 +819,19 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,2u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,2u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(4,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(4,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -888,19 +888,19 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(4,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(4,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -1002,13 +1002,13 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -1067,10 +1067,10 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -1121,16 +1121,16 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -1175,13 +1175,13 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -1238,19 +1238,19 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(4,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(4,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });
@@ -1326,16 +1326,16 @@ go_bandit([]() {
         level_info_test_stream<arc_t, ARC_FILE_COUNT> meta_arcs(out);
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(0,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(0,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(1,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(1,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(2,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(2,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().True());
-        AssertThat(meta_arcs.pull(), Is().EqualTo(create_meta(3,1u)));
+        AssertThat(meta_arcs.pull(), Is().EqualTo(create_level_info(3,1u)));
 
         AssertThat(meta_arcs.can_pull(), Is().False());
       });

--- a/test/adiar/zdd/test_zdd.cpp
+++ b/test/adiar/zdd/test_zdd.cpp
@@ -1,187 +1,187 @@
 go_bandit([]() {
-    describe("ZDD: ZDD Class", [&]() {
-        node_file x0_nf;
+  describe("ZDD: ZDD Class", [&]() {
+    node_file x0_nf;
 
-        {
-          node_writer nw_0(x0_nf);
+    {
+      node_writer nw_0(x0_nf);
+      nw_0 << create_node(0,MAX_ID,
+                          create_sink_ptr(false),
+                          create_sink_ptr(true));
+    }
+
+    zdd x0(x0_nf);
+
+    node_file x1_nf;
+
+    {
+      node_writer nw_1(x1_nf);
+      nw_1 << create_node(1,MAX_ID,
+                          create_sink_ptr(false),
+                          create_sink_ptr(true));
+    }
+
+    zdd x1(x1_nf);
+
+    node_file x0_or_x1_nf;
+
+    {
+      node_writer nw_01(x0_or_x1_nf);
+
+      nw_01 << create_node(1, MAX_ID,
+                           create_sink_ptr(false),
+                           create_sink_ptr(true));
+
+      nw_01 << create_node(0, MAX_ID,
+                           create_node_ptr(1, MAX_ID),
+                           create_sink_ptr(true));
+    }
+
+    zdd x0_or_x1(x0_or_x1_nf);
+
+    node_file sink_T_nf;
+
+    {
+      node_writer nw_T(sink_T_nf);
+      nw_T << create_sink(true);
+    }
+
+    zdd sink_T(sink_T_nf);
+
+    node_file sink_F_nf;
+
+    {
+      node_writer nw_F(sink_F_nf);
+      nw_F << create_sink(false);
+    }
+
+    zdd sink_F(sink_F_nf);
+
+    describe("__zdd class", [&]() {
+      it("should copy-construct values from zdd", [&]() {
+        __zdd t1 = x0_or_x1;
+        AssertThat(t1.has<node_file>(), Is().True());
+        AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
+        AssertThat(t1.negate, Is().False());
+      });
+
+      it("should copy-construct values from __zdd", [&]() {
+        __zdd t1 = x0_or_x1;
+        __zdd t2 = t1;
+        AssertThat(t2.has<node_file>(), Is().True());
+        AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
+        AssertThat(t2.negate, Is().False());
+      });
+
+      it("should copy-construct values from node_file", [&]() {
+        __zdd t1 = x0_or_x1;
+        AssertThat(t1.has<node_file>(), Is().True());
+        AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
+        AssertThat(t1.negate, Is().False());
+      });
+
+      arc_file af;
+
+      {
+        arc_writer aw(af);
+        aw.unsafe_push_node(arc {create_node_ptr(0,0), create_node_ptr(1,0)});
+
+        aw.unsafe_push_sink(arc {flag(create_node_ptr(0,0)), create_sink_ptr(true)});
+        aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(false)});
+        aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
+
+        aw.unsafe_push(create_level_info(0,1u));
+        aw.unsafe_push(create_level_info(1,1u));
+      }
+
+      it("should copy-construct values from arc_file", [&]() {
+        __zdd t1 = af;
+        AssertThat(t1.has<arc_file>(), Is().True());
+        AssertThat(t1.get<arc_file>()._file_ptr, Is().EqualTo(af._file_ptr));
+        AssertThat(t1.negate, Is().False());
+      });
+
+      it("should reduce on copy construct to zdd with arc_file", [&]() {
+        zdd out = __zdd(af);
+        AssertThat(out, Is().EqualTo(x0_or_x1));
+      });
+    });
+
+    it("should copy-construct node_file and negation back to zdd", [&]() {
+      // Since we know the __zdd copy constructor works, then we can use
+      // it to peek into the 'zdd' class
+      __zdd t2 = __zdd(zdd(__zdd(x0_or_x1)));
+      AssertThat(t2.has<node_file>(), Is().True());
+      AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
+      AssertThat(t2.negate, Is().False());
+    });
+
+
+    describe("operators", [&]() {
+      it("should reject Ø == {Ø}", [&]() {
+        AssertThat(sink_F, Is().Not().EqualTo(sink_T));
+      });
+
+      it("should accept {{x0}} == {{x0}} (different files)", [&]() {
+        node_file x0_nf_2;
+
+        { node_writer nw_0(x0_nf_2);
           nw_0 << create_node(0,MAX_ID,
                               create_sink_ptr(false),
                               create_sink_ptr(true));
         }
 
-        zdd x0(x0_nf);
+        zdd x0_2(x0_nf);
 
-        node_file x1_nf;
-
-        {
-          node_writer nw_1(x1_nf);
-          nw_1 << create_node(1,MAX_ID,
-                              create_sink_ptr(false),
-                              create_sink_ptr(true));
-        }
-
-        zdd x1(x1_nf);
-
-        node_file x0_or_x1_nf;
-
-        {
-          node_writer nw_01(x0_or_x1_nf);
-
-          nw_01 << create_node(1, MAX_ID,
-                               create_sink_ptr(false),
-                               create_sink_ptr(true));
-
-          nw_01 << create_node(0, MAX_ID,
-                               create_node_ptr(1, MAX_ID),
-                               create_sink_ptr(true));
-        }
-
-        zdd x0_or_x1(x0_or_x1_nf);
-
-        node_file sink_T_nf;
-
-        {
-          node_writer nw_T(sink_T_nf);
-          nw_T << create_sink(true);
-        }
-
-        zdd sink_T(sink_T_nf);
-
-        node_file sink_F_nf;
-
-        {
-          node_writer nw_F(sink_F_nf);
-          nw_F << create_sink(false);
-        }
-
-        zdd sink_F(sink_F_nf);
-
-        describe("__zdd class", [&]() {
-            it("should copy-construct values from zdd", [&]() {
-                __zdd t1 = x0_or_x1;
-                AssertThat(t1.has<node_file>(), Is().True());
-                AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
-                AssertThat(t1.negate, Is().False());
-              });
-
-            it("should copy-construct values from __zdd", [&]() {
-                __zdd t1 = x0_or_x1;
-                __zdd t2 = t1;
-                AssertThat(t2.has<node_file>(), Is().True());
-                AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
-                AssertThat(t2.negate, Is().False());
-              });
-
-            it("should copy-construct values from node_file", [&]() {
-                __zdd t1 = x0_or_x1;
-                AssertThat(t1.has<node_file>(), Is().True());
-                AssertThat(t1.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
-                AssertThat(t1.negate, Is().False());
-              });
-
-            arc_file af;
-
-            {
-              arc_writer aw(af);
-              aw.unsafe_push_node(arc {create_node_ptr(0,0), create_node_ptr(1,0)});
-
-              aw.unsafe_push_sink(arc {flag(create_node_ptr(0,0)), create_sink_ptr(true)});
-              aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(false)});
-              aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
-
-              aw.unsafe_push(create_level_info(0,1u));
-              aw.unsafe_push(create_level_info(1,1u));
-            }
-
-            it("should copy-construct values from arc_file", [&]() {
-                __zdd t1 = af;
-                AssertThat(t1.has<arc_file>(), Is().True());
-                AssertThat(t1.get<arc_file>()._file_ptr, Is().EqualTo(af._file_ptr));
-                AssertThat(t1.negate, Is().False());
-              });
-
-            it("should reduce on copy construct to zdd with arc_file", [&]() {
-                zdd out = __zdd(af);
-                AssertThat(out, Is().EqualTo(x0_or_x1));
-              });
-          });
-
-        it("should copy-construct node_file and negation back to zdd", [&]() {
-            // Since we know the __zdd copy constructor works, then we can use
-            // it to peek into the 'zdd' class
-            __zdd t2 = __zdd(zdd(__zdd(x0_or_x1)));
-            AssertThat(t2.has<node_file>(), Is().True());
-            AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
-            AssertThat(t2.negate, Is().False());
-         });
-
-
-        describe("operators", [&]() {
-            it("should reject Ø == {Ø}", [&]() {
-                AssertThat(sink_F, Is().Not().EqualTo(sink_T));
-              });
-
-            it("should accept {{x0}} == {{x0}} (different files)", [&]() {
-                node_file x0_nf_2;
-
-                { node_writer nw_0(x0_nf_2);
-                  nw_0 << create_node(0,MAX_ID,
-                                      create_sink_ptr(false),
-                                      create_sink_ptr(true));
-                }
-
-                zdd x0_2(x0_nf);
-
-                AssertThat(x0, Is().EqualTo(x0_2));
-              });
-
-            it("should compute {{x0}} /\\ {{x1}} == {{x0}, {x1}}", [&]() {
-                AssertThat((x0 | x1) == x0_or_x1, Is().True());
-              });
-
-            it("should compute {{x0}} \\/ {{x0},{x1}} == {{x0}}", [&]() {
-                AssertThat((x0 & x0_or_x1) == x0, Is().True());
-              });
-
-            it("should compute {{x0},{x1}} \\ {{x0} == {{x0}}", [&]() {
-                AssertThat((x0_or_x1 - x0) == x1, Is().True());
-              });
-
-            it("should compute with __zdd&& operators", [&]() {
-                zdd out = ((x0_or_x1 - x0) | ((x0 | x1) & (x0_or_x1 - x1))) - (x0_or_x1 - x0);
-                AssertThat(x0, Is().EqualTo(out));
-              });
-
-            it("should ?= __zdd&&", [&]() {
-                zdd out = x0_or_x1;
-                out -= x1;
-                AssertThat(out, Is().EqualTo(x0));
-
-                out |= x0_or_x1 & x1;
-                AssertThat(out, Is().EqualTo(x0_or_x1));
-
-                out &= x0_or_x1 & x1;
-                AssertThat(out, Is().EqualTo(x1));
-             });
-
-            it("should check two derivations of same __bdd&&", [&]() {
-                AssertThat((x0 | x1) == ((x0_or_x1 - x1) | x1), Is().True());
-                AssertThat((x0 | x1) != ((x0_or_x1 - x1) | x1), Is().False());
-             });
-
-            it("should check two derivations of different __bdd&&", [&]() {
-                AssertThat((x0 | x1) == (x0_or_x1 - x1), Is().False());
-                AssertThat((x0 | x1) != (x0_or_x1 - x1), Is().True());
-             });
-          });
-
-        it("should copy-construct node_file and negation back to zdd", [&]() {
-            // Since we know the __zdd copy constructor works, then we can use
-            // it to peek into the 'zdd' class
-            __zdd t2 = __zdd(zdd(__zdd(x0_or_x1)));
-            AssertThat(t2.has<node_file>(), Is().True());
-            AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
-            AssertThat(t2.negate, Is().False());
-          });
+        AssertThat(x0, Is().EqualTo(x0_2));
       });
+
+      it("should compute {{x0}} /\\ {{x1}} == {{x0}, {x1}}", [&]() {
+        AssertThat((x0 | x1) == x0_or_x1, Is().True());
+      });
+
+      it("should compute {{x0}} \\/ {{x0},{x1}} == {{x0}}", [&]() {
+        AssertThat((x0 & x0_or_x1) == x0, Is().True());
+      });
+
+      it("should compute {{x0},{x1}} \\ {{x0} == {{x0}}", [&]() {
+        AssertThat((x0_or_x1 - x0) == x1, Is().True());
+      });
+
+      it("should compute with __zdd&& operators", [&]() {
+        zdd out = ((x0_or_x1 - x0) | ((x0 | x1) & (x0_or_x1 - x1))) - (x0_or_x1 - x0);
+        AssertThat(x0, Is().EqualTo(out));
+      });
+
+      it("should ?= __zdd&&", [&]() {
+        zdd out = x0_or_x1;
+        out -= x1;
+        AssertThat(out, Is().EqualTo(x0));
+
+        out |= x0_or_x1 & x1;
+        AssertThat(out, Is().EqualTo(x0_or_x1));
+
+        out &= x0_or_x1 & x1;
+        AssertThat(out, Is().EqualTo(x1));
+      });
+
+      it("should check two derivations of same __bdd&&", [&]() {
+        AssertThat((x0 | x1) == ((x0_or_x1 - x1) | x1), Is().True());
+        AssertThat((x0 | x1) != ((x0_or_x1 - x1) | x1), Is().False());
+      });
+
+      it("should check two derivations of different __bdd&&", [&]() {
+        AssertThat((x0 | x1) == (x0_or_x1 - x1), Is().False());
+        AssertThat((x0 | x1) != (x0_or_x1 - x1), Is().True());
+      });
+    });
+
+    it("should copy-construct node_file and negation back to zdd", [&]() {
+      // Since we know the __zdd copy constructor works, then we can use
+      // it to peek into the 'zdd' class
+      __zdd t2 = __zdd(zdd(__zdd(x0_or_x1)));
+      AssertThat(t2.has<node_file>(), Is().True());
+      AssertThat(t2.get<node_file>()._file_ptr, Is().EqualTo(x0_or_x1_nf._file_ptr));
+      AssertThat(t2.negate, Is().False());
+    });
   });
+ });

--- a/test/adiar/zdd/test_zdd.cpp
+++ b/test/adiar/zdd/test_zdd.cpp
@@ -89,8 +89,8 @@ go_bandit([]() {
               aw.unsafe_push_sink(arc {create_node_ptr(1,0), create_sink_ptr(false)});
               aw.unsafe_push_sink(arc {flag(create_node_ptr(1,0)), create_sink_ptr(true)});
 
-              aw.unsafe_push(create_meta(0,1u));
-              aw.unsafe_push(create_meta(1,1u));
+              aw.unsafe_push(create_level_info(0,1u));
+              aw.unsafe_push(create_level_info(1,1u));
             }
 
             it("should copy-construct values from arc_file", [&]() {


### PR DESCRIPTION
- Fixes missing rename of `create_meta` ( closes #205 )
- Reindents _test/_ and _src/_ with GNU Emacs 27 + Spacemacs :heart: 