### PR TITLE
Add citations guide and improve Credits section

### DIFF
--- a/CITE.md
+++ b/CITE.md
@@ -1,0 +1,81 @@
+# Citing Adiar
+
+Please consider to cite one or more of the following papers, if you use Adiar in
+some of your academic work.
+
+## Lars Arge
+
+Adiar is based on the theoretical work of Lars Arge back in
+[1995](https://link.springer.com/chapter/10.1007/BFb0015411) and
+[1996](https://tidsskrift.dk/brics/issue/view/2576).
+
+```bibtex
+@InProceedings{arge1995:ISAAC,
+  title     = {The I/O-complexity of Ordered Binary-Decision Diagram manipulation},
+  author    = {Arge, Lars},
+  editor    = {Staples, John
+           and Eades, Peter
+           and Katoh, Naoki
+           and Moffat, Alistair},
+  booktitle = {Sixth International Symposium on Algorithms and Computation},
+  year      = {1995},
+  publisher = {Springer Berlin Heidelberg},
+  address   = {Berlin, Heidelberg},
+  pages     = {82--91},
+  isbn      = {978-3-540-47766-2}
+}
+```
+
+```bibtex
+@InProceedings{arge1996:BRICS,
+  author    = {Arge, Lars},
+  title     = {The I/O-Complexity of Ordered Binary-Decision Diagram},
+  booktitle = {BRICS RS preprint series},
+  year      = {1996},
+  publisher = {Department of Computer Science, University of Aarhus},
+}
+```
+
+## Adiar
+
+We have, for your convenience, grouped all papers based on the semantic version
+of Adiar. Depending on what feature of Adiar that you are referring to, then
+pick the most relevant paper(s) to cite.
+
+### Adiar [1.0](https://github.com/SSoelvsten/adiar/releases/tag/v1.0.0)
+
+With [v1.0.0](https://github.com/SSoelvsten/adiar/releases/tag/v1.0.0) (and its
+patch [v1.0.1](https://github.com/SSoelvsten/adiar/releases/tag/v1.0.1)) we
+provide an implementation of the above algorithms and also add non-trivial
+optimisations, extensions, and new theoretical contributions to make it usable
+in practice.
+
+```bibtex
+@InProceedings{soelvsten2022:TACAS,
+  title         = {Adiar: Binary Decision Diagrams in External Memory},
+  author        = {S{\o}lvstxen, Steffan Christ
+               and van de Pol, Jaco
+               and Jakobsen, Anna Blume
+               and Thomasen, Mathias Weller Berg},
+  year          = {2022},
+  booktitle     = {Tools and Algorithms for the Construction and Analysis of Systems},
+  numpages      = {20},
+  publisher     = {Springer Berlin Heidelberg},
+  address       = {Berlin, Heidelberg},
+}
+```
+
+```bibtex
+@Misc{soelvsten2021:arXiv,
+  title         = {Efficient Binary Decision Diagram Manipulation in External Memory}, 
+  author        = {S{\o}lvsten, Steffan Christ
+               and van de Pol, Jaco
+               and Jakobsen, Anna Blume
+               and Thomasen, Mathias Weller Berg},
+  year          = {2021},
+  eprint        = {2104.12101},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.DS}
+  numpages      = {36},
+}
+```

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ given machine.
     - [Makefile targets](#makefile-targets)
     - [Examples](#examples)
 - [Contributions](#contributions)
-- [Credits](#credits)
 - [License](#license)
+- [Credits](#credits)
 - [References](#references)
 
 
@@ -139,6 +139,19 @@ as [future work](/FUTURE_WORK.md) and other possible things to contribute with
 as [issues](https://github.com/SSoelvsten/adiar/issues).
 
 
+## License
+The software and documentation files in this repository are provided under the
+[MIT License](/LICENSE.md).
+
+Using Adiar will indirectly use [TPIE](https://github.com/thomasmoelhave/tpie)
+underneath, which in turn is licensed under the _LGPL v3_ license. Hence, a
+binary of yours that is statically linked to Adiar will be affected by that
+license. That is, if you share that binary with others, then you will be obliged
+to make the source public. This can be resolved by using Adiar as a shared
+library or have it use an alternative to TPIE, such as
+[STXXL](https://github.com/stxxl/stxxl).
+
+
 ## Credits
 
 This project has been developed at the [Logic and Semantics](https://logsem.github.io/)
@@ -177,18 +190,6 @@ Also, thanks to the following wonderful people for their indirect contributions
 - **[Mathias Rav](https://github.com/Mortal)**:
   Developer of _TPIE_ and always helpful oracle about everything _TPIE_, _I/O_
   algorithms, and _C++_.
-
-## License
-The software and documentation files in this repository are provided under the
-[MIT License](/LICENSE.md).
-
-Using Adiar will indirectly use [TPIE](https://github.com/thomasmoelhave/tpie)
-underneath, which in turn is licensed under the _LGPL v3_ license. Hence, a
-binary of yours that is statically linked to Adiar will be affected by that
-license. That is, if you share that binary with others, then you will be obliged
-to make the source public. This can be resolved by using Adiar as a shared
-library or have it use an alternative to TPIE, such as
-[STXXL](https://github.com/stxxl/stxxl).
 
 
 ## References

--- a/README.md
+++ b/README.md
@@ -144,30 +144,39 @@ as [issues](https://github.com/SSoelvsten/adiar/issues).
 This project has been developed at the [Logic and Semantics](https://logsem.github.io/)
 group at [Aarhus University](https://cs.au.dk).
 
-- **[Steffan Sølvsten](https://github.com/SSoelvsten)**:
+- **[Steffan Sølvsten](https://ssoelvsten.github.io/)**:
   [soelvsten@cs.au.dk](mailto:soelvsten@cs.au.dk)
 
-- **[Jaco van de Pol](https://github.com/jacopol)**:
+- **[Jaco van de Pol](https://cs.au.dk/~jaco/)**:
   [jaco@cs.au.dk](mailto:jaco@cs.au.dk)
 
-Thank you, to the following wonderful people:
+Thank you, to all the contributors to this project
 
 - **[Anna Blume Jakobsen](https://github.com/AnnaBlume99)**:
-  Bachelor student, who during a summer project wrote the prototype
+  Bachelor student, who during the summer of 2020 wrote the prototype
   implementation of many core algorithms.
 
-- **[Asger Hautop Drewsen](https://github.com/Tyilo)**: Previous maintainer of
-  _TPIE_, who helped debug a few issues and gave general feedback on the
-  codebase.
-
-- **[Mathias Rav](https://github.com/Mortal)**:
-  Developer of _TPIE_, always helpful oracle about everything _TPIE_,
-  _I/O_ algorithms, and _C++_.
+- **[Asger Hautop Drewsen](https://github.com/Tyilo)**:
+  Previous maintainer of _TPIE_, who helped debug a few issues and gave general
+  feedback on the codebase.
 
 - **[Mathias Weller Berg Thomasen](https://github.com/MathiasWeller42)**:
-  Bachelor student, who during a summer project wrote the prototype
+  Bachelor student, who during the summer of 2020 wrote the prototype
   implementation of many core algorithms.
 
+Also, thanks to the following wonderful people for their indirect contributions
+
+- **[Gerth Stølting brodal](https://cs.au.dk/~gerth/)**:
+  Professor, who helped on the theory of I/O-algorithms and has suggested
+  multiple algorithmic improvements.
+
+- **[Lars Arge](http://lars.arge.dk/)**:
+  Professor, who created the foundation in [[Arge96](#references)] and was glad
+  to give advice on how to pick up on his ideas.
+
+- **[Mathias Rav](https://github.com/Mortal)**:
+  Developer of _TPIE_ and always helpful oracle about everything _TPIE_, _I/O_
+  algorithms, and _C++_.
 
 ## License
 The software and documentation files in this repository are provided under the

--- a/README.md
+++ b/README.md
@@ -166,25 +166,31 @@ group at [Aarhus University](https://cs.au.dk).
 Thank you, to all the contributors to this project
 
 - **[Anna Blume Jakobsen](https://github.com/AnnaBlume99)**:
+
   Implemented the prototype of many core algorithms during the summer of 2020.
 
 - **[Asger Hautop Drewsen](https://github.com/Tyilo)**:
+
   Helped debug a few issues and gave general feedback on the codebase.
 
 - **[Mathias Weller Berg Thomasen](https://github.com/MathiasWeller42)**:
+
   Implemented the prototype of many core algorithms during the summer of 2020.
 
 Also, thanks to the following wonderful people for their indirect contributions
 
 - **[Gerth Stølting brodal](https://cs.au.dk/~gerth/)**:
+
   Helped on the theory of I/O-algorithms and has suggested multiple algorithmic
   improvements.
 
 - **[Lars Arge](http://lars.arge.dk/)**:
+
   Created the foundation in [[Arge96](#references)] and was glad to give advice
   on how to pick up on his ideas.
 
 - **[Mathias Rav](https://github.com/Mortal)**:
+
   Always helpful oracle about everything _TPIE_, _I/O_ algorithms, and _C++_.
 
 

--- a/README.md
+++ b/README.md
@@ -166,30 +166,26 @@ group at [Aarhus University](https://cs.au.dk).
 Thank you, to all the contributors to this project
 
 - **[Anna Blume Jakobsen](https://github.com/AnnaBlume99)**:
-  Bachelor student, who during the summer of 2020 wrote the prototype
-  implementation of many core algorithms.
+  Implemented the prototype of many core algorithms during the summer of 2020.
 
 - **[Asger Hautop Drewsen](https://github.com/Tyilo)**:
-  Previous maintainer of _TPIE_, who helped debug a few issues and gave general
-  feedback on the codebase.
+  Helped debug a few issues and gave general feedback on the codebase.
 
 - **[Mathias Weller Berg Thomasen](https://github.com/MathiasWeller42)**:
-  Bachelor student, who during the summer of 2020 wrote the prototype
-  implementation of many core algorithms.
+  Implemented the prototype of many core algorithms during the summer of 2020.
 
 Also, thanks to the following wonderful people for their indirect contributions
 
 - **[Gerth Stølting brodal](https://cs.au.dk/~gerth/)**:
-  Professor, who helped on the theory of I/O-algorithms and has suggested
-  multiple algorithmic improvements.
+  Helped on the theory of I/O-algorithms and has suggested multiple algorithmic
+  improvements.
 
 - **[Lars Arge](http://lars.arge.dk/)**:
-  Professor, who created the foundation in [[Arge96](#references)] and was glad
-  to give advice on how to pick up on his ideas.
+  Created the foundation in [[Arge96](#references)] and was glad to give advice
+  on how to pick up on his ideas.
 
 - **[Mathias Rav](https://github.com/Mortal)**:
-  Developer of _TPIE_ and always helpful oracle about everything _TPIE_, _I/O_
-  algorithms, and _C++_.
+  Always helpful oracle about everything _TPIE_, _I/O_ algorithms, and _C++_.
 
 
 ## References


### PR DESCRIPTION
I will merge this in tomorrow, when we have heard back from TACAS. The _CITE.md_ file should maybe be moved into the _docs/_ folder, such that it is also directly available in the documentation