### PR TITLE
Make priority queues totally ordered in debug mode

### DIFF
--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -25,27 +25,70 @@ namespace adiar
   // the placement of the else-BDD on whether any element from the if-BDD or
   // then-BDD has been forwarded.
 
-  struct ite_triple : triple
+  struct ite_triple_1 : triple
   {
     ptr_t source;
   };
 
-  struct ite_triple_data_1 : ite_triple
+#ifndef NDEBUG
+  struct ite_triple_1_lt : public std::binary_function<ite_triple_1, ite_triple_1, bool>
+  {
+    bool operator()(const ite_triple_1 &a, const ite_triple_1 &b)
+    {
+      return triple_fst_lt()(a,b)
+        || (!triple_fst_lt()(b,a) && a.source < b.source);
+    }
+  };
+#else
+  typedef triple_fst_lt ite_triple_1_lt;
+#endif
+
+  typedef levelized_node_priority_queue<ite_triple_1, triple_label, ite_triple_1_lt, std::less<>, 3>
+  ite_priority_queue_1_t;
+
+  struct ite_triple_2 : ite_triple_1
   {
     ptr_t data_1_low;
     ptr_t data_1_high;
   };
 
-  struct ite_triple_data_2 : ite_triple_data_1
+#ifndef NDEBUG
+  struct ite_triple_2_lt : public std::binary_function<ite_triple_2, ite_triple_2, bool>
+  {
+    bool operator()(const ite_triple_2 &a, const ite_triple_2 &b)
+    {
+      return triple_snd_lt()(a,b)
+        || (!triple_snd_lt()(b,a) && a.source < b.source);
+    }
+  };
+#else
+  typedef triple_snd_lt ite_triple_2_lt;
+#endif
+
+  typedef tpie::priority_queue<ite_triple_2, ite_triple_2_lt>
+  ite_priority_queue_2_t;
+
+  struct ite_triple_3 : ite_triple_2
   {
     ptr_t data_2_low;
     ptr_t data_2_high;
   };
 
+#ifndef NDEBUG
+  struct ite_triple_3_lt : public std::binary_function<ite_triple_3, ite_triple_3, bool>
+  {
+    bool operator()(const ite_triple_3 &a, const ite_triple_3 &b)
+    {
+      return triple_trd_lt()(a,b)
+        || (!triple_trd_lt()(b,a) && a.source < b.source);
+    }
+  };
+#else
+  typedef triple_trd_lt ite_triple_3_lt;
+#endif
 
-  typedef levelized_node_priority_queue<ite_triple, triple_label, triple_fst_lt, std::less<>, 3> ite_priority_queue_1_t;
-  typedef tpie::priority_queue<ite_triple_data_1, triple_snd_lt> ite_priority_queue_2_t;
-  typedef tpie::priority_queue<ite_triple_data_2, triple_trd_lt> ite_priority_queue_3_t;
+  typedef tpie::priority_queue<ite_triple_3, ite_triple_3_lt>
+  ite_priority_queue_3_t;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions
@@ -254,7 +297,7 @@ namespace adiar
       if (ite_pq_1.can_pull()
           && (ite_pq_2.empty() || fst(ite_pq_1.top()) < snd(ite_pq_2.top()))
           && (ite_pq_3.empty() || fst(ite_pq_1.top()) < trd(ite_pq_3.top()))) {
-        ite_triple r = ite_pq_1.top();
+        ite_triple_1 r = ite_pq_1.top();
         ite_pq_1.pop();
 
         source = r.source;
@@ -263,7 +306,7 @@ namespace adiar
         t_else = r.t3;
       } else if (!ite_pq_2.empty()
                  && (ite_pq_3.empty() || snd(ite_pq_2.top()) < trd(ite_pq_3.top()))) {
-        ite_triple_data_1 r = ite_pq_2.top();
+        ite_triple_2 r = ite_pq_2.top();
         ite_pq_2.pop();
 
         source = r.source;
@@ -275,7 +318,7 @@ namespace adiar
         data_1_low = r.data_1_low;
         data_1_high = r.data_1_high;
       } else {
-        ite_triple_data_2 r = ite_pq_3.top();
+        ite_triple_3 r = ite_pq_3.top();
         ite_pq_3.pop();
 
         source = r.source;

--- a/src/adiar/data.h
+++ b/src/adiar/data.h
@@ -245,7 +245,11 @@ namespace adiar {
   struct arc_target_lt : public std::binary_function<arc_t, arc_t, bool>
   {
     bool operator ()(const arc_t& a, const arc_t& b) const {
-      return a.target < b.target;
+      return a.target < b.target
+#ifndef NDEBUG
+        || (a.target == b.target && a.source < b.source)
+#endif
+        ;
     }
   };
 

--- a/src/adiar/internal/intercut.h
+++ b/src/adiar/internal/intercut.h
@@ -29,7 +29,11 @@ namespace adiar
     bool operator()(const arc_cut &a, const arc_cut &b)
     {
       return a.cut_at < b.cut_at
-        || (a.cut_at == b.cut_at && a.target < b.target);
+        || (a.cut_at == b.cut_at && a.target < b.target)
+#ifndef NDEBUG
+        || (a.cut_at == b.cut_at && a.target == b.target && a.source < b.source)
+#endif
+           ;
     }
   };
 

--- a/src/adiar/internal/product_construction.h
+++ b/src/adiar/internal/product_construction.h
@@ -23,15 +23,43 @@ namespace adiar
     ptr_t source;
   };
 
+#ifndef NDEBUG
+  struct prod_tuple_1_lt : public std::binary_function<tuple, tuple, bool>
+  {
+    bool operator()(const prod_tuple_1 &a, const prod_tuple_1 &b)
+    {
+      return tuple_fst_lt()(a,b)
+        || (!tuple_fst_lt()(b,a) && a.source < b.source)
+        ;
+    }
+  };
+#else
+  typedef tuple_fst_lt prod_tuple_1_lt;
+#endif
+
+  typedef levelized_node_priority_queue<prod_tuple_1, tuple_label, prod_tuple_1_lt, std::less<>, 2>
+  prod_priority_queue_1_t;
+
   struct prod_tuple_2 : tuple_data
   {
     ptr_t source;
   };
 
-  typedef levelized_node_priority_queue<prod_tuple_1, tuple_label, tuple_fst_lt, std::less<>, 2>
-  prod_priority_queue_1_t;
+#ifndef NDEBUG
+  struct prod_tuple_2_lt : public std::binary_function<tuple, tuple, bool>
+  {
+    bool operator()(const prod_tuple_2 &a, const prod_tuple_2 &b)
+    {
+      return tuple_snd_lt()(a,b)
+        || (!tuple_snd_lt()(b,a) && a.source < b.source)
+        ;
+    }
+  };
+#else
+  typedef tuple_snd_lt prod_tuple_2_lt;
+#endif
 
-  typedef tpie::priority_queue<prod_tuple_2, tuple_snd_lt>
+  typedef tpie::priority_queue<prod_tuple_2, prod_tuple_2_lt>
   prod_priority_queue_2_t;
 
   struct prod_rec_output {

--- a/src/adiar/internal/quantify.h
+++ b/src/adiar/internal/quantify.h
@@ -40,7 +40,11 @@ namespace adiar
   {
     bool operator()(const quantify_tuple &a, const quantify_tuple &b)
     {
-      return a.t1 < b.t1 || (a.t1 == b.t1 && a.t2 < b.t2);
+      return a.t1 < b.t1 || (a.t1 == b.t1 && a.t2 < b.t2)
+#ifndef NDEBUG
+        || (a.t1 == b.t1 && a.t2 == b.t2 && a.source < b.source)
+#endif
+        ;
     }
   };
 
@@ -48,7 +52,11 @@ namespace adiar
   {
     bool operator()(const quantify_tuple_data &a, const quantify_tuple_data &b)
     {
-      return a.t2 < b.t2 || (a.t2 == b.t2 && a.t1 < b.t1);
+      return a.t2 < b.t2 || (a.t2 == b.t2 && a.t1 < b.t1)
+#ifndef NDEBUG
+        || (a.t1 == b.t1 && a.t2 == b.t2 && a.source < b.source)
+#endif
+        ;
     }
   };
 

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -713,14 +713,13 @@ go_bandit([]() {
 
         node_arc_test_stream node_arcs(out);
 
-        // The high arc is forwarded first, since (2) was resolved before (3)
-
         AssertThat(node_arcs.can_pull(), Is().True()); // (4,5)
         AssertThat(node_arcs.pull(),
-                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
+                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+
         AssertThat(node_arcs.can_pull(), Is().True());
         AssertThat(node_arcs.pull(),
-                   Is().EqualTo(arc { create_node_ptr(0,0), create_node_ptr(2,0) }));
+                   Is().EqualTo(arc { flag(create_node_ptr(0,0)), create_node_ptr(2,0) }));
 
         AssertThat(node_arcs.can_pull(), Is().False());
 

--- a/test/adiar/zdd/test_expand.cpp
+++ b/test/adiar/zdd/test_expand.cpp
@@ -369,21 +369,17 @@ go_bandit([]() {
       AssertThat(node_arcs.can_pull(), Is().True());
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(3,0)), create_node_ptr(4,0) }));
 
-      // TODO: why are the arcs output in a valid but unexpected order?
-      //
-      // We would expect the next four arcs to be low, high, low, high, since
-      // the tpie::priority_queue has until now been stable?
-      AssertThat(node_arcs.can_pull(), Is().True());
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(4,0)), create_node_ptr(5,0) }));
-
       AssertThat(node_arcs.can_pull(), Is().True());
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(4,0), create_node_ptr(5,0) }));
 
       AssertThat(node_arcs.can_pull(), Is().True());
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(5,0)), create_node_ptr(6,0) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(4,0)), create_node_ptr(5,0) }));
 
       AssertThat(node_arcs.can_pull(), Is().True());
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(5,0), create_node_ptr(6,0) }));
+
+      AssertThat(node_arcs.can_pull(), Is().True());
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(5,0)), create_node_ptr(6,0) }));
 
       AssertThat(node_arcs.can_pull(), Is().False());
 
@@ -689,12 +685,11 @@ go_bandit([]() {
       AssertThat(node_arcs.can_pull(), Is().True());
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(6,0)), create_node_ptr(7,1) }));
 
-      // TODO: Again, why are these nodes swapped in their order?
-      AssertThat(node_arcs.can_pull(), Is().True()); // T chain
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(5,1)), create_node_ptr(7,2) }));
-
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(5,1), create_node_ptr(7,2) }));
+
+      AssertThat(node_arcs.can_pull(), Is().True()); // T chain
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(5,1)), create_node_ptr(7,2) }));
 
       // (5) and (6) and their x9 cuts
       AssertThat(node_arcs.can_pull(), Is().True());
@@ -713,20 +708,19 @@ go_bandit([]() {
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(8,0), create_node_ptr(9,0) }));
 
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(7,2), create_node_ptr(9,1) }));
+
+      AssertThat(node_arcs.can_pull(), Is().True()); // T chain
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(7,2)), create_node_ptr(9,1) }));
 
-      // TODO: Another unstable ordering of four arcs...
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(8,1)), create_node_ptr(9,1) }));
-
-      AssertThat(node_arcs.can_pull(), Is().True()); // T chain
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(7,2), create_node_ptr(9,1) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(8,0)), create_node_ptr(9,1) }));
 
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(8,1), create_node_ptr(9,1) }));
 
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(8,0)), create_node_ptr(9,1) }));
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(8,1)), create_node_ptr(9,1) }));
 
       // (7) and the x11 cuts
       AssertThat(node_arcs.can_pull(), Is().True());
@@ -735,12 +729,11 @@ go_bandit([]() {
       AssertThat(node_arcs.can_pull(), Is().True());
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(9,0)), create_node_ptr(10,0) }));
 
-      // TODO: ...
-      AssertThat(node_arcs.can_pull(), Is().True()); // T chain
-      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(9,1)), create_node_ptr(11,0) }));
-
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { create_node_ptr(9,1), create_node_ptr(11,0) }));
+
+      AssertThat(node_arcs.can_pull(), Is().True()); // T chain
+      AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(9,1)), create_node_ptr(11,0) }));
 
       AssertThat(node_arcs.can_pull(), Is().True()); // T chain
       AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(create_node_ptr(10,0)), create_node_ptr(11,0) }));

--- a/test/adiar/zdd/test_subset.cpp
+++ b/test/adiar/zdd/test_subset.cpp
@@ -1215,10 +1215,10 @@ go_bandit([]() {
         AssertThat(node_arcs.pull(), Is().EqualTo(arc { n1_3.uid, n1_4.uid }));
 
         AssertThat(node_arcs.can_pull(), Is().True());
-        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1_4.uid), n1_6.uid }));
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1_3.uid), n1_6.uid }));
 
         AssertThat(node_arcs.can_pull(), Is().True());
-        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1_3.uid), n1_6.uid }));
+        AssertThat(node_arcs.pull(), Is().EqualTo(arc { flag(n1_4.uid), n1_6.uid }));
 
         AssertThat(node_arcs.can_pull(), Is().False());
 


### PR DESCRIPTION
In #210 I realized that the `tpie::priority_queue` is not stable - i.e. when two elements are tied, then the oldest element is not necessarily output. It has just been a pure coincidence or due to the stability of merge sort, that I haven't noticed this in the first 700 unit tests.

We don't really care about this in production, as it does provide a slowdown and does not affect correctness of our algorithms. But, for our unit tests - since they are so strictly defining the order - we need the ordering to be total. If we didn't, then orderings will break, when we switch to other sorting algorithms and priority queue implementations, such as the ones mentioned in #98