### PR TITLE
Add benchmarking of smaller instances (closes #246)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,11 +43,19 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
 
   run_benchmark:
-    name: 'Run benchmark report'
+    name: 'Benchmark: ${{ matrix.N }}-Queens'
     runs-on: ubuntu-latest
 
     needs: [fetch-branch, fetch-remote, skip_duplicate]
     if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - N: '9'
+          - N: '12'
+          - N: '14'
 
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +69,7 @@ jobs:
 
       - name: 'Run benchmark.py'
         run: |
-          python3 ./.github/workflows/benchmark.py origin main ${{ needs.fetch-remote.outputs.remote }} ${{ needs.fetch-branch.outputs.branch }}
+          python3 ./.github/workflows/benchmark.py ${{ matrix.N }} origin main ${{ needs.fetch-remote.outputs.remote }} ${{ needs.fetch-branch.outputs.branch }}
 
       - name: 'Post benchmark.out on PR'
         if: always()
@@ -72,11 +80,18 @@ jobs:
           path: ./benchmark.out
 
   run_dummy:
-    name: 'Run benchmark report'
+    name: 'Benchmark: ${{ matrix.N }}-Queens'
     runs-on: ubuntu-latest
 
     needs: [skip_duplicate]
     if: ${{ needs.skip_duplicate.outputs.should_skip == 'true' }}
+
+    strategy:
+      matrix:
+        include:
+          - N: '9'
+          - N: '12'
+          - N: '14'
 
     steps:
     - name: Echo skip

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -31,7 +31,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
 
   run-benchmark:
-    name: 'Benchmark: ${{ matrix.name }}'
+    name: 'System Test: ${{ matrix.name }}'
     runs-on: ubuntu-latest
 
     needs: [fetch-branch, skip_duplicate]


### PR DESCRIPTION
This expands the `.github/workflows/benchmark.yml` to not only run *14*-Queens but instead

- **9-Queens** The smallest N, where we don't print the solutions. The largest BDD created is roughly 3 MiB which makes the simple bounds in #98 be ~10 MiB and so easily inside of internal memory.
- **12-Queens** The largest here is 113 MiB which makes some estimates up to ~12 GiB.
- **14-Queens** Here the largest instance itself is larger than the 8 GiB of main memory available.

For *9* and *12* the bottleneck is compilation which takes 2 minutes every time.