### PR TITLE
LPQ/Faster relabel of buckets on next level

### DIFF
--- a/src/adiar/internal/levelized_priority_queue.h
+++ b/src/adiar/internal/levelized_priority_queue.h
@@ -645,6 +645,7 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     bool empty_level()
     {
+      // TODO: change semantics to require 'has_current_level'
       return !has_current_level() ||
         (// Do we not have any cached element from top()?
          !_has_top_elem


### PR DESCRIPTION
Closes #238 and #245 . This change includes the following computational optimisations

1. Skips the 'go through all buckets before relabelling' work.
2. Relabels all buckets more often.
3. Relabelling leaves all buckets in phase 1 thereby improving the likelihood the bucket will be used.
4. Heavily simplifies the logic for the primary case (and changes it into a do-while loop)