### PR TITLE
LPQ/Remove size hack for buffered top element logic

### DIFF
--- a/src/adiar/internal/levelized_priority_queue.h
+++ b/src/adiar/internal/levelized_priority_queue.h
@@ -230,7 +230,8 @@ namespace adiar {
 
   private:
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Number of elements in the priority queue
+    /// \brief Number of elements in the levelized priority queue (excluding the
+    ///        one element possibly in '_top_elem').
     ////////////////////////////////////////////////////////////////////////////
     size_t _size = 0;
 
@@ -466,12 +467,17 @@ namespace adiar {
       adiar_debug(can_push(),
                   "Should only push when there is a yet unvisited level.");
 
-      _size++;
       const label_t level = elem_level_t::label_of(e);
+
+      adiar_debug(_level_cmp_le(next_bucket_level(), level),
+                  "Can only push element to next bucket or later.");
+
       const size_t pushable_buckets = active_buckets() - has_front_bucket();
 
       adiar_debug(pushable_buckets > 0,
                   "There is at least one pushable bucket (i.e. level)");
+
+      _size++;
 
       label_t bucket_offset = 1u;
       do {
@@ -630,10 +636,9 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     elem_t top()
     {
-      adiar_debug (can_pull(), "Cannot peek on empty level/queue");
+      adiar_debug (can_pull(), "Can only obtain top element on non-empty level");
 
       if (!_has_top_elem) {
-        _size++; // Compensate that pull() decrements the size
         _top_elem = pull();
         _has_top_elem = true;
       }
@@ -656,18 +661,20 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     elem_t pull()
     {
-      adiar_debug (can_pull(), "Cannot pull on empty level/queue");
+      adiar_debug (!empty_level(), "Can only pull on non-empty level");
 
-      _size--;
       if (_has_top_elem) {
         _has_top_elem = false;
         return _top_elem;
       }
 
+      adiar_debug (_size > 0, "pull on non-top element requires content");
+      _size--;
+
       // Merge bucket with overflow queue
       if (_overflow_queue.empty() || (_has_next_from_bucket
                                       && _e_comparator(_next_from_bucket, _overflow_queue.top()))) {
-        elem_t ret = _next_from_bucket;
+        const elem_t ret = _next_from_bucket;
         if (_buckets_sorter[_front_bucket_idx] -> can_pull()) {
           _next_from_bucket = _buckets_sorter[_front_bucket_idx] -> pull();
         } else {
@@ -675,7 +682,7 @@ namespace adiar {
         }
         return ret;
       } else {
-        elem_t ret = _overflow_queue.top();
+        const elem_t ret = _overflow_queue.top();
         _overflow_queue.pop();
         return ret;
       }
@@ -696,7 +703,8 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     size_t size() const
     {
-      return _size;
+      // TODO: also separate '_size' away from the overflow queue?
+      return _size + _has_top_elem;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -710,7 +718,7 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     bool empty() const
     {
-      return _size == 0;
+      return size() == 0;
     }
 
   private:

--- a/test/adiar/internal/test_levelized_priority_queue.cpp
+++ b/test/adiar/internal/test_levelized_priority_queue.cpp
@@ -1763,7 +1763,77 @@ go_bandit([]() {
           AssertThat(pq.can_pull(), Is().False());
         });
 
-        // TODO: peek -> push -> peek
+        it("is the same after pushing an element", [&]() {
+          pq_test_file f;
+
+          { // Garbage collect the writer early
+            pq_test_writer fw(f);
+
+            fw.unsafe_push(create_level_info(6,2u)); // .
+            fw.unsafe_push(create_level_info(5,2u)); // .
+            fw.unsafe_push(create_level_info(4,3u)); // overflow
+            fw.unsafe_push(create_level_info(3,2u)); // bucket
+            fw.unsafe_push(create_level_info(2,2u)); // bucket
+            fw.unsafe_push(create_level_info(1,1u)); // skipped
+          }
+
+          test_priority_queue<pq_test_file, 1> pq({f}, tpie::get_memory_manager().available(), 32);
+
+          pq.push(pq_test_data {2, 1});  // bucket
+          AssertThat(pq.size(), Is().EqualTo(1u));
+
+          pq.setup_next_level(); // 2
+
+          AssertThat(pq.can_pull(), Is().True());
+          AssertThat(pq.top(), Is().EqualTo(pq_test_data {2, 1}));
+          AssertThat(pq.size(), Is().EqualTo(1u));
+
+          pq.push(pq_test_data {3, 1});  // bucket
+          AssertThat(pq.size(), Is().EqualTo(2u));
+
+          AssertThat(pq.can_pull(), Is().True());
+          AssertThat(pq.top(), Is().EqualTo(pq_test_data {2, 1}));
+          AssertThat(pq.size(), Is().EqualTo(2u));
+        });
+
+        it("can look into bucket, pop, and then look again", [&]() {
+          pq_test_file f;
+
+          { // Garbage collect the writer early
+            pq_test_writer fw(f);
+
+            fw.unsafe_push(create_level_info(6,2u)); // .
+            fw.unsafe_push(create_level_info(5,2u)); // .
+            fw.unsafe_push(create_level_info(4,3u)); // overflow
+            fw.unsafe_push(create_level_info(3,2u)); // bucket
+            fw.unsafe_push(create_level_info(2,2u)); // bucket
+            fw.unsafe_push(create_level_info(1,1u)); // skipped
+          }
+
+          test_priority_queue<pq_test_file, 1> pq({f}, tpie::get_memory_manager().available(), 32);
+
+          pq.push(pq_test_data {2, 1});  // bucket
+          AssertThat(pq.size(), Is().EqualTo(1u));
+
+          pq.push(pq_test_data {2, 2});  // bucket
+          AssertThat(pq.size(), Is().EqualTo(2u));
+
+          pq.setup_next_level(); // 2
+
+          AssertThat(pq.can_pull(), Is().True());
+          AssertThat(pq.top(), Is().EqualTo(pq_test_data {2, 1}));
+          AssertThat(pq.size(), Is().EqualTo(2u));
+
+          AssertThat(pq.can_pull(), Is().True());
+          AssertThat(pq.pull(), Is().EqualTo(pq_test_data {2, 1}));
+          AssertThat(pq.size(), Is().EqualTo(1u));
+
+          AssertThat(pq.can_pull(), Is().True());
+          AssertThat(pq.top(), Is().EqualTo(pq_test_data {2, 2}));
+          AssertThat(pq.size(), Is().EqualTo(1u));
+
+          AssertThat(pq.can_pull(), Is().True());
+        });
       });
 
       describe(".size()", [&]{


### PR DESCRIPTION
Fixes the hack in the *levelized priority queue* `top()` function compensates for the decrement in the `pull()` function. Now, the `_size` variable does not account for the buffered top element.