### PR TITLE
Fix: size_based bounds are off-by-one

### DIFF
--- a/src/adiar/internal/pred.cpp
+++ b/src/adiar/internal/pred.cpp
@@ -1,6 +1,7 @@
 #include "pred.h"
 
 #include <adiar/file_stream.h>
+#include <adiar/internal/util.h>
 
 namespace adiar
 {
@@ -24,10 +25,18 @@ namespace adiar
     size_t curr_level_processed;
 
   public:
-    static size_t __comparison_size_based_upper_bound
-      (const node_file &in_1, const node_file &/*in_2*/)
+    static size_t max_cut_upper_bound(const node_file &in_1, const node_file &/*in_2*/)
     {
-      return in_1.size();
+      const size_t number_of_nodes = in_1._file_ptr->size();
+      const bits_approximation input_bits(number_of_nodes);
+
+      const bits_approximation bound_bits = input_bits + 1;
+
+      if (bound_bits.may_overflow()) {
+        return std::numeric_limits<size_t>::max();
+      } else {
+        return in_1.size() + 1u;
+      }
     }
 
     static constexpr size_t memory_usage()

--- a/src/adiar/internal/pred.h
+++ b/src/adiar/internal/pred.h
@@ -215,12 +215,12 @@ namespace adiar
     const size_t pq_1_internal_memory =
       (aux_available_memory / (data_structures_in_pq_1 + data_structures_in_pq_2)) * data_structures_in_pq_1;
 
-    const size_t size_bound = comp_policy::level_check_t::__comparison_size_based_upper_bound(f1, f2);
+    const size_t max_pq_size = comp_policy::level_check_t::max_cut_upper_bound(f1, f2);
 
     const size_t pq_1_memory_fits =
       comparison_priority_queue_1_t<internal_sorter, internal_priority_queue>::memory_fits(pq_1_internal_memory);
 
-    if(size_bound <= pq_1_memory_fits) {
+    if(max_pq_size <= pq_1_memory_fits) {
 #ifdef ADIAR_STATS
       stats_equality.lpq_internal++;
 #endif
@@ -229,7 +229,7 @@ namespace adiar
       return __comparison_check<comp_policy,
                                 comparison_priority_queue_1_t<internal_sorter, internal_priority_queue>,
                                 comparison_priority_queue_2_t<internal_priority_queue>>
-        (f1, f2, negate1, negate2, pq_1_internal_memory, pq_2_memory, size_bound);
+        (f1, f2, negate1, negate2, pq_1_internal_memory, pq_2_memory, max_pq_size);
     } else {
 #ifdef ADIAR_STATS
       stats_equality.lpq_external++;
@@ -240,7 +240,7 @@ namespace adiar
       return __comparison_check<comp_policy,
                                 comparison_priority_queue_1_t<external_sorter, external_priority_queue>,
                                 comparison_priority_queue_2_t<external_priority_queue>>
-        (f1, f2, negate1, negate2, pq_1_memory, pq_2_memory, size_bound);
+        (f1, f2, negate1, negate2, pq_1_memory, pq_2_memory, max_pq_size);
     }
   }
 

--- a/src/adiar/internal/quantify.h
+++ b/src/adiar/internal/quantify.h
@@ -292,9 +292,8 @@ namespace adiar
   }
 
   template<typename quantify_policy>
-  size_t __quantify_size_based_upper_bound(const typename quantify_policy::reduced_t &in)
+  size_t __quantify_max_cut_upper_bound(const typename quantify_policy::reduced_t &in)
   {
-    // Can the size_bound computation overflow?
     const size_t number_of_nodes = in.file_ptr()->size();
     const bits_approximation input_bits(number_of_nodes);
 
@@ -328,7 +327,7 @@ namespace adiar
       // Output stream
       - arc_writer::memory_usage();
 
-    const size_t size_bound = __quantify_size_based_upper_bound<quantify_policy>(in);
+    const size_t max_pq_size = __quantify_max_cut_upper_bound<quantify_policy>(in);
 
     constexpr size_t data_structures_in_pq_1 =
       quantify_priority_queue_1_t<internal_sorter, internal_priority_queue>::DATA_STRUCTURES;
@@ -342,7 +341,7 @@ namespace adiar
     const size_t pq_1_memory_fits =
       quantify_priority_queue_1_t<internal_sorter, internal_priority_queue>::memory_fits(pq_1_internal_memory);
 
-    if(size_bound <= pq_1_memory_fits) {
+    if(max_pq_size <= pq_1_memory_fits) {
 #ifdef ADIAR_STATS
       stats_quantify.lpq_internal++;
 #endif
@@ -351,7 +350,7 @@ namespace adiar
       return __quantify<quantify_policy,
                         quantify_priority_queue_1_t<internal_sorter, internal_priority_queue>,
                         quantify_priority_queue_2_t<internal_priority_queue>>
-        (in, label, op, pq_1_internal_memory, pq_2_memory, size_bound);
+        (in, label, op, pq_1_internal_memory, pq_2_memory, max_pq_size);
     } else {
 #ifdef ADIAR_STATS
       stats_quantify.lpq_external++;
@@ -362,7 +361,7 @@ namespace adiar
       return __quantify<quantify_policy,
                         quantify_priority_queue_1_t<external_sorter, external_priority_queue>,
                         quantify_priority_queue_2_t<external_priority_queue>>
-        (in, label, op, pq_1_memory, pq_2_memory, size_bound);
+        (in, label, op, pq_1_memory, pq_2_memory, max_pq_size);
     }
   }
 }

--- a/src/adiar/internal/substitution.h
+++ b/src/adiar/internal/substitution.h
@@ -202,9 +202,8 @@ namespace adiar
   }
 
   template<typename substitute_policy>
-  size_t __substitute_size_based_upper_bound(const typename substitute_policy::reduced_t &dd)
+  size_t __substitute_max_cut_upper_bound(const typename substitute_policy::reduced_t &dd)
   {
-    // Can the size_bound computation overflow?
     const size_t number_of_nodes = dd.file_ptr()->size();
     const bits_approximation input_bits(number_of_nodes);
 
@@ -226,25 +225,25 @@ namespace adiar
 
     // Derive an upper bound on the size of auxiliary data structures and check
     // whether we can run them with a faster internal memory variant.
-    const size_t size_bound = __substitute_size_based_upper_bound<substitute_policy>(dd);
+    const size_t max_pq_size = __substitute_max_cut_upper_bound<substitute_policy>(dd);
 
-    const tpie::memory_size_type lpq_memory_fits =
+    const tpie::memory_size_type pq_memory_fits =
       substitute_priority_queue_t<internal_sorter, internal_priority_queue>::memory_fits(aux_available_memory);
 
-    if(size_bound <= lpq_memory_fits) {
+    if(max_pq_size <= pq_memory_fits) {
 #ifdef ADIAR_STATS
       stats_substitute.lpq_internal++;
 #endif
       return __substitute<substitute_policy, substitute_act_mgr,
                           substitute_priority_queue_t<internal_sorter, internal_priority_queue>>
-        (dd, amgr, aux_available_memory, size_bound);
+        (dd, amgr, aux_available_memory, max_pq_size);
     } else {
 #ifdef ADIAR_STATS
       stats_substitute.lpq_external++;
 #endif
       return __substitute<substitute_policy, substitute_act_mgr,
                           substitute_priority_queue_t<external_sorter, external_priority_queue>>
-        (dd, amgr, aux_available_memory, size_bound);
+        (dd, amgr, aux_available_memory, max_pq_size);
     }
   }
 }

--- a/src/adiar/zdd/pred.cpp
+++ b/src/adiar/zdd/pred.cpp
@@ -14,19 +14,17 @@ namespace adiar {
   class ignore_levels
   {
   public:
-    static size_t __comparison_size_based_upper_bound
-      (const node_file &in_1, const node_file &in_2)
+    static size_t max_cut_upper_bound(const node_file &in_1, const node_file &in_2)
     {
-      // Can the size_bound computation overflow?
       const bits_approximation in_1_bits(in_1.size());
       const bits_approximation in_2_bits(in_2.size());
 
-      const bits_approximation bound_bits = in_1_bits * in_2_bits;
+      const bits_approximation bound_bits = (in_1_bits + 1) * (in_2_bits + 1);
 
       if(bound_bits.may_overflow()) {
         return std::numeric_limits<size_t>::max();
       } else {
-        return in_1.size() * in_2.size();
+        return (in_1.size() + 1) * (in_2.size() + 1);
       }
     }
 


### PR DESCRIPTION
On my way to uni I went over the proof for upper bounding based on the number of nodes. The good news are one can almost trivially copy over the proof based on the priority queue to be merely an argument related to the actual (NP-complete) max-cut problem. The bad news are, that we are off-by-one with our current bounds from #98 .

This fixes that.