### PR TITLE
Fix not counting sinks in quantify 2-level cuts

### DIFF
--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -42,6 +42,15 @@ namespace adiar
 
       return { r_fst, r_snd };
     }
+
+  public:
+    static cut_type cut_with_sinks(const bool_op &op)
+    {
+      const bool incl_false = !can_right_shortcut(op, create_sink_ptr(false));
+      const bool incl_true = !can_right_shortcut(op, create_sink_ptr(true));
+
+      return cut_type_with(incl_false, incl_true);
+    }
   };
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/quantify.h
+++ b/src/adiar/internal/quantify.h
@@ -294,10 +294,16 @@ namespace adiar
   }
 
   template<typename quantify_policy>
-  size_t __quantify_2level_upper_bound(const typename quantify_policy::reduced_t &in)
+  size_t __quantify_2level_upper_bound(const typename quantify_policy::reduced_t &in,
+                                       const bool_op &op)
   {
-    const safe_size_t max_2level_cut = in.max_2level_cut(cut_type::INTERNAL);
-    return unpack(max_2level_cut * max_2level_cut + 2u);
+    const cut_type ct_internal = cut_type::INTERNAL;
+    const cut_type ct_sinks = quantify_policy::cut_with_sinks(op);
+
+    const safe_size_t max_2level_cut_internal = in.max_2level_cut(ct_internal);
+    const safe_size_t max_2level_cut_sinks = in.max_2level_cut(ct_sinks);
+
+    return unpack(max_2level_cut_internal * max_2level_cut_sinks + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -325,7 +331,7 @@ namespace adiar
       // Output stream
       - arc_writer::memory_usage();
 
-    const size_t max_pq_size = __quantify_2level_upper_bound<quantify_policy>(in);
+    const size_t max_pq_size = __quantify_2level_upper_bound<quantify_policy>(in, op);
 
     constexpr size_t data_structures_in_pq_1 =
       quantify_priority_queue_1_t<internal_sorter, internal_priority_queue>::DATA_STRUCTURES;

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -27,7 +27,7 @@ namespace adiar
     {
       adiar_debug(!is_nil(r1) && !is_nil(r2), "Resolve request is only used for tuple cases");
 
-      ptr_t r_fst = fst(r1,r2);
+      const ptr_t r_fst = fst(r1,r2);
       ptr_t r_snd = snd(r1,r2);
 
       // Has the second option fallen out, while the first is still within? Then
@@ -37,6 +37,12 @@ namespace adiar
       }
 
       return { r_fst, r_snd };
+    }
+
+  public:
+    static cut_type cut_with_sinks(const bool_op &/*op*/)
+    {
+      return cut_type::ALL;
     }
   };
 


### PR DESCRIPTION
That or we need to write down the proof as to why it truly only is internal arcs. Notice, for a node (t1,t2) with a child (t1',F) we turn it into (t1') but that is still an arc (t1,t2) -> (t1') corresponding to the pair of (t1) -> (t1') and (t2) -> (F)