### PR TITLE
Improve 2-level cut computations

### DIFF
--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -485,11 +485,30 @@ namespace adiar
                                   const decision_diagram &in_then,
                                   const decision_diagram &in_else)
   {
-    const safe_size_t if_cut = in_if.max_2level_cut(cut_type::INTERNAL);
-    const safe_size_t then_cut = in_then.max_2level_cut(cut_type::ALL);
-    const safe_size_t else_cut = in_else.max_2level_cut(cut_type::ALL);
+    // 2-level cuts for 'if', where we split the false and true arcs away.
+    const safe_size_t if_cut_internal = in_if.max_2level_cut(cut_type::INTERNAL);
+    const safe_size_t if_cut_falses = in_if.max_2level_cut(cut_type::INTERNAL_FALSE) - if_cut_internal;
+    const safe_size_t if_cut_trues = in_if.max_2level_cut(cut_type::INTERNAL_TRUE) - if_cut_internal;
 
-    return unpack((if_cut * then_cut * else_cut) + (then_cut * else_cut) + 2u);
+    // 2-level cuts for 'then'
+    const safe_size_t then_cut_internal = in_then.max_2level_cut(cut_type::INTERNAL);
+    const safe_size_t then_cut_falses = in_then.max_2level_cut(cut_type::INTERNAL_FALSE) - then_cut_internal;
+    const safe_size_t then_cut_trues = in_then.max_2level_cut(cut_type::INTERNAL_TRUE) - then_cut_internal;
+    const safe_size_t then_cut_all = in_then.max_2level_cut(cut_type::ALL);
+
+    // 2-level cuts for 'else'
+    const safe_size_t else_cut_internal = in_else.max_2level_cut(cut_type::INTERNAL);
+    const safe_size_t else_cut_falses = in_else.max_2level_cut(cut_type::INTERNAL_FALSE) - else_cut_internal;
+    const safe_size_t else_cut_trues = in_else.max_2level_cut(cut_type::INTERNAL_TRUE) - else_cut_internal;
+    const safe_size_t else_cut_all = in_else.max_2level_cut(cut_type::ALL);
+
+    // Compute 2-level cut where irrelevant pairs of sinks are not paired
+    return unpack((if_cut_internal * (then_cut_all * else_cut_internal + then_cut_internal * else_cut_all
+                                      + then_cut_falses * else_cut_trues
+                                      + then_cut_trues * else_cut_falses))
+                  + if_cut_trues  * then_cut_internal
+                  + if_cut_falses * else_cut_internal
+                  + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/cut.h
+++ b/src/adiar/internal/cut.h
@@ -66,6 +66,16 @@ namespace adiar
     return includes_sink(static_cast<cut_type>(cut), sink_val);
   }
 
+  inline size_t number_of_sinks(const cut_type cut)
+  {
+    return includes_sink(cut, false) + includes_sink(cut, true);
+  }
+
+  inline size_t number_of_sinks(const size_t cut)
+  {
+    return number_of_sinks(static_cast<cut_type>(cut));
+  }
+
   // TODO: Exact top-down sweep computation of 1-level and 2-level cuts.
 }
 

--- a/src/adiar/internal/product_construction.h
+++ b/src/adiar/internal/product_construction.h
@@ -413,13 +413,23 @@ namespace adiar
                                    const typename prod_policy::reduced_t &in_2,
                                    const bool_op &op)
   {
+    // Cuts for left-hand side
+    const safe_size_t left_cut_internal = in_1.max_2level_cut(cut_type::INTERNAL);
+
     const cut_type left_ct = prod_policy::left_cut(op);
-    const safe_size_t left_2level_cut = in_1.max_2level_cut(left_ct);
+    const safe_size_t left_cut_sinks = in_1.max_2level_cut(left_ct) - left_cut_internal;
+
+    // Cuts for right-hand side
+    const safe_size_t right_cut_internal = in_2.max_2level_cut(cut_type::INTERNAL);
 
     const cut_type right_ct = prod_policy::right_cut(op);
-    const safe_size_t right_2level_cut = in_2.max_2level_cut(right_ct);
+    const safe_size_t right_cut_sinks = in_2.max_2level_cut(right_ct) - right_cut_internal;
 
-    return unpack(left_2level_cut * right_2level_cut + 2u);
+    // Compute cut, where we make sure not to pair sinks with sinks.
+    return unpack(left_cut_internal * right_cut_internal
+                  + left_cut_sinks * right_cut_internal
+                  + left_cut_internal * right_cut_sinks
+                  + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/quantify.h
+++ b/src/adiar/internal/quantify.h
@@ -293,6 +293,9 @@ namespace adiar
     return out_arcs;
   }
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// Derives upper bound based on the product of the maximum 2-level cut.
+  //////////////////////////////////////////////////////////////////////////////
   template<typename quantify_policy>
   size_t __quantify_2level_upper_bound(const typename quantify_policy::reduced_t &in,
                                        const bool_op &op)
@@ -304,6 +307,17 @@ namespace adiar
     const safe_size_t max_2level_cut_sinks = in.max_2level_cut(ct_sinks);
 
     return unpack(max_2level_cut_internal * max_2level_cut_sinks + 2u);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// Computes the maximum possible output size and uses a simple upper bound of
+  /// its maximum cut to derive an upper bound.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename quantify_policy>
+  size_t __quantify_size_upper_bound(const typename quantify_policy::reduced_t &in)
+  {
+    const safe_size_t in_size = in->size();
+    return unpack(in_size * in_size + 1u + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -331,7 +345,10 @@ namespace adiar
       // Output stream
       - arc_writer::memory_usage();
 
-    const size_t max_pq_size = __quantify_2level_upper_bound<quantify_policy>(in, op);
+    const size_t max_pq_size = std::min({
+        __quantify_2level_upper_bound<quantify_policy>(in,op),
+        __quantify_size_upper_bound<quantify_policy>(in)
+      });
 
     constexpr size_t data_structures_in_pq_1 =
       quantify_priority_queue_1_t<internal_sorter, internal_priority_queue>::DATA_STRUCTURES;


### PR DESCRIPTION
Closes #296 .

## Tighten Product Construction 2-level cut to not pair sinks with sinks

As you can see below there was a slight improvement for the *10-Queens* at *M = 4096* but otherwise nothing happened.

### Main
|                                | 128 | 192 | 256 | 512 | 1024 | 1536 | 2048 | 4096 |
|---------------------------|-----|-----|-----|----|-----|-----|-----|----|
| 8                              | 3   | 1 | 0 | 0 | 0 | 0 | 0 | 0 |
| 9                              | 6   | 5 | 5 | 5 | 3 | 1 | 0 | 0 |
| 10                             | 7   | 7 | 7 | 6 | 6 | 6 | 6 | 5 |
| 11                             | 8   | 8 | 8 | 8 | 8 | 7 | 7 | 7 |
| 12                             | 10  | 10 | 9 | 9 | 9 | 9 | 9 | 8 |

### internal/better\_2level\_usage
|                                | 128 | 192 | 256 | 512 | 1024 | 1536 | 2048 | 4096 |
|---------------------------|-----|-----|-----|----|-----|-----|-----|----|
| 8                              | 3   | 1 | 0 | 0 | 0 | 0 | 0 | 0 |
| 9                              | 6   | 5 | 5 | 5 | 3 | 1 | 0 | 0 |
| 10                             | 7   | 7 | 7 | 6 | 6 | 6 | 6 | 4 |
| 11                             | 8   | 8 | 8 | 8 | 8 | 7 | 7 | 7 |
| 12                             | 10  | 10 | 9 | 9 | 9 | 9 | 9 | 8 |

## Tighten If-Then-Else 2-level cut to not pair impossible sinks

I don't have a benchmark to test whether there is an improvement for bdd_ite. But, it probably worsens it since this change also (siimilar to https://github.com/SSoelvsten/adiar/pull/324) fixes a missing accounting of pairs of sink arcs in the if BDD.

## Add upper bound for product construction that may be tighter some times

This is a slight improvement. For *M = 2048* we have one more in internal memory for *N = 10* and *N = 12*.

## Add back in the purely size-based bounds for product constructions

This is very unlikely an improvement (it requires both have their 2-level cuts bound by their number of nodes). But, we need it for later experiments (where we switch off the other bounds). I might remove it before the final release of *v.1.2.0*