### PR TITLE
Statistics/wide integer

### DIFF
--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADERS
   # internal
   internal/assert.h
   internal/build.h
+  internal/cnl.h
   internal/convert.h
   internal/count.h
   internal/cut.h

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -4,11 +4,11 @@
 #include <adiar/file_writer.h>
 
 #include <adiar/internal/assert.h>
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/levelized_priority_queue.h>
 #include <adiar/internal/tuple.h>
 #include <adiar/internal/util.h>
-#include <adiar/internal/safe_number.h>
 
 #include <adiar/statistics.h>
 
@@ -509,12 +509,12 @@ namespace adiar
     const safe_size_t else_cut_all = cut::get(in_else, cut_type::ALL);
 
     // Compute 2-level cut where irrelevant pairs of sinks are not paired
-    return unpack((if_cut_internal * (then_cut_all * else_cut_internal + then_cut_internal * else_cut_all
-                                      + then_cut_falses * else_cut_trues
-                                      + then_cut_trues * else_cut_falses))
-                  + if_cut_trues  * then_cut_internal
-                  + if_cut_falses * else_cut_internal
-                  + const_size_inc);
+    return to_size((if_cut_internal * (then_cut_all * else_cut_internal + then_cut_internal * else_cut_all
+                                       + then_cut_falses * else_cut_trues
+                                       + then_cut_trues * else_cut_falses))
+                   + if_cut_trues  * then_cut_internal
+                   + if_cut_falses * else_cut_internal
+                   + const_size_inc);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -532,7 +532,7 @@ namespace adiar
     // internal node and t_then and t_else are nodes or (mismatching) sinks.
     // Then also count the copies of in_then and in_else for when in_if hits a
     // sink early.
-    return unpack(if_size * ((then_size + 2u) * (else_size + 2u) - 2u) + then_size + else_size + 1u + 2u);
+    return to_size(if_size * ((then_size + 2u) * (else_size + 2u) - 2u) + then_size + else_size + 1u + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/cnl.h
+++ b/src/adiar/internal/cnl.h
@@ -1,8 +1,9 @@
-#ifndef ADIAR_INTERNAL_SAFE_NUMBER_H
-#define ADIAR_INTERNAL_SAFE_NUMBER_H
+#ifndef ADIAR_INTERNAL_CNL_H
+#define ADIAR_INTERNAL_CNL_H
 
 #include <sstream>
 
+#include <cnl/fraction.h>
 #include <cnl/overflow_integer.h>
 #include <cnl/wide_integer.h>
 
@@ -16,7 +17,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Unpacks the value from a 'safe_size_t'.
   //////////////////////////////////////////////////////////////////////////////
-  inline size_t unpack(const safe_size_t s)
+  inline size_t to_size(const safe_size_t s)
   {
     return cnl::convert<cnl::saturated_overflow_tag, cnl::saturated_overflow_tag, size_t>(s);
   }
@@ -25,6 +26,14 @@ namespace adiar
   /// \brief A wide intger, i.e. suport of infinite size.
   //////////////////////////////////////////////////////////////////////////////
   typedef cnl::wide_integer<128, uint32_t> uintwide_t;
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Compute (100 * nominator) / denominator as a double.
+  //////////////////////////////////////////////////////////////////////////////
+  inline double percent_frac(uintwide_t nominator, uintwide_t denominator) {
+    const cnl::fraction<uintwide_t, uintwide_t> frac(nominator * 100u, denominator);
+    return cnl::convert<cnl::saturated_overflow_tag, cnl::saturated_overflow_tag, double>(frac);
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// Derivative of the 'cnl:_impl:to_chars_natural' (and 'cnl::_impl:itoc'
@@ -58,4 +67,4 @@ namespace adiar
   }
 }
 
-#endif // ADIAR_INTERNAL_SAFE_NUMBER_H
+#endif // ADIAR_INTERNAL_CNL_H

--- a/src/adiar/internal/intercut.h
+++ b/src/adiar/internal/intercut.h
@@ -8,9 +8,9 @@
 #include <adiar/file_writer.h>
 
 #include <adiar/internal/assert.h>
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/levelized_priority_queue.h>
-#include <adiar/internal/safe_number.h>
 
 namespace adiar
 {
@@ -319,7 +319,7 @@ namespace adiar
                                       intercut_policy::cut_true_sink);
     const safe_size_t max_2level_cut = dd.max_2level_cut(ct);
 
-    return unpack((2u * max_2level_cut) + 2u);
+    return to_size((2u * max_2level_cut) + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/levelized_priority_queue.h
+++ b/src/adiar/internal/levelized_priority_queue.h
@@ -354,6 +354,13 @@ namespace adiar {
     ////////////////////////////////////////////////////////////////////////////
     priority_queue_t _overflow_queue;
 
+#ifdef ADIAR_STATS_EXTRA
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The actual maximum size of the levelized priority queue.
+    ////////////////////////////////////////////////////////////////////////////
+    size_t _actual_max_size = 0u;
+#endif
+
   private:
     static tpie::memory_size_type m_overflow_queue(tpie::memory_size_type memory_given)
     {
@@ -445,6 +452,14 @@ namespace adiar {
       }
     }
 
+  public:
+    ~levelized_priority_queue()
+    {
+#ifdef ADIAR_STATS_EXTRA
+      stats_priority_queue.sum_predicted_max_size += _max_size;
+      stats_priority_queue.sum_actual_max_size += _actual_max_size;
+#endif
+    }
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -509,6 +524,9 @@ namespace adiar {
                   "There is at least one pushable bucket (i.e. level)");
 
       _size++;
+#ifdef ADIAR_STATS_EXTRA
+      _actual_max_size = std::max(_actual_max_size, _size);
+#endif
 
       label_t bucket_offset = 1u;
       do {

--- a/src/adiar/internal/product_construction.h
+++ b/src/adiar/internal/product_construction.h
@@ -12,10 +12,10 @@
 #include <adiar/bdd/bdd.h>
 
 #include <adiar/internal/build.h>
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/decision_diagram.h>
 #include <adiar/internal/levelized_priority_queue.h>
-#include <adiar/internal/safe_number.h>
 #include <adiar/internal/tuple.h>
 
 namespace adiar
@@ -429,10 +429,10 @@ namespace adiar
     const safe_size_t right_cut_sinks = cut::get(in_2, right_ct) - right_cut_internal;
 
     // Compute cut, where we make sure not to pair sinks with sinks.
-    return unpack(left_cut_internal * right_cut_internal
-                  + left_cut_sinks * right_cut_internal
-                  + left_cut_internal * right_cut_sinks
-                  + const_size_inc);
+    return to_size(left_cut_internal * right_cut_internal
+                   + left_cut_sinks * right_cut_internal
+                   + left_cut_internal * right_cut_sinks
+                   + const_size_inc);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -464,10 +464,10 @@ namespace adiar
 
     // Compute cut, where we count the product, the input-sink pairings, and the
     // connection from the product to the input-sink pairings separately.
-    return unpack(left_2level_cut * right_2level_cut
-                  + (right_1level_cut * left_sink_arcs) + left_sink_vals * right_2level_cut
-                  + (left_1level_cut * right_sink_arcs) + right_sink_vals * left_2level_cut
-                  + 2u);
+    return to_size(left_2level_cut * right_2level_cut
+                   + (right_1level_cut * left_sink_arcs) + left_sink_vals * right_2level_cut
+                   + (left_1level_cut * right_sink_arcs) + right_sink_vals * left_2level_cut
+                   + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -487,7 +487,7 @@ namespace adiar
     const safe_size_t right_sink_vals = number_of_sinks(right_ct);
     const safe_size_t right_size = in_2->size();
 
-    return unpack((left_size + left_sink_vals) * (right_size + right_sink_vals) + 1u + 2u);
+    return to_size((left_size + left_sink_vals) * (right_size + right_sink_vals) + 1u + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/quantify.h
+++ b/src/adiar/internal/quantify.h
@@ -10,8 +10,8 @@
 #include <adiar/file_writer.h>
 
 #include <adiar/internal/cut.h>
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/levelized_priority_queue.h>
-#include <adiar/internal/safe_number.h>
 #include <adiar/internal/tuple.h>
 
 namespace adiar
@@ -306,7 +306,7 @@ namespace adiar
     const safe_size_t max_cut_internal = cut::get(in, ct_internal);
     const safe_size_t max_cut_sinks = cut::get(in, ct_sinks);
 
-    return unpack(max_cut_internal * max_cut_sinks + const_size_inc);
+    return to_size(max_cut_internal * max_cut_sinks + const_size_inc);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -316,7 +316,7 @@ namespace adiar
   size_t __quantify_ilevel_upper_bound(const typename quantify_policy::reduced_t &in)
   {
     const safe_size_t in_size = in->size();
-    return unpack(in_size * in_size + 1u + 2u);
+    return to_size(in_size * in_size + 1u + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/safe_number.h
+++ b/src/adiar/internal/safe_number.h
@@ -1,22 +1,60 @@
 #ifndef ADIAR_INTERNAL_SAFE_NUMBER_H
 #define ADIAR_INTERNAL_SAFE_NUMBER_H
 
+#include <sstream>
+
 #include <cnl/overflow_integer.h>
+#include <cnl/wide_integer.h>
 
 namespace adiar
 {
-  ////////////////////////////////////////////////////////////////////////////
-  /// \brief An overflow safe variant of the 'size_t' unsigned integer. If a
-  ///        value overflows, then it is capped at the maximum value.
-  ////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief An (overflow safe) size_t (64 bit unsigned number).
+  //////////////////////////////////////////////////////////////////////////////
   typedef cnl::overflow_integer<size_t, cnl::saturated_overflow_tag> safe_size_t;
 
-  ////////////////////////////////////////////////////////////////////////////
-  /// \brief Unpacks the value from a 'safe_size_t'
-  ////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Unpacks the value from a 'safe_size_t'.
+  //////////////////////////////////////////////////////////////////////////////
   inline size_t unpack(const safe_size_t s)
   {
     return cnl::convert<cnl::saturated_overflow_tag, cnl::saturated_overflow_tag, size_t>(s);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief A wide intger, i.e. suport of infinite size.
+  //////////////////////////////////////////////////////////////////////////////
+  typedef cnl::wide_integer<128, uint32_t> uintwide_t;
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// Derivative of the 'cnl:_impl:to_chars_natural' (and 'cnl::_impl:itoc'
+  /// inlined) for the 'cnl::wide_integer' without compiler errors.
+  //////////////////////////////////////////////////////////////////////////////
+  inline void to_stringstream(const uintwide_t &value, std::stringstream &s)
+  {
+    constexpr size_t base = 10u;
+    const uintwide_t quotient = value / base;
+
+    if (quotient) {
+      to_stringstream(quotient, s);
+    }
+
+    const uintwide_t remainder = value - (quotient * base);
+    const int remainder_int = cnl::convert<cnl::saturated_overflow_tag, cnl::saturated_overflow_tag, int>(remainder);
+    const char remainder_char = static_cast<char>('0'+remainder_int);
+
+    s << remainder_char;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Convert a wide integer to a string.
+  //////////////////////////////////////////////////////////////////////////////
+  inline std::string to_string(const uintwide_t &value)
+  {
+    std::stringstream s;
+    to_stringstream(value, s);
+
+    return s.str();
   }
 }
 

--- a/src/adiar/internal/substitution.h
+++ b/src/adiar/internal/substitution.h
@@ -9,10 +9,10 @@
 #include <adiar/file_stream.h>
 #include <adiar/file_writer.h>
 
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/decision_diagram.h>
 #include <adiar/internal/levelized_priority_queue.h>
-#include <adiar/internal/safe_number.h>
 
 namespace adiar
 {
@@ -207,7 +207,7 @@ namespace adiar
   size_t __substitute_2level_upper_bound(const typename substitute_policy::reduced_t &dd)
   {
     const safe_size_t max_2level_cut = dd.max_2level_cut(cut_type::INTERNAL);
-    return unpack(max_2level_cut + 2u);
+    return to_size(max_2level_cut + 2u);
   }
 
   template<typename substitute_policy, typename substitute_act_mgr>

--- a/src/adiar/statistics.cpp
+++ b/src/adiar/statistics.cpp
@@ -1,7 +1,5 @@
 #include "statistics.h"
 
-#include <cnl/fraction.h>
-
 #include <adiar/internal/pred.h>
 #include <adiar/internal/levelized_priority_queue.h>
 #include <adiar/internal/reduce.h>
@@ -14,6 +12,16 @@
 
 namespace adiar
 {
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Convert a wide integer to a string and push to an output stream.
+  ///
+  /// TODO: move into 'adiar/internal/cnl.h'
+  //////////////////////////////////////////////////////////////////////////////
+  inline std::ostream& operator<< (std::ostream& os, const uintwide_t &s)
+  {
+    return os << to_string(s);
+  }
+
   // Define the available function
   stats_t adiar_stats()
   {
@@ -40,16 +48,6 @@ namespace adiar
   inline std::ostream& percent(std::ostream& os)  { return os << "%"; }
   inline std::ostream& indent(std::ostream& os)   { return os << "  "; }
   inline std::ostream& endl(std::ostream& os)     { return os << std::endl; }
-
-  inline std::ostream& operator<< (std::ostream& os, const uintwide_t &s)
-  {
-    return os << to_string(s);
-  }
-
-  double frac_to_percent(uintwide_t nominator, uintwide_t denominator) {
-    const cnl::fraction<uintwide_t, uintwide_t> frac(nominator * 100u, denominator);
-    return cnl::convert<cnl::saturated_overflow_tag, cnl::saturated_overflow_tag, double>(frac);
-  }
 
   void adiar_printstat(std::ostream &o)
   {
@@ -83,9 +81,9 @@ namespace adiar
 
     o << indent << bold_on << "Levelized Priority Queue" << bold_off << endl;
     o << indent << indent << "pushes to bucket        " << indent << stats_priority_queue.push_bucket
-      << " = " << frac_to_percent(stats_priority_queue.push_bucket, total_pushes) << percent << endl;
+      << " = " << percent_frac(stats_priority_queue.push_bucket, total_pushes) << percent << endl;
     o << indent << indent << "pushes to overflow      " << indent << stats_priority_queue.push_overflow
-      << " = " << frac_to_percent(stats_priority_queue.push_overflow, total_pushes) << percent << endl;
+      << " = " << percent_frac(stats_priority_queue.push_overflow, total_pushes) << percent << endl;
     o << endl;
 
 #endif
@@ -95,22 +93,22 @@ namespace adiar
     o << indent << indent << "input size              " << indent << total_arcs << " arcs = " << total_arcs / 2 << " nodes" << endl;
 
     o << indent << indent << indent << "node arcs:            " << indent
-      << stats_reduce.sum_node_arcs << " = " << frac_to_percent(stats_reduce.sum_node_arcs, total_arcs) << percent << endl;
+      << stats_reduce.sum_node_arcs << " = " << percent_frac(stats_reduce.sum_node_arcs, total_arcs) << percent << endl;
 
     o << indent << indent << indent << "sink arcs:            " << indent
-      << stats_reduce.sum_sink_arcs << " = " << frac_to_percent(stats_reduce.sum_sink_arcs, total_arcs) << percent << endl;
+      << stats_reduce.sum_sink_arcs << " = " << percent_frac(stats_reduce.sum_sink_arcs, total_arcs) << percent << endl;
 
 #ifdef ADIAR_STATS_EXTRA
     uintwide_t total_removed = stats_reduce.removed_by_rule_1 + stats_reduce.removed_by_rule_2;
     o << indent << indent << "nodes removed           " << indent
-      << total_removed << " = " << frac_to_percent(total_removed, total_arcs) << percent << endl;
+      << total_removed << " = " << percent_frac(total_removed, total_arcs) << percent << endl;
 
     if (total_removed > 0) {
       o << indent << indent << indent << "rule 1:               " << indent
-        << stats_reduce.removed_by_rule_1 << " = " << frac_to_percent(stats_reduce.removed_by_rule_1, total_removed) << percent << endl;
+        << stats_reduce.removed_by_rule_1 << " = " << percent_frac(stats_reduce.removed_by_rule_1, total_removed) << percent << endl;
 
       o << indent << indent << indent << "rule 2:               " << indent
-        << stats_reduce.removed_by_rule_2 << " = " << frac_to_percent(stats_reduce.removed_by_rule_2, total_removed) << percent << endl;
+        << stats_reduce.removed_by_rule_2 << " = " << percent_frac(stats_reduce.removed_by_rule_2, total_removed) << percent << endl;
     }
     o << endl;
 #endif
@@ -119,58 +117,58 @@ namespace adiar
     uintwide_t total_reduce = stats_reduce.lpq_internal + stats_reduce.lpq_external;
     o << indent << indent << "Reduce" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_reduce.lpq_internal << " = " << frac_to_percent(stats_reduce.lpq_internal, total_reduce) << percent << endl;
+      << stats_reduce.lpq_internal << " = " << percent_frac(stats_reduce.lpq_internal, total_reduce) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_reduce.lpq_external << " = " << frac_to_percent(stats_reduce.lpq_external, total_reduce) << percent << endl;
+      << stats_reduce.lpq_external << " = " << percent_frac(stats_reduce.lpq_external, total_reduce) << percent << endl;
 
     uintwide_t total_count = stats_count.lpq_internal + stats_count.lpq_external;
     o << indent << indent << "Count" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_count.lpq_internal << " = " << frac_to_percent(stats_count.lpq_internal, total_count) << percent << endl;
+      << stats_count.lpq_internal << " = " << percent_frac(stats_count.lpq_internal, total_count) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_count.lpq_external << " = " << frac_to_percent(stats_count.lpq_external, total_count) << percent << endl;
+      << stats_count.lpq_external << " = " << percent_frac(stats_count.lpq_external, total_count) << percent << endl;
 
     uintwide_t total_product = stats_product_construction.lpq_internal + stats_product_construction.lpq_external;
     o << indent << indent << "Product construction" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_product_construction.lpq_internal << " = " << frac_to_percent(stats_product_construction.lpq_internal, total_product) << percent << endl;
+      << stats_product_construction.lpq_internal << " = " << percent_frac(stats_product_construction.lpq_internal, total_product) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_product_construction.lpq_external << " = " << frac_to_percent(stats_product_construction.lpq_external, total_product) << percent << endl;
+      << stats_product_construction.lpq_external << " = " << percent_frac(stats_product_construction.lpq_external, total_product) << percent << endl;
 
     uintwide_t total_quantify = stats_quantify.lpq_internal + stats_quantify.lpq_external;
     o << indent << indent << "Quantification" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_quantify.lpq_internal << " = " << frac_to_percent(stats_quantify.lpq_internal, total_quantify) << percent << endl;
+      << stats_quantify.lpq_internal << " = " << percent_frac(stats_quantify.lpq_internal, total_quantify) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_quantify.lpq_external << " = " << frac_to_percent(stats_quantify.lpq_external, total_quantify) << percent << endl;
+      << stats_quantify.lpq_external << " = " << percent_frac(stats_quantify.lpq_external, total_quantify) << percent << endl;
 
     uintwide_t total_if_else = stats_if_else.lpq_internal + stats_if_else.lpq_external;
     o << indent << indent << "If-then-else" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_if_else.lpq_internal << " = " << frac_to_percent(stats_if_else.lpq_internal, total_if_else) << percent << endl;
+      << stats_if_else.lpq_internal << " = " << percent_frac(stats_if_else.lpq_internal, total_if_else) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_if_else.lpq_external << " = " << frac_to_percent(stats_if_else.lpq_external, total_if_else) << percent << endl;
+      << stats_if_else.lpq_external << " = " << percent_frac(stats_if_else.lpq_external, total_if_else) << percent << endl;
 
     uintwide_t total_substitute = stats_substitute.lpq_internal + stats_substitute.lpq_external;
     o << indent << indent << "Substitution" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_substitute.lpq_internal << " = " << frac_to_percent(stats_substitute.lpq_internal, total_substitute) << percent << endl;
+      << stats_substitute.lpq_internal << " = " << percent_frac(stats_substitute.lpq_internal, total_substitute) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_substitute.lpq_external << " = " << frac_to_percent(stats_substitute.lpq_external, total_substitute) << percent << endl;
+      << stats_substitute.lpq_external << " = " << percent_frac(stats_substitute.lpq_external, total_substitute) << percent << endl;
 
     uintwide_t total_compare = stats_equality.lpq_internal + stats_equality.lpq_external;
     o << indent << indent << "Comparison" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_equality.lpq_internal << " = " << frac_to_percent(stats_equality.lpq_internal, total_compare) << percent << endl;
+      << stats_equality.lpq_internal << " = " << percent_frac(stats_equality.lpq_internal, total_compare) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_equality.lpq_external << " = " << frac_to_percent(stats_equality.lpq_external, total_compare) << percent << endl;
+      << stats_equality.lpq_external << " = " << percent_frac(stats_equality.lpq_external, total_compare) << percent << endl;
 
     uintwide_t total_intercut = stats_intercut.lpq_internal + stats_intercut.lpq_external;
     o << indent << indent << "Intercut" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_intercut.lpq_internal << " = " << frac_to_percent(stats_intercut.lpq_internal, total_intercut) << percent << endl;
+      << stats_intercut.lpq_internal << " = " << percent_frac(stats_intercut.lpq_internal, total_intercut) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_intercut.lpq_external << " = " << frac_to_percent(stats_intercut.lpq_external, total_intercut) << percent << endl;
+      << stats_intercut.lpq_external << " = " << percent_frac(stats_intercut.lpq_external, total_intercut) << percent << endl;
 
     o << endl;
 #endif

--- a/src/adiar/statistics.cpp
+++ b/src/adiar/statistics.cpp
@@ -77,13 +77,20 @@ namespace adiar
     o << endl;
 
 #ifdef ADIAR_STATS_EXTRA
-    uintwide_t total_pushes = stats_priority_queue.push_bucket + stats_priority_queue.push_overflow;
-
     o << indent << bold_on << "Levelized Priority Queue" << bold_off << endl;
+
+    uintwide_t total_pushes = stats_priority_queue.push_bucket + stats_priority_queue.push_overflow;
     o << indent << indent << "pushes to bucket        " << indent << stats_priority_queue.push_bucket
       << " = " << percent_frac(stats_priority_queue.push_bucket, total_pushes) << percent << endl;
     o << indent << indent << "pushes to overflow      " << indent << stats_priority_queue.push_overflow
       << " = " << percent_frac(stats_priority_queue.push_overflow, total_pushes) << percent << endl;
+    o << endl;
+
+    o << indent << indent << "max size precision ratio" << indent
+      << stats_priority_queue.sum_actual_max_size << " / " << stats_priority_queue.sum_predicted_max_size
+      << " = " << percent_frac(stats_priority_queue.sum_actual_max_size, stats_priority_queue.sum_predicted_max_size) << percent
+      << endl;
+
     o << endl;
 
 #endif

--- a/src/adiar/statistics.cpp
+++ b/src/adiar/statistics.cpp
@@ -1,5 +1,7 @@
 #include "statistics.h"
 
+#include <cnl/fraction.h>
+
 #include <adiar/internal/pred.h>
 #include <adiar/internal/levelized_priority_queue.h>
 #include <adiar/internal/reduce.h>
@@ -33,13 +35,21 @@ namespace adiar
   }
 
   // Helper functions for pretty printing (UNIX)
-  std::ostream& bold_on(std::ostream& os)  { return os << "\e[1m"; }
-  std::ostream& bold_off(std::ostream& os) { return os << "\e[0m"; }
-  std::ostream& percent(std::ostream& os)  { return os << "%"; }
-  std::ostream& indent(std::ostream& os)   { return os << "  "; }
-  std::ostream& endl(std::ostream& os)     { return os << std::endl; }
+  inline std::ostream& bold_on(std::ostream& os)  { return os << "\e[1m"; }
+  inline std::ostream& bold_off(std::ostream& os) { return os << "\e[0m"; }
+  inline std::ostream& percent(std::ostream& os)  { return os << "%"; }
+  inline std::ostream& indent(std::ostream& os)   { return os << "  "; }
+  inline std::ostream& endl(std::ostream& os)     { return os << std::endl; }
 
-  double compute_percent(size_t s, size_t of) { return (static_cast<double>(s) / static_cast<double>(of)) * 100; }
+  inline std::ostream& operator<< (std::ostream& os, const uintwide_t &s)
+  {
+    return os << to_string(s);
+  }
+
+  double frac_to_percent(uintwide_t nominator, uintwide_t denominator) {
+    const cnl::fraction<uintwide_t, uintwide_t> frac(nominator * 100u, denominator);
+    return cnl::convert<cnl::saturated_overflow_tag, cnl::saturated_overflow_tag, double>(frac);
+  }
 
   void adiar_printstat(std::ostream &o)
   {
@@ -69,98 +79,98 @@ namespace adiar
     o << endl;
 
 #ifdef ADIAR_STATS_EXTRA
-    size_t total_pushes = stats_priority_queue.push_bucket + stats_priority_queue.push_overflow;
+    uintwide_t total_pushes = stats_priority_queue.push_bucket + stats_priority_queue.push_overflow;
 
     o << indent << bold_on << "Levelized Priority Queue" << bold_off << endl;
     o << indent << indent << "pushes to bucket        " << indent << stats_priority_queue.push_bucket
-      << " = " << compute_percent(stats_priority_queue.push_bucket, total_pushes) << percent << endl;
+      << " = " << frac_to_percent(stats_priority_queue.push_bucket, total_pushes) << percent << endl;
     o << indent << indent << "pushes to overflow      " << indent << stats_priority_queue.push_overflow
-      << " = " << compute_percent(stats_priority_queue.push_overflow, total_pushes) << percent << endl;
+      << " = " << frac_to_percent(stats_priority_queue.push_overflow, total_pushes) << percent << endl;
     o << endl;
 
 #endif
-    size_t total_arcs = stats_reduce.sum_node_arcs + stats_reduce.sum_sink_arcs;
+    uintwide_t total_arcs = stats_reduce.sum_node_arcs + stats_reduce.sum_sink_arcs;
     o << indent << bold_on << "Reduce" << bold_off << endl;
 
     o << indent << indent << "input size              " << indent << total_arcs << " arcs = " << total_arcs / 2 << " nodes" << endl;
 
     o << indent << indent << indent << "node arcs:            " << indent
-      << stats_reduce.sum_node_arcs << " = " << compute_percent(stats_reduce.sum_node_arcs, total_arcs) << percent << endl;
+      << stats_reduce.sum_node_arcs << " = " << frac_to_percent(stats_reduce.sum_node_arcs, total_arcs) << percent << endl;
 
     o << indent << indent << indent << "sink arcs:            " << indent
-      << stats_reduce.sum_sink_arcs << " = " << compute_percent(stats_reduce.sum_sink_arcs, total_arcs) << percent << endl;
+      << stats_reduce.sum_sink_arcs << " = " << frac_to_percent(stats_reduce.sum_sink_arcs, total_arcs) << percent << endl;
 
 #ifdef ADIAR_STATS_EXTRA
-    size_t total_removed = stats_reduce.removed_by_rule_1 + stats_reduce.removed_by_rule_2;
+    uintwide_t total_removed = stats_reduce.removed_by_rule_1 + stats_reduce.removed_by_rule_2;
     o << indent << indent << "nodes removed           " << indent
-      << total_removed << " = " << compute_percent(total_removed, total_arcs) << percent << endl;
+      << total_removed << " = " << frac_to_percent(total_removed, total_arcs) << percent << endl;
 
     if (total_removed > 0) {
       o << indent << indent << indent << "rule 1:               " << indent
-        << stats_reduce.removed_by_rule_1 << " = " << compute_percent(stats_reduce.removed_by_rule_1, total_removed) << percent << endl;
+        << stats_reduce.removed_by_rule_1 << " = " << frac_to_percent(stats_reduce.removed_by_rule_1, total_removed) << percent << endl;
 
       o << indent << indent << indent << "rule 2:               " << indent
-        << stats_reduce.removed_by_rule_2 << " = " << compute_percent(stats_reduce.removed_by_rule_2, total_removed) << percent << endl;
+        << stats_reduce.removed_by_rule_2 << " = " << frac_to_percent(stats_reduce.removed_by_rule_2, total_removed) << percent << endl;
     }
     o << endl;
 #endif
 
     o << indent << bold_on << "Type of auxilliary data structures" << bold_off << endl;
-    size_t total_reduce = stats_reduce.lpq_internal + stats_reduce.lpq_external;
+    uintwide_t total_reduce = stats_reduce.lpq_internal + stats_reduce.lpq_external;
     o << indent << indent << "Reduce" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_reduce.lpq_internal << " = " << compute_percent(stats_reduce.lpq_internal, total_reduce) << percent << endl;
+      << stats_reduce.lpq_internal << " = " << frac_to_percent(stats_reduce.lpq_internal, total_reduce) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_reduce.lpq_external << " = " << compute_percent(stats_reduce.lpq_external, total_reduce) << percent << endl;
+      << stats_reduce.lpq_external << " = " << frac_to_percent(stats_reduce.lpq_external, total_reduce) << percent << endl;
 
-    size_t total_count = stats_count.lpq_internal + stats_count.lpq_external;
+    uintwide_t total_count = stats_count.lpq_internal + stats_count.lpq_external;
     o << indent << indent << "Count" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_count.lpq_internal << " = " << compute_percent(stats_count.lpq_internal, total_count) << percent << endl;
+      << stats_count.lpq_internal << " = " << frac_to_percent(stats_count.lpq_internal, total_count) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_count.lpq_external << " = " << compute_percent(stats_count.lpq_external, total_count) << percent << endl;
+      << stats_count.lpq_external << " = " << frac_to_percent(stats_count.lpq_external, total_count) << percent << endl;
 
-    size_t total_product = stats_product_construction.lpq_internal + stats_product_construction.lpq_external;
+    uintwide_t total_product = stats_product_construction.lpq_internal + stats_product_construction.lpq_external;
     o << indent << indent << "Product construction" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_product_construction.lpq_internal << " = " << compute_percent(stats_product_construction.lpq_internal, total_product) << percent << endl;
+      << stats_product_construction.lpq_internal << " = " << frac_to_percent(stats_product_construction.lpq_internal, total_product) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_product_construction.lpq_external << " = " << compute_percent(stats_product_construction.lpq_external, total_product) << percent << endl;
+      << stats_product_construction.lpq_external << " = " << frac_to_percent(stats_product_construction.lpq_external, total_product) << percent << endl;
 
-    size_t total_quantify = stats_quantify.lpq_internal + stats_quantify.lpq_external;
+    uintwide_t total_quantify = stats_quantify.lpq_internal + stats_quantify.lpq_external;
     o << indent << indent << "Quantification" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_quantify.lpq_internal << " = " << compute_percent(stats_quantify.lpq_internal, total_quantify) << percent << endl;
+      << stats_quantify.lpq_internal << " = " << frac_to_percent(stats_quantify.lpq_internal, total_quantify) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_quantify.lpq_external << " = " << compute_percent(stats_quantify.lpq_external, total_quantify) << percent << endl;
+      << stats_quantify.lpq_external << " = " << frac_to_percent(stats_quantify.lpq_external, total_quantify) << percent << endl;
 
-    size_t total_if_else = stats_if_else.lpq_internal + stats_if_else.lpq_external;
+    uintwide_t total_if_else = stats_if_else.lpq_internal + stats_if_else.lpq_external;
     o << indent << indent << "If-then-else" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_if_else.lpq_internal << " = " << compute_percent(stats_if_else.lpq_internal, total_if_else) << percent << endl;
+      << stats_if_else.lpq_internal << " = " << frac_to_percent(stats_if_else.lpq_internal, total_if_else) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_if_else.lpq_external << " = " << compute_percent(stats_if_else.lpq_external, total_if_else) << percent << endl;
+      << stats_if_else.lpq_external << " = " << frac_to_percent(stats_if_else.lpq_external, total_if_else) << percent << endl;
 
-    size_t total_substitute = stats_substitute.lpq_internal + stats_substitute.lpq_external;
+    uintwide_t total_substitute = stats_substitute.lpq_internal + stats_substitute.lpq_external;
     o << indent << indent << "Substitution" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_substitute.lpq_internal << " = " << compute_percent(stats_substitute.lpq_internal, total_substitute) << percent << endl;
+      << stats_substitute.lpq_internal << " = " << frac_to_percent(stats_substitute.lpq_internal, total_substitute) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_substitute.lpq_external << " = " << compute_percent(stats_substitute.lpq_external, total_substitute) << percent << endl;
+      << stats_substitute.lpq_external << " = " << frac_to_percent(stats_substitute.lpq_external, total_substitute) << percent << endl;
 
-    size_t total_compare = stats_equality.lpq_internal + stats_equality.lpq_external;
+    uintwide_t total_compare = stats_equality.lpq_internal + stats_equality.lpq_external;
     o << indent << indent << "Comparison" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_equality.lpq_internal << " = " << compute_percent(stats_equality.lpq_internal, total_compare) << percent << endl;
+      << stats_equality.lpq_internal << " = " << frac_to_percent(stats_equality.lpq_internal, total_compare) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_equality.lpq_external << " = " << compute_percent(stats_equality.lpq_external, total_compare) << percent << endl;
+      << stats_equality.lpq_external << " = " << frac_to_percent(stats_equality.lpq_external, total_compare) << percent << endl;
 
-    size_t total_intercut = stats_intercut.lpq_internal + stats_intercut.lpq_external;
+    uintwide_t total_intercut = stats_intercut.lpq_internal + stats_intercut.lpq_external;
     o << indent << indent << "Intercut" << endl;
     o << indent << indent << indent << "Internal" << indent
-      << stats_intercut.lpq_internal << " = " << compute_percent(stats_intercut.lpq_internal, total_intercut) << percent << endl;
+      << stats_intercut.lpq_internal << " = " << frac_to_percent(stats_intercut.lpq_internal, total_intercut) << percent << endl;
     o << indent << indent << indent << "External" << indent
-      << stats_intercut.lpq_external << " = " << compute_percent(stats_intercut.lpq_external, total_intercut) << percent << endl;
+      << stats_intercut.lpq_external << " = " << frac_to_percent(stats_intercut.lpq_external, total_intercut) << percent << endl;
 
     o << endl;
 #endif

--- a/src/adiar/statistics.h
+++ b/src/adiar/statistics.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <cstddef>
 
-#include <adiar/internal/safe_number.h>
+#include <adiar/internal/cnl.h>
 
 namespace adiar
 {

--- a/src/adiar/statistics.h
+++ b/src/adiar/statistics.h
@@ -4,13 +4,15 @@
 #include <iostream>
 #include <cstddef>
 
+#include <adiar/internal/safe_number.h>
+
 namespace adiar
 {
   // Internal/external memory (ADIAR_STATS)
   struct memory_t
   {
-    size_t lpq_internal = 0;
-    size_t lpq_external = 0;
+    uintwide_t lpq_internal = 0;
+    uintwide_t lpq_external = 0;
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -34,25 +36,25 @@ namespace adiar
     struct equality_t : public memory_t
     {
       // Early termination cases
-      size_t exit_on_same_file = 0;
-      size_t exit_on_nodecount = 0;
-      size_t exit_on_varcount = 0;
-      size_t exit_on_sinkcount = 0;
-      size_t exit_on_levels_mismatch = 0;
+      uintwide_t exit_on_same_file = 0;
+      uintwide_t exit_on_nodecount = 0;
+      uintwide_t exit_on_varcount = 0;
+      uintwide_t exit_on_sinkcount = 0;
+      uintwide_t exit_on_levels_mismatch = 0;
 
       // Statistics on non-trivial cases
       struct slow_t
       {
-        size_t runs = 0;
-        size_t exit_on_root = 0;
-        size_t exit_on_processed_on_level = 0;
-        size_t exit_on_children = 0;
+        uintwide_t runs = 0;
+        uintwide_t exit_on_root = 0;
+        uintwide_t exit_on_processed_on_level = 0;
+        uintwide_t exit_on_children = 0;
       } slow_check;
 
       struct fast_t
       {
-        size_t runs = 0;
-        size_t exit_on_mismatch = 0;
+        uintwide_t runs = 0;
+        uintwide_t exit_on_mismatch = 0;
       } fast_check;
     } equality;
 
@@ -67,8 +69,8 @@ namespace adiar
     // Levelized Priority Queue (ADIAR_STATS_EXTRA)
     struct priority_queue_t
     {
-      size_t push_bucket = 0;
-      size_t push_overflow = 0;
+      uintwide_t push_bucket = 0;
+      uintwide_t push_overflow = 0;
     } priority_queue;
 
     // Product construction
@@ -83,12 +85,12 @@ namespace adiar
     struct reduce_t : public memory_t
     {
       // (ADIAR_STATS)
-      size_t sum_node_arcs = 0;
-      size_t sum_sink_arcs = 0;
+      uintwide_t sum_node_arcs = 0;
+      uintwide_t sum_sink_arcs = 0;
 
       // (ADIAR_STATS_EXTRA)
-      size_t removed_by_rule_1 = 0;
-      size_t removed_by_rule_2 = 0;
+      uintwide_t removed_by_rule_1 = 0;
+      uintwide_t removed_by_rule_2 = 0;
     } reduce;
 
     // Substitution

--- a/src/adiar/statistics.h
+++ b/src/adiar/statistics.h
@@ -71,6 +71,9 @@ namespace adiar
     {
       uintwide_t push_bucket = 0;
       uintwide_t push_overflow = 0;
+
+      uintwide_t sum_predicted_max_size = 0;
+      uintwide_t sum_actual_max_size = 0;
     } priority_queue;
 
     // Product construction

--- a/src/adiar/zdd/pred.cpp
+++ b/src/adiar/zdd/pred.cpp
@@ -1,9 +1,9 @@
 #include <adiar/zdd.h>
 #include <adiar/zdd/zdd_policy.h>
 
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/pred.h>
 #include <adiar/internal/product_construction.h>
-#include <adiar/internal/safe_number.h>
 
 namespace adiar {
   bool zdd_equal(const zdd &s1, const zdd &s2)
@@ -21,7 +21,7 @@ namespace adiar {
       const safe_size_t max_2level_cut_1 = in_1->max_2level_cut[ct_1];
       const safe_size_t max_2level_cut_2 = in_2->max_2level_cut[ct_2];
 
-      return unpack(max_2level_cut_1 * max_2level_cut_2);
+      return to_size(max_2level_cut_1 * max_2level_cut_2);
     }
 
     static constexpr size_t memory_usage()

--- a/src/adiar/zdd/zdd.h
+++ b/src/adiar/zdd/zdd.h
@@ -4,8 +4,8 @@
 #include <adiar/data.h>
 #include <adiar/file.h>
 
+#include <adiar/internal/cnl.h>
 #include <adiar/internal/decision_diagram.h>
-#include <adiar/internal/safe_number.h>
 #include <adiar/internal/util.h>
 
 namespace adiar {
@@ -133,7 +133,7 @@ namespace adiar {
       //   with.
       const size_t add_suppressed = !includes_sink(ct, false) && cut_size == ilevel_cuts[ct_excl_false];
 
-      return unpack(cut_size + add_suppressed);
+      return to_size(cut_size + add_suppressed);
     }
   };
 }


### PR DESCRIPTION
- Switches from `size_t` to `cnl::wide_integer` to make sure statistics do not overflow.
- Adds statistics on precision of 2-level cuts predictions ( closes #328 ).