### PR TITLE
Remove (irrelevant) use of deprecated 'std::binary_function'

### DIFF
--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -34,7 +34,7 @@ namespace adiar
   };
 
 #ifndef NDEBUG
-  struct ite_triple_1_lt : public std::binary_function<ite_triple_1, ite_triple_1, bool>
+  struct ite_triple_1_lt
   {
     bool operator()(const ite_triple_1 &a, const ite_triple_1 &b)
     {
@@ -60,7 +60,7 @@ namespace adiar
   };
 
 #ifndef NDEBUG
-  struct ite_triple_2_lt : public std::binary_function<ite_triple_2, ite_triple_2, bool>
+  struct ite_triple_2_lt
   {
     bool operator()(const ite_triple_2 &a, const ite_triple_2 &b)
     {
@@ -82,7 +82,7 @@ namespace adiar
   };
 
 #ifndef NDEBUG
-  struct ite_triple_3_lt : public std::binary_function<ite_triple_3, ite_triple_3, bool>
+  struct ite_triple_3_lt
   {
     bool operator()(const ite_triple_3 &a, const ite_triple_3 &b)
     {

--- a/src/adiar/data.h
+++ b/src/adiar/data.h
@@ -708,7 +708,7 @@ namespace adiar {
   /// \brief Sorting predicate: First on unique identifier of the source, and
   ///        secondly on whether it is the high arc.
   //////////////////////////////////////////////////////////////////////////////
-  struct arc_source_lt : public std::binary_function<arc_t, arc_t, bool>
+  struct arc_source_lt
   {
     bool operator ()(const arc_t& a, const arc_t& b) const {
       return a.source < b.source;
@@ -718,7 +718,7 @@ namespace adiar {
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Sorting predicate on the target.
   //////////////////////////////////////////////////////////////////////////////
-  struct arc_target_lt : public std::binary_function<arc_t, arc_t, bool>
+  struct arc_target_lt
   {
     bool operator ()(const arc_t& a, const arc_t& b) const {
       return a.target < b.target

--- a/src/adiar/file_writer.h
+++ b/src/adiar/file_writer.h
@@ -19,7 +19,7 @@ namespace adiar {
   ///          check induces a total ordering.
   //////////////////////////////////////////////////////////////////////////////
   template<typename T>
-  struct no_ordering : public std::binary_function<T, T, bool>
+  struct no_ordering
   {
     bool operator()(const T&, const T&) const
     { return true; }

--- a/src/adiar/internal/product_construction.h
+++ b/src/adiar/internal/product_construction.h
@@ -32,7 +32,7 @@ namespace adiar
   };
 
 #ifndef NDEBUG
-  struct prod_tuple_1_lt : public std::binary_function<tuple, tuple, bool>
+  struct prod_tuple_1_lt
   {
     bool operator()(const prod_tuple_1 &a, const prod_tuple_1 &b)
     {
@@ -58,7 +58,7 @@ namespace adiar
   };
 
 #ifndef NDEBUG
-  struct prod_tuple_2_lt : public std::binary_function<tuple, tuple, bool>
+  struct prod_tuple_2_lt
   {
     bool operator()(const prod_tuple_2 &a, const prod_tuple_2 &b)
     {

--- a/src/adiar/internal/tuple.h
+++ b/src/adiar/internal/tuple.h
@@ -70,7 +70,7 @@ namespace adiar {
     }
   };
 
-  struct tuple_lt : public std::binary_function<tuple, tuple, bool>
+  struct tuple_lt
   {
     bool operator()(const tuple &a, const tuple &b)
     {
@@ -78,7 +78,7 @@ namespace adiar {
     }
   };
 
-  struct tuple_fst_lt : public std::binary_function<tuple, tuple, bool>
+  struct tuple_fst_lt
   {
     bool operator()(const tuple &a, const tuple &b)
     {
@@ -89,7 +89,7 @@ namespace adiar {
     }
   };
 
-  struct tuple_snd_lt : public std::binary_function<tuple, tuple, bool>
+  struct tuple_snd_lt
   {
     bool operator()(const tuple &a, const tuple &b)
     {
@@ -108,7 +108,7 @@ namespace adiar {
     }
   };
 
-  struct triple_lt : public std::binary_function<triple, triple, bool>
+  struct triple_lt
   {
     bool operator()(const triple &a, const triple &b)
     {
@@ -118,7 +118,7 @@ namespace adiar {
     }
   };
 
-  struct triple_fst_lt : public std::binary_function<triple, triple, bool>
+  struct triple_fst_lt
   {
     bool operator()(const triple &a, const triple &b)
     {
@@ -128,7 +128,7 @@ namespace adiar {
     }
   };
 
-  struct triple_snd_lt : public std::binary_function<triple, triple, bool>
+  struct triple_snd_lt
   {
     bool operator()(const triple &a, const triple &b)
     {
@@ -138,7 +138,7 @@ namespace adiar {
     }
   };
 
-  struct triple_trd_lt : public std::binary_function<triple, triple, bool>
+  struct triple_trd_lt
   {
     bool operator()(const triple &a, const triple &b)
     {


### PR DESCRIPTION
Closes #323 