### PR TITLE
Builder Cleanup

### DIFF
--- a/example/examples_common.cpp
+++ b/example/examples_common.cpp
@@ -19,7 +19,7 @@ inline double duration_of(timestamp_t &before, timestamp_t &after) {
 #include <adiar/adiar.h>
 
 // Command-line arguments
-uint64_t N = std::numeric_limits<uint64_t>::max();
+int N = -1;
 size_t M = 0;
 
 bool init_cl_arguments(int argc, char* argv[])
@@ -61,7 +61,7 @@ bool init_cl_arguments(int argc, char* argv[])
     }
   }
 
-  if (N == std::numeric_limits<uint64_t>::max()) {
+  if (N == -1) {
     std::cout << "  Must specify instance size (-N)" << std::endl;
     exit = true;
   }

--- a/example/knights_tour.cpp
+++ b/example/knights_tour.cpp
@@ -18,16 +18,16 @@ size_t largest_nodes = 1;
 /*******************************************************************************
  *                             Variable ordering
  *
- *                          (N^2 * t) + (N * i) + j.
+ *                          (N^2 * t) + (N * r) + c.
  *
  * That is, we encode the entire information about position and time-step into
- * the very variable label. This ordering is first by row, second by column, and
+ * the very variable label. This ordering is first by column, second by row, and
  * finally by time. Most importantly, this means that any "snapshot" of the
  * board at a specific time-step are grouped together.
  */
-inline adiar::label_t label_of_position(int N, int i, int j, int t)
+inline adiar::label_t int_of_position(int N, int r, int c, int t = 0)
 {
-  return (N * N * t) + (N * i) + j;
+  return (N * N * t) + (N * r) + c;
 }
 
 /*******************************************************************************
@@ -43,93 +43,80 @@ inline adiar::label_t label_of_position(int N, int i, int j, int t)
  */
 const int closed_squares [3][2] = {{0,0}, {1,2}, {2,1}};
 
-bool is_closed_square(int i, int j)
+bool is_closed_square(int r, int c)
 {
-  return (i == closed_squares[0][0] && j == closed_squares[0][1])
-      || (i == closed_squares[1][0] && j == closed_squares[1][1])
-      || (i == closed_squares[2][0] && j == closed_squares[2][1]);
-}
-
-/*******************************************************************************
- * Creates a long "don't care" chain for all the positions and times, that we do
- * not care about. If we are working with the closed tour, then we can safely
- * skip these to make the intermediate ZDDs smaller.
- */
-template<bool filter_closed_squares = false>
-void constraint_dont_care(adiar::node_writer &out_writer, adiar::ptr_t &curr_root,
-                          int N, int max_t, int min_t)
-{
-  for (int curr_t = max_t; curr_t >= min_t; curr_t--) {
-    for (int i = N - 1; i >= 0; i--) {
-      for (int j = N - 1; j >= 0; j--) {
-        if (filter_closed_squares && is_closed_square(i,j)) {
-          continue;
-        }
-
-        adiar::node_t out_node = adiar::create_node(label_of_position(N,i,j,curr_t),
-                                                    0,
-                                                    curr_root,
-                                                    curr_root);
-
-        out_writer << out_node;
-        curr_root = out_node.uid;
-      }
-    }
-  }
+  return (r == closed_squares[0][0] && c == closed_squares[0][1])
+      || (r == closed_squares[1][0] && c == closed_squares[1][1])
+      || (r == closed_squares[2][0] && c == closed_squares[2][1]);
 }
 
 /*******************************************************************************
  * Combining the above, we can construct the ZDD that fixes the initial
- * position, the second position, and the final position.
+ * position, the second position, and the final position while allowing any
+ * possibilities for anything in between.
+ *
+ *                              *          ---- position (0,0) at time 0
+ *                             / \
+ *                             F *         ---- position (1,2) at time 1
+ *                              / \
+ *                              F *
+ *                                ||
+ *                                         ---- positions at time 2 ... N*N-2
+ *                                ||
+ *                                *        ---- position (2,1) at time N*N-1
+ *                               / \
+ *                               F T
  */
-adiar::zdd constraint_closed(uint64_t N)
+adiar::zdd constraint_closed(int N)
 {
-  adiar::node_file out;
+  adiar::zdd_builder builder;
 
-  { adiar::node_writer out_writer(out);
+  // Fix t = max_time to be (1,2)
+  const int max_time = N*N-1;
 
-    // Set final time step to (2,1)
-    adiar::node_t n_t_end = adiar::create_node(label_of_position(N,
-                                                                 closed_squares[2][0],
-                                                                 closed_squares[2][1],
-                                                                 N*N-1),
-                                               adiar::MAX_ID,
-                                               adiar::create_sink_ptr(false),
-                                               adiar::create_sink_ptr(true));
-    out_writer << n_t_end;
+  const int stepMax_position = int_of_position(N,
+                                               closed_squares[2][0],
+                                               closed_squares[2][1],
+                                               max_time);
 
-    // Create don't care on all intermediate steps
-    adiar::ptr_t curr_root = n_t_end.uid;
-    constraint_dont_care<true>(out_writer, curr_root, N, N*N-2, 2);
+  typename adiar::zdd_ptr root = builder.add_node(stepMax_position, false, true);
 
-    // Set t = 1 to (1,2)
-    adiar::node_t n_t_1 = adiar::create_node(label_of_position(N,
-                                                               closed_squares[1][0],
-                                                               closed_squares[1][1],
-                                                               1),
-                                             adiar::MAX_ID,
-                                             adiar::create_sink_ptr(false),
-                                             curr_root);
-    out_writer << n_t_1;
+  // All in between is as-is but take the hamiltonian constraint into account.
+  for (int t = max_time - 1; t > 1; t--) {
+    for (int r = N-1; r >= 0; r--) {
+      for (int c = N-1; c >= 0; c--) {
+        if (is_closed_square(r,c)) { continue; }
 
-    // Set t = 0 to (0,0)
-    adiar::node_t n_t_0 = adiar::create_node(label_of_position(N,
-                                                               closed_squares[0][0],
-                                                               closed_squares[0][1],
-                                                               0),
-                                             adiar::MAX_ID,
-                                             adiar::create_sink_ptr(false),
-                                             n_t_1.uid);
-    out_writer << n_t_0;
+        root = builder.add_node(int_of_position(N,r,c,t), root, root);
+      }
+    }
   }
 
-  largest_nodes = std::max(largest_nodes, out.size());
+  // Fix t = 1 to be (2,1)
+  const int step1_position = int_of_position(N,
+                                             closed_squares[1][0],
+                                             closed_squares[1][1],
+                                             1);
+  root = builder.add_node(step1_position, false, root);
+
+  // Fix t = 0 to be (0,0)
+  const int step0_position = int_of_position(N,
+                                             closed_squares[0][0],
+                                             closed_squares[0][1],
+                                             0);
+  root = builder.add_node(step0_position, false, root);
+
+  // Finalize
+  adiar::zdd out = builder.build();
+
+  const size_t nodecount = zdd_nodecount(out);
+  largest_nodes = std::max(largest_nodes, nodecount);
+
   return out;
 }
 
-
 /*******************************************************************************
- *                      Move Logic for Transition Function
+ *                              Legal Moves
  *
  * We need a little bit of logic to compute the different parts of a move. This
  * is not the bottleneck, so we will do something somewhat easily comprehensible
@@ -141,120 +128,137 @@ adiar::zdd constraint_closed(uint64_t N)
 constexpr int row_moves[8]    = { -2, -2, -1, -1,  1,  1,  2,  2 };
 constexpr int column_moves[8] = { -1,  1, -2,  2, -2,  2, -1,  1 };
 
-bool is_move(int i_from, int j_from, int i_to, int j_to)
+bool is_legal_move(int /*N*/, int r_from, int c_from, int r_to, int c_to)
 {
   for (int idx = 0; idx < 8; idx++) {
-    if (i_from + row_moves[idx] == i_to &&
-        j_from + column_moves[idx] == j_to) {
+    if (r_from + row_moves[idx] == r_to &&
+        c_from + column_moves[idx] == c_to) {
       return true;
     }
   }
   return false;
 }
 
-adiar::ptr_t ptr_to_first(int N, int i_from, int j_from, int t)
+bool is_legal_position(int N, int r, int c, int t = 0)
 {
-  for (int idx = 0; idx < 8; idx++) {
-    int i_to = i_from + row_moves[idx];
-    int j_to = j_from + column_moves[idx];
+  if (r < 0 || N-1 < r)  { return false; }
+  if (c < 0 || N-1 < c)  { return false; }
+  if (t < 0 || N*N-1 < t) { return false; }
 
-    if (i_to < 0 || N <= i_to || j_to < 0 || N <= j_to) { continue; }
-    adiar::label_t from_label = label_of_position(N, i_from, j_from, t);
-    adiar::label_t to_label = label_of_position(N, i_to, j_to, t+1);
-
-    return adiar::create_node_ptr(to_label, from_label);
-  }
-  return adiar::create_sink_ptr(false);
+  return true;
 }
 
-/* When we have the latest 'legal' move we then also want to obtain the next
-   'legal' move, or 'false' if there is none.
- */
-adiar::ptr_t ptr_to_next(int N, int i_from, int j_from, int i_to, int j_to, int t)
+bool is_reachable(int /*N*/, int r, int c)
 {
-  bool seen_move = false;
-
   for (int idx = 0; idx < 8; idx++) {
-    int i = i_from + row_moves[idx];
-    int j = j_from + column_moves[idx];
-
-    if (i < 0 || N <= i || j < 0 || N <= j) { continue; }
-
-    if (seen_move) {
-      adiar::label_t from_label = label_of_position(N, i_from, j_from, t);
-      adiar::label_t to_label = label_of_position(N, i, j, t+1);
-
-      return adiar::create_node_ptr(to_label, from_label);
+    if (is_legal_position(N, r + row_moves[idx], c + column_moves[idx])) {
+      return true;
     }
-    seen_move = i == i_to && j == j_to;
   }
-  return adiar::create_sink_ptr(false);
+  return false;
 }
 
 /*******************************************************************************
- *                            Transition System
+ * With the above, we can encode what the legal transitions from one state of
+ * one time step to the next. To this end, we have a "don't care" chain for time
+ * steps prior and past the two time steps of interest. At time step t we may
+ * ask exactly where the Knight is placed to then check whether it is placed in
+ * any legal position at the next time step.
+ *
+ *                       *
+ *                       ||
+ *                                 ---- positions at time t-1 and earlier
+ *                       ||
+ *                       *         ---- pos (0,0) at time t
+ *                      / \
+ *                      *  \       ---- pos (1,0) at time t
+ *                     / \  \
+ *                    .  .  |
+ *                   .   .  |
+ *                  .    .  |
+ *                          *      ---- pos (1,2) at time t+1
+ *                         / \
+ *                        *   \    ---- pos (2,1) at time t+1
+ *                       / \  |
+ *                       F  \ /
+ *                           *
+ *                           ||
+ *                                 ---- positions at time t+2 and later
+ *                           ||
+ *                           T
  */
 adiar::zdd constraint_transition(int N, int t)
 {
-  adiar::node_file out;
+  adiar::zdd_builder builder;
 
-  { // When calling `out.size()` below, we have to make it read-only. So, we
-    // have to detach the node_writer before we do. This is automatically done
-    // on garbage collection, which is why we add an inner scope.
-    adiar::node_writer out_writer(out);
+  const int max_cell = N-1;
 
-    adiar::ptr_t curr_root = adiar::create_sink_ptr(true);
+  // Time steps t' > t+1:
+  adiar::zdd_ptr post_chain_root = builder.add_node(true);
 
-    // "Don't care" for future time steps
-    constraint_dont_care<>(out_writer, curr_root, N, N*N-1, t+2);
+  const int max_time = N*N-1;
 
-    // Node chains at time-step t+1 where exactly one possible square (i',j') is
-    // visited for every possible one (i,j) at time step t.
-    for (int i_t1 = N-1; i_t1 >= 0; i_t1--) {
-      for (int j_t1 = N-1; j_t1 >= 0; j_t1--) {
-        adiar::label_t next_pos = label_of_position(N, i_t1, j_t1, t+1);
+  for (int time = max_time; time > t+1; time--) {
+    for (int row = max_cell; row >= 0; row--) {
+      for (int col = max_cell; col >= 0; col--) {
+        if (!is_reachable(N, row, col)) { continue; }
 
-        // We encode the (i,j) inside of the node id to make linking easy.
-        for (int i_t = N-1; i_t >= 0; i_t--) {
-          for (int j_t = N-1; j_t >= 0; j_t--) {
+        const int this_label = int_of_position(N, row, col, time);
+        post_chain_root = builder.add_node(this_label, post_chain_root, post_chain_root);
+      }
+    }
+  }
 
-            // Is (i',j') reachable from (i,j)?
-            if (is_move(i_t, j_t, i_t1, j_t1)) {
-              adiar::label_t curr_pos = label_of_position(N, i_t, j_t, t);
-              adiar::ptr_t low = ptr_to_next(N, i_t, j_t, i_t1, j_t1, t);
+  // Time step t+1:
+  //   Chain with each possible position reachable from some position at time 't'.
+  std::vector<adiar::zdd_ptr> to_chains(N*N, builder.add_node(false));
 
-              adiar::node_t out_node = adiar::create_node(next_pos,
-                                                          curr_pos,
-                                                          low,
-                                                          curr_root);
-              out_writer << out_node;
-            }
-          }
+  for (int row = max_cell; row >= 0; row--) {
+    for (int col = max_cell; col >= 0; col--) {
+      const int this_label = int_of_position(N, row, col, t+1);
+
+      for (int row_t = max_cell; row_t >= 0; row_t--) {
+        for (int col_t = max_cell; col_t >= 0; col_t--) {
+          if (!is_reachable(N, row_t, col_t)) { continue; }
+          if (!is_legal_move(N, row_t, col_t, row, col)) { continue; }
+
+          const int vector_idx = int_of_position(N, row_t, col_t);
+
+          to_chains.at(vector_idx) = builder.add_node(this_label,
+                                                      to_chains.at(vector_idx),
+                                                      post_chain_root);
         }
       }
     }
-
-    // Node chain at time step t
-    curr_root = adiar::create_sink_ptr(false);
-
-    for (int i = N-1; i >= 0; i--) {
-      for (int j = N-1; j >= 0; j--) {
-        adiar::label_t out_label = label_of_position(N, i, j, t);
-
-        adiar::ptr_t high = ptr_to_first(N, i, j, t);
-
-        adiar::node_t out_node = adiar::create_node(out_label, 0, curr_root, high);
-
-        out_writer << out_node;
-        curr_root = out_node.uid;
-      }
-    }
-
-    // "Don't care" for previous time steps
-    constraint_dont_care<>(out_writer, curr_root, N, t-1, 0);
   }
 
-  largest_nodes = std::max(largest_nodes, out.size());
+  // Time step t:
+  //   For each position at time step 't', check whether we are "here" and go to
+  //   the chain checking "where we go to" at 't+1'.
+  typename adiar::zdd_ptr root = builder.add_node(false);
+
+  for (int row = max_cell; row >= 0; row--) {
+    for (int col = max_cell; col >= 0; col--) {
+      if (!is_reachable(N, row, col)) { continue; }
+
+      const int this_label = int_of_position(N, row, col, t);
+      const int to_chain_idx = int_of_position(N, row, col);
+      root = builder.add_node(this_label, root, to_chains.at(to_chain_idx));
+    }
+  }
+
+  // Time-step t' < t:
+  //   Just allow everything, i.e. add no constraints
+  for (int pos = int_of_position(N, max_cell, max_cell, t-1); pos >= 0; pos--) {
+    root = builder.add_node(pos, root, root);
+  }
+
+  // Finalize
+  adiar::zdd out = builder.build();
+
+  const size_t nodecount = zdd_nodecount(out);
+  largest_nodes = std::max(largest_nodes, nodecount);
+
   return out;
 }
 
@@ -269,41 +273,39 @@ adiar::zdd constraint_transition(int N, int t)
  * the position is 'seen' as taken then one goes to a second chain of nodes,
  * where it may not be seen again.
  */
-adiar::zdd constraint_exactly_once(uint64_t N, uint64_t i, uint64_t j)
+adiar::zdd constraint_exactly_once(int N, int r, int c)
 {
-  adiar::node_file out;
+  adiar::zdd_builder builder;
 
-  { adiar::node_writer out_writer(out);
+  adiar::zdd_ptr out_never = builder.add_node(false);
+  adiar::zdd_ptr out_once = builder.add_node(true);
 
-    adiar::ptr_t next0 = adiar::create_sink_ptr(false);
-    adiar::ptr_t next1 = adiar::create_sink_ptr(true);
+  const int max_time = N*N-1;
+  const int max_cell = N-1;
 
-    for (int curr_t = N*N-1; curr_t >= 0; curr_t--) {
-      for (int curr_i = N-1; curr_i >= 0; curr_i--) {
-        for (int curr_j = N-1; curr_j >= 0; curr_j--) {
-          adiar::label_t out_label = label_of_position(N, curr_i, curr_j, curr_t);
+  for (int this_t = max_time; this_t >= 0; this_t--) {
+    for (int this_r = max_cell; this_r >= 0; this_r--) {
+      for (int this_c = max_cell; this_c >= 0; this_c--) {
+        const int this_label = int_of_position(N, this_r, this_c, this_t);
+        const bool is_rc = r == this_r && c == this_c;
 
-          bool is_ij = i == curr_i && j == curr_j;
-
-          // If we are talking about (i,j) and we already have counted it once, then
-          // it is forced to zero. In ZDDs this is represented by skipping it.
-          if (!is_ij && (curr_t > 0 || curr_i > i)) {
-            adiar::node_t out_n1 = adiar::create_node(out_label, 1, next1, next1);
-            out_writer << out_n1;
-            next1 = out_n1.uid;
-          }
-
-          adiar::node_t out_n0 = adiar::create_node(out_label, 0,
-                                                    next0,
-                                                    is_ij ? next1 : next0);
-          out_writer << out_n0;
-          next0 = out_n0.uid;
+        if (!is_rc && (this_t > 0 || this_r > r)) {
+          out_once = builder.add_node(this_label, out_once, out_once);
         }
+
+        out_never = builder.add_node(this_label,
+                                     out_never,
+                                     is_rc ? out_once : out_never);
       }
     }
   }
 
-  largest_nodes = std::max(largest_nodes, out.size());
+  // Finalize
+  adiar::zdd out = builder.build();
+
+  const size_t nodecount = zdd_nodecount(out);
+  largest_nodes = std::max(largest_nodes, nodecount);
+
   return out;
 }
 
@@ -347,7 +349,7 @@ int main(int argc, char* argv[])
       switch(c) {
       case 'c':
         // HACK: 'constraint_closed' only works for 3x3 boards and bigger.
-        only_closed = 3u <= N;
+        only_closed = 3 <= N;
         continue;
 
       case 'h':

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -38,7 +38,7 @@ namespace adiar {
     ///////////////////////////////////////////////////////////////////////////////
     /// \brief Unique shared reference for the parent builder object.
     ///////////////////////////////////////////////////////////////////////////////
-    /*const*/ std::shared_ptr<builder_shared> builder_ref;
+    /*const*/ std::shared_ptr<const builder_shared> builder_ref;
 
     ///////////////////////////////////////////////////////////////////////////////
     /// \brief Reference for this specific 'uid' recording whether it is a child
@@ -51,7 +51,8 @@ namespace adiar {
     builder_ptr(const builder_ptr&) = default;
 
   private:
-    builder_ptr(uid_t &p, std::shared_ptr<builder_shared> &sp) : uid(p), builder_ref(sp)
+    builder_ptr(const uid_t p, const std::shared_ptr<const builder_shared> &sp)
+      : uid(p), builder_ref(sp)
     { }
   };
 

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -149,10 +149,16 @@ namespace adiar {
       }
 
       // Create potential node
-      node_t node = create_node(label, current_id, low.uid, high.uid);
+      const node_t node = create_node(label, current_id, low.uid, high.uid);
 
       // Check whether this node is 'redundant'
-      uid_t res_uid = dd_policy::reduction_rule(node);
+      const uid_t res_uid = dd_policy::reduction_rule(node);
+
+      if (is_terminal(res_uid)) {
+        created_terminal = true;
+        terminal_val = value_of(res_uid);
+      }
+
       if(res_uid == low.uid) { return low; }
       if(res_uid == high.uid) { return high; }
 

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -253,7 +253,7 @@ namespace adiar {
     /// \throws std::domain_error If (a) add_node has not been called or (b) if
     ///                           there are more than one root in the diagram.
     /////////////////////////////////////////////////////////////////////////////
-    typename dd_policy::reduced_t create()
+    typename dd_policy::reduced_t build()
     {
       if(!nw.has_pushed()) {
         if(created_terminal) {
@@ -277,13 +277,16 @@ namespace adiar {
     /// \brief Clear builder of all its current content, discarding all nodes
     ///        and invalidating any pointers to them.
     /////////////////////////////////////////////////////////////////////////////
-    void abort()
+    void clear() noexcept
     {
       reset();
     }
 
   private:
-    void reset()
+    /////////////////////////////////////////////////////////////////////////////
+    /// \brief Reset all internal values to their initial.
+    /////////////////////////////////////////////////////////////////////////////
+    void reset() noexcept
     {
       nw.detach();
       nf = node_file();
@@ -297,8 +300,11 @@ namespace adiar {
       unref_nodes = 0;
     }
 
-  private:
-    builder_ptr<dd_policy> make_ptr(ptr_t p) {
+    /////////////////////////////////////////////////////////////////////////////
+    /// \brief Create a builder_ptr with 'this' builder as its parent.
+    /////////////////////////////////////////////////////////////////////////////
+    builder_ptr<dd_policy> make_ptr(const ptr_t p) noexcept
+    {
       return builder_ptr<dd_policy>(p, builder_ref);
     }
   };

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -149,7 +149,7 @@ namespace adiar {
       }
 
       // Create potential node
-      node_t node = create_node(label, current_id--, low.uid, high.uid);
+      node_t node = create_node(label, current_id, low.uid, high.uid);
 
       // Check whether this node is 'redundant'
       uid_t res_uid = dd_policy::reduction_rule(node);
@@ -159,6 +159,7 @@ namespace adiar {
       // Push node to file
       nw.push(node);
       unref_nodes++;
+      current_id--;
 
       // Update count of unreferenced nodes
       bool& low_unref = *low.unreferenced;

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -220,16 +220,27 @@ namespace adiar {
           throw std::domain_error("There must be at least one node or terminal in the decision diagram");
         }
       }
+      nw.detach();
+
       if(unref_nodes > 1) {
         throw std::domain_error("Decision diagram has more than one root");
       }
-      nw.detach();
-      return nf;
+
+      const typename dd_policy::reduced_t res(nf);
+      reset();
+      return res;
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    /// \brief Reset to create a new decision diagram.
+    /// \brief Discards all current content and sets up for creating a new
+    ///        decision diagram.
     /////////////////////////////////////////////////////////////////////////////
+    void abort()
+    {
+      reset();
+    }
+
+  private:
     void reset()
     {
       nw.detach();

--- a/test/adiar/test_builder.cpp
+++ b/test/adiar/test_builder.cpp
@@ -632,6 +632,108 @@ go_bandit([]() {
         AssertThat(out->number_of_terminals[1], Is().EqualTo(1u));
       });
 
+      it("can collapse BDD reduction rule to a false terminal", [&]() {
+        bdd_builder b;
+
+        const bdd_ptr p2 = b.add_node(2,false,false);
+        const bdd_ptr p1 = b.add_node(1,false,p2);
+
+        bdd out = b.create();
+
+        // Check it looks all right
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_terminal(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().False());
+
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->number_of_terminals[0], Is().EqualTo(1u));
+        AssertThat(out->number_of_terminals[1], Is().EqualTo(0u));
+      });
+
+      it("can collapse BDD reduction rule to a true terminal [1]", [&]() {
+        bdd_builder b;
+
+        const bdd_ptr p2 = b.add_node(2,true,true);
+        const bdd_ptr p1 = b.add_node(1,p2,p2);
+
+        bdd out = b.create();
+
+        // Check it looks all right
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_terminal(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().False());
+
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->number_of_terminals[0], Is().EqualTo(0u));
+        AssertThat(out->number_of_terminals[1], Is().EqualTo(1u));
+      });
+
+      it("can collapse BDD reduction rule to a true terminal [2]", [&]() {
+        bdd_builder b;
+
+        const bdd_ptr p2 = b.add_node(2,true,true);
+        const bdd_ptr p1 = b.add_node(1,p2,true);
+
+        bdd out = b.create();
+
+        // Check it looks all right
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_terminal(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().False());
+
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->number_of_terminals[0], Is().EqualTo(0u));
+        AssertThat(out->number_of_terminals[1], Is().EqualTo(1u));
+      });
+
       it("does not decrement 'id' when applying the BDD reduction rule", [&]() {
         bdd_builder b;
 
@@ -805,6 +907,74 @@ go_bandit([]() {
         AssertThat(out->max_2level_cut[cut_type::ALL], Is().LessThanOrEqualTo(3u));
 
         AssertThat(out->number_of_terminals[0], Is().EqualTo(1u));
+        AssertThat(out->number_of_terminals[1], Is().EqualTo(1u));
+      });
+
+      it("can collapse ZDD reduction rule to a false terminal", [&]() {
+        zdd_builder b;
+
+        const zdd_ptr p2 = b.add_node(2,false,false);
+        const zdd_ptr p1 = b.add_node(1,p2,false);
+
+        zdd out = b.create();
+
+        // Check it looks all right
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_terminal(false)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().False());
+
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->number_of_terminals[0], Is().EqualTo(1u));
+        AssertThat(out->number_of_terminals[1], Is().EqualTo(0u));
+      });
+
+      it("can collapse ZDD reduction rule to a true terminal", [&]() {
+        zdd_builder b;
+
+        const zdd_ptr p2 = b.add_node(2,true,false);
+        const zdd_ptr p1 = b.add_node(1,p2,false);
+
+        zdd out = b.create();
+
+        // Check it looks all right
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+
+        AssertThat(out_nodes.pull(), Is().EqualTo(create_terminal(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream<node_t> out_meta(out);
+
+        AssertThat(out_meta.can_pull(), Is().False());
+
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(out->number_of_terminals[0], Is().EqualTo(0u));
         AssertThat(out->number_of_terminals[1], Is().EqualTo(1u));
       });
 

--- a/test/adiar/test_builder.cpp
+++ b/test/adiar/test_builder.cpp
@@ -12,7 +12,7 @@ go_bandit([]() {
 
          const bdd_ptr p3 = b.add_node(0,p2,true);
 
-         bdd out = b.create();
+         bdd out = b.build();
          node_test_stream out_nodes(out);
 
          AssertThat(out_nodes.can_pull(), Is().True());
@@ -35,7 +35,7 @@ go_bandit([]() {
 
         b.add_node(0,b.add_node(1,false,true),true);
 
-        bdd out = b.create();
+        bdd out = b.build();
         node_test_stream out_nodes(out);
 
         AssertThat(out_nodes.can_pull(), Is().True());
@@ -59,7 +59,7 @@ go_bandit([]() {
 
       b.add_node(false);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -92,7 +92,7 @@ go_bandit([]() {
 
       b.add_node(true);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -127,7 +127,7 @@ go_bandit([]() {
 
       b.add_node(false);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -158,16 +158,16 @@ go_bandit([]() {
     it("throws an exception when create is called on an empty file", [&]() {
       bdd_builder b;
 
-      AssertThrows(std::domain_error, b.create());
+      AssertThrows(std::domain_error, b.build());
     });
 
     it("throws an exception when calling create a second time with no new nodes in between", [&]() {
       bdd_builder b;
 
       b.add_node(0,false,true);
-      b.create();
+      b.build();
 
-      AssertThrows(std::domain_error, b.create());
+      AssertThrows(std::domain_error, b.build());
     });
 
     it("can create a single-node BDD", [&]() {
@@ -175,7 +175,7 @@ go_bandit([]() {
 
       b.add_node(0,false,true);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -234,7 +234,7 @@ go_bandit([]() {
       bdd_builder b;
 
       builder_ptr p = b.add_node(1,true,false);
-      b.reset();
+      b.clear();
 
       AssertThrows(std::invalid_argument, b.add_node(0,p,false));
     });
@@ -243,7 +243,7 @@ go_bandit([]() {
       bdd_builder b;
 
       builder_ptr p = b.add_node(1,true,false);
-      b.create();
+      b.build();
 
       AssertThrows(std::invalid_argument, b.add_node(0,p,false));
     });
@@ -311,7 +311,7 @@ go_bandit([]() {
       const bdd_ptr p2 = b.add_node(1,p3,true);
       const bdd_ptr p1 = b.add_node(0,p3,p2);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -386,7 +386,7 @@ go_bandit([]() {
       const bdd_ptr p2 = b.add_node(1,p4,p5);
       const bdd_ptr p1 = b.add_node(0,p2,p3);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -456,11 +456,11 @@ go_bandit([]() {
 
       b.add_node(0,false,true);
 
-      b.reset();
+      b.clear();
 
       b.add_node(1,true,false);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -502,9 +502,9 @@ go_bandit([]() {
 
       b.add_node(0,false,true);
 
-      b.reset();
+      b.clear();
 
-      AssertThrows(std::domain_error, b.create());
+      AssertThrows(std::domain_error, b.build());
     });
 
     it("can create two different BDDs", [&]() {
@@ -512,7 +512,7 @@ go_bandit([]() {
 
       { // FIRST
         b.add_node(0,false,true);
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -552,7 +552,7 @@ go_bandit([]() {
       { // SECOND
         b.add_node(1,true,false);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -596,7 +596,7 @@ go_bandit([]() {
       b.add_node(0,false,true);
       b.add_node(0,true,false);
 
-      AssertThrows(std::domain_error, b.create());
+      AssertThrows(std::domain_error, b.build());
     });
 
     it("throws an exception when there is more than one root [2]", [&]() {
@@ -605,7 +605,7 @@ go_bandit([]() {
       b.add_node(4,false,true);
       b.add_node(2,true,false);
 
-      AssertThrows(std::domain_error, b.create());
+      AssertThrows(std::domain_error, b.build());
     });
 
     it("throws an exception when there is more than one root [3]", [&]() {
@@ -617,7 +617,7 @@ go_bandit([]() {
       const bdd_ptr p2 = b.add_node(2,p3,p4);
       const bdd_ptr p1 = b.add_node(1,p3,p5);
 
-      AssertThrows(std::domain_error, b.create());
+      AssertThrows(std::domain_error, b.build());
     });
 
     it("recognizes copies of nodes", [&]() {
@@ -639,7 +639,7 @@ go_bandit([]() {
       const bdd_ptr p2 = p3;
       const bdd_ptr p1 = b.add_node(2,p2,p4);
 
-      bdd out = b.create();
+      bdd out = b.build();
 
       // Check it looks all right
       node_test_stream out_nodes(out);
@@ -705,7 +705,7 @@ go_bandit([]() {
 
         b.add_node(0,p,p);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -748,7 +748,7 @@ go_bandit([]() {
         const bdd_ptr p2 = b.add_node(2,false,false);
         const bdd_ptr p1 = b.add_node(1,false,p2);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -782,7 +782,7 @@ go_bandit([]() {
         const bdd_ptr p2 = b.add_node(2,true,true);
         const bdd_ptr p1 = b.add_node(1,p2,p2);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -816,7 +816,7 @@ go_bandit([]() {
         const bdd_ptr p2 = b.add_node(2,true,true);
         const bdd_ptr p1 = b.add_node(1,p2,true);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -861,7 +861,7 @@ go_bandit([]() {
         const bdd_ptr p2 = b.add_node(1, false, p4);
         const bdd_ptr p1 = b.add_node(0, p3, p2);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -925,7 +925,7 @@ go_bandit([]() {
 
         b.add_node(0,p1,p2);
 
-        bdd out = b.create();
+        bdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -971,7 +971,7 @@ go_bandit([]() {
         const bdd_ptr p1 = b.add_node(1,p3,p4); // root
         const bdd_ptr p0 = b.add_node(0,p2,p2); // root
 
-        AssertThrows(std::domain_error, b.create());
+        AssertThrows(std::domain_error, b.build());
       });
     });
 
@@ -983,7 +983,7 @@ go_bandit([]() {
 
         b.add_node(0,p,false);
 
-        zdd out = b.create();
+        zdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -1026,7 +1026,7 @@ go_bandit([]() {
         const zdd_ptr p2 = b.add_node(2,false,false);
         const zdd_ptr p1 = b.add_node(1,p2,false);
 
-        zdd out = b.create();
+        zdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -1060,7 +1060,7 @@ go_bandit([]() {
         const zdd_ptr p2 = b.add_node(2,true,false);
         const zdd_ptr p1 = b.add_node(1,p2,false);
 
-        zdd out = b.create();
+        zdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -1105,7 +1105,7 @@ go_bandit([]() {
         const zdd_ptr p2 = b.add_node(1, p4, p4);
         const zdd_ptr p1 = b.add_node(0, p3, p2);
 
-        zdd out = b.create();
+        zdd out = b.build();
 
         // Check it looks all right
         node_test_stream out_nodes(out);
@@ -1170,7 +1170,7 @@ go_bandit([]() {
         const zdd_ptr p1 = b.add_node(1,p3,p4);    // root
         const zdd_ptr p0 = b.add_node(0,p2,false); // root
 
-        AssertThrows(std::domain_error, b.create());
+        AssertThrows(std::domain_error, b.build());
       });
     });
   });


### PR DESCRIPTION
Several small bugs / undesired behaviour fixed
- `id` is decremented even if no new node is created
- Crashes on reduction rule 1 collapses everything to a terminal
- Rename `.create()` to `.build()` and `.reset()` to `clear()` to be closer to regular naming schemes.

Furthermore drastically improves documentation
- Doxygen documentation for builder
- Use builders in examples (implementation and documentation) rather than `node_writer`