### PR TITLE
Add global domain to 'bdd_satcount'

### DIFF
--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -461,10 +461,12 @@ namespace adiar
   /// \brief   Count the number of assignments x that make f(x) true.
   ///
   /// \details Same as <tt>bdd_satcount(bdd, varcount)</tt>, with varcount set
-  ///          to be <tt>varcount(bdd)</tt>.
+  ///          to be the size of the global domain or the number of variables
+  ///          within the given BDD.
+  ///
+  /// \sa adiar_set_domain bdd_varcount
   //////////////////////////////////////////////////////////////////////////////
-  inline uint64_t bdd_satcount(const bdd &f)
-  { return bdd_satcount(f, bdd_varcount(f)); };
+  uint64_t bdd_satcount(const bdd &f);
 
   /// \}
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd/count.cpp
+++ b/src/adiar/bdd/count.cpp
@@ -1,4 +1,5 @@
 #include <adiar/bdd.h>
+#include <adiar/domain.h>
 
 #include <adiar/data.h>
 
@@ -100,4 +101,11 @@ namespace adiar
 
     return count<sat_count_policy>(bdd, varcount);
   }
+
+  uint64_t bdd_satcount(const bdd &f)
+  {
+    const label_t domain_size = adiar_has_domain() ? adiar_get_domain().size() : 0;
+    const label_t varcount = bdd_varcount(f);
+    return bdd_satcount(f, std::max(domain_size, varcount));
+  };
 }

--- a/test/adiar/bdd/test_count.cpp
+++ b/test/adiar/bdd/test_count.cpp
@@ -123,6 +123,10 @@ go_bandit([]() {
       nw_root_1 << create_node(1,0, terminal_F, terminal_T);
     }
 
+    // Set domain to be empty
+    label_file empty_dom;
+    adiar_set_domain(empty_dom);
+
     describe("bdd_nodecount", [&]() {
       it("can count number of nodes", [&]() {
         AssertThat(bdd_nodecount(bdd_1), Is().EqualTo(4u));
@@ -237,7 +241,7 @@ go_bandit([]() {
       });
     });
 
-    describe("bdd_satcount(f)", [&]() {
+    describe("bdd_satcount(f) [empty dom]", [&]() {
       it("can count assignments leading to T terminals [1]", [&]() {
         AssertThat(bdd_satcount(bdd_1), Is().EqualTo(5u));
       });
@@ -266,6 +270,45 @@ go_bandit([]() {
       it("should count assignments of a root-only BDD [1]", [&]() {
         AssertThat(bdd_satcount(bdd_not(bdd_root_1)), Is().EqualTo(1u));
         AssertThat(bdd_satcount(bdd_root_1), Is().EqualTo(1u));
+      });
+    });
+
+    describe("bdd_satcount(f) [non-empty dom]", [&]() {
+      label_file dom;
+      {
+        label_writer lw(dom);
+        lw << 0 << 1 << 2 << 3 << 4 << 5 << 6;
+      }
+      adiar_set_domain(dom);
+
+      it("can count assignments leading to T terminals [1]", [&]() {
+        AssertThat(bdd_satcount(bdd_1), Is().EqualTo(8u * 5u));
+      });
+
+      it("can count assignments leading to T terminals [2]", [&]() {
+        AssertThat(bdd_satcount(bdd_2), Is().EqualTo(32u * 3u));
+      });
+
+      it("can count assignments leading to F terminals [1]", [&]() {
+        AssertThat(bdd_satcount(bdd_not(bdd_1)), Is().EqualTo(8u * 11u));
+      });
+
+      it("can count assignments leading to F terminals [2]", [&]() {
+        AssertThat(bdd_satcount(bdd_not(bdd_2)), Is().EqualTo(32u * 1u));
+      });
+
+      it("should count assignments to the true terminal-only BDD", [&]() {
+        AssertThat(bdd_satcount(bdd_T), Is().EqualTo(128u * 1u));
+        AssertThat(bdd_satcount(bdd_not(bdd_F)), Is().EqualTo(128u * 1u));
+      });
+
+      it("should count no assignments in a false terminal-only BDD", [&]() {
+        AssertThat(bdd_satcount(bdd_F), Is().EqualTo(0u));
+      });
+
+      it("should count assignments of a root-only BDD [1]", [&]() {
+        AssertThat(bdd_satcount(bdd_not(bdd_root_1)), Is().EqualTo(64u * 1u));
+        AssertThat(bdd_satcount(bdd_root_1), Is().EqualTo(64u * 1u));
       });
     });
   });


### PR DESCRIPTION
Closes #379 by non-intrusively increasing the default value of `varcount` in `bdd_satcount` if the global domain is set.