### PR TITLE
Internal/Nested-Sweeping (Preparation)

### DIFF
--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ test:
       --reporter=info --colorizer=light
 
 #	@./build/test/$(TEST_NAME) --reporter=info --colorizer=light
-	$(MAKE) clean/file
+	$(MAKE) clean/files
 
 test/all:
 	make $(MAKE_FLAGS) test

--- a/src/adiar/bdd/bdd_policy.h
+++ b/src/adiar/bdd/bdd_policy.h
@@ -21,7 +21,7 @@ namespace adiar
     // If adding attributed edges, i.e. complement edges:
     //    remove the 'unflag' below. Currently, it removes any forwarding of
     //    applying Reduction Rule.
-    if (unflag(n.low()) == unflag(n.high())) { return n.low(); }
+    if (essential(n.low()) == essential(n.high())) { return n.low(); }
     return n.uid();
   }
 

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -236,8 +236,8 @@ namespace adiar
 
     {
       const internal::node::uid_t out_uid(out_label, out_id++);
-      __ite_resolve_request(ite_pq_1, aw, out_uid, low_if, low_then, low_else);
-      __ite_resolve_request(ite_pq_1, aw, flag(out_uid), high_if, high_then, high_else);
+      __ite_resolve_request(ite_pq_1, aw, out_uid.with(false), low_if, low_then, low_else);
+      __ite_resolve_request(ite_pq_1, aw, out_uid.with(true),  high_if, high_then, high_else);
     }
 
     size_t max_1level_cut = 0;
@@ -418,8 +418,8 @@ namespace adiar
       adiar_debug(out_id < bdd::MAX_ID, "Has run out of ids");
       const internal::node::uid_t out_uid(out_label, out_id++);
 
-      __ite_resolve_request(ite_pq_1, aw, out_uid, low_if, low_then, low_else);
-      __ite_resolve_request(ite_pq_1, aw, flag(out_uid), high_if, high_then, high_else);
+      __ite_resolve_request(ite_pq_1, aw, out_uid.with(false), low_if, low_then, low_else);
+      __ite_resolve_request(ite_pq_1, aw, out_uid.with(true),  high_if, high_then, high_else);
 
       // Output ingoing arcs
       internal::node::ptr_t source = req.data.source;

--- a/src/adiar/bool_op.h
+++ b/src/adiar/bool_op.h
@@ -25,7 +25,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   const bool_op and_op = [](const internal::ptr_uint64 &terminal1, const internal::ptr_uint64 &terminal2) -> internal::uid_uint64
   {
-    return unflag(terminal1 & terminal2);
+    return essential(terminal1 & terminal2);
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -41,7 +41,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   const bool_op or_op = [](const internal::ptr_uint64 &terminal1, const internal::ptr_uint64 &terminal2) -> internal::uid_uint64
   {
-    return unflag(terminal1 | terminal2);
+    return essential(terminal1 | terminal2);
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   const bool_op xor_op = [](const internal::ptr_uint64 &terminal1, const internal::ptr_uint64 &terminal2) -> internal::uid_uint64
   {
-    return unflag(terminal1 ^ terminal2);
+    return essential(terminal1 ^ terminal2);
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   const bool_op imp_op = [](const internal::ptr_uint64 &terminal1, const internal::ptr_uint64 &terminal2) -> internal::uid_uint64
   {
-    return internal::ptr_uint64(unflag(terminal1) <= unflag(terminal2));
+    return internal::ptr_uint64(essential(terminal1) <= essential(terminal2));
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -81,7 +81,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   const bool_op invimp_op = [](const internal::ptr_uint64 &terminal1, const internal::ptr_uint64 &terminal2) -> internal::ptr_uint64
   {
-    return internal::ptr_uint64(unflag(terminal2) <= unflag(terminal1));
+    return internal::ptr_uint64(essential(terminal2) <= essential(terminal1));
   };
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/deprecated.h
+++ b/src/adiar/deprecated.h
@@ -299,7 +299,7 @@ namespace adiar
 
   [[deprecated("Replaced by member function in 'adiar/internal/data_types/arc.h'")]]
   inline internal::node is_high(const internal::arc &a)
-  { return a.is_high(); }
+  { return a.source().out_idx(); }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \copydoc adiar::internal::arc::operator~

--- a/src/adiar/internal/algorithms/intercut.h
+++ b/src/adiar/internal/algorithms/intercut.h
@@ -239,10 +239,10 @@ namespace adiar::internal
           const node::uid_t out_uid(out_label, out_id++);
 
           intercut_out__pq<intercut_policy>::forward
-            (aw, intercut_pq, out_uid, ro.low, out_label, l);
+            (aw, intercut_pq, out_uid.with(false), ro.low, out_label, l);
 
           intercut_out__pq<intercut_policy>::forward
-            (aw, intercut_pq, flag(out_uid), ro.high, out_label, l);
+            (aw, intercut_pq, out_uid.with(true),  ro.high, out_label, l);
 
           intercut_in__pq<intercut_policy, intercut_out__writer>
             (aw, intercut_pq, out_label, n.uid(), out_uid, l);
@@ -259,10 +259,10 @@ namespace adiar::internal
         const node::uid_t out_uid(out_label, out_id++);
 
         intercut_out__pq<intercut_policy>::forward
-          (aw, intercut_pq, out_uid, ro.low, out_label, l);
+          (aw, intercut_pq, out_uid.with(false), ro.low, out_label, l);
 
         intercut_out__pq<intercut_policy>::forward
-          (aw, intercut_pq, flag(out_uid), ro.high, out_label, l);
+          (aw, intercut_pq, out_uid.with(true),  ro.high, out_label, l);
 
         intercut_in__pq<intercut_policy, intercut_out__writer>
           (aw, intercut_pq, out_label, request.target(), out_uid, l);

--- a/src/adiar/internal/algorithms/prod2.h
+++ b/src/adiar/internal/algorithms/prod2.h
@@ -343,8 +343,8 @@ namespace adiar::internal
         adiar_debug(out_id < prod_policy::MAX_ID, "Has run out of ids");
         const node::uid_t out_uid(out_label, out_id++);
 
-        __prod2_recurse_out(prod_pq_1, aw, op, out_uid, r.low);
-        __prod2_recurse_out(prod_pq_1, aw, op, flag(out_uid), r.high);
+        __prod2_recurse_out(prod_pq_1, aw, op, out_uid.with(false), r.low);
+        __prod2_recurse_out(prod_pq_1, aw, op, out_uid.with(true),  r.high);
 
         __prod2_recurse_in<__prod2_recurse_in__output_node>(prod_pq_1, prod_pq_2, aw, out_uid, req.target);
 

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -74,8 +74,7 @@ namespace adiar::internal
       quantify_request<0>::target_t rec = quantify_policy::resolve_request(op, {target.fst(), target.snd()});
 
       if (rec[0].is_terminal() /* sorted ==> rec[1].is_terminal() */) {
-        arc out_arc = { source, op(rec[0], rec[1]) };
-        aw.push_terminal(out_arc);
+        aw.push_terminal({ source, op(rec[0], rec[1]) });
       } else {
         quantify_pq_1.push({ rec, {}, {source} });
       }
@@ -238,11 +237,11 @@ namespace adiar::internal
         const node::uid_t out_uid(out_label, out_id++);
 
         __quantify_resolve_request<quantify_policy>(quantify_pq_1, aw, op,
-                                                    out_uid,
+                                                    out_uid.with(false),
                                                     { children0[false], children1[false] });
 
         __quantify_resolve_request<quantify_policy>(quantify_pq_1, aw, op,
-                                                    flag(out_uid),
+                                                    out_uid.with(true),
                                                     { children0[true], children1[true] });
 
         if (!req.data.source.is_nil()) {

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -260,14 +260,15 @@ namespace adiar::internal
             || reduce_pq.can_pull()) {
       // TODO (MDD):
       // TODO (QMDD):
-      //   Use __reduce_get_next node_t::OUTDEGREE times to create a node_t::children_t.
+      //   Use __reduce_get_next node_t::OUTDEGREE times to create a
+      //   node_t::children_t.
       const arc e_high = __reduce_get_next(reduce_pq, arcs);
-      const arc e_low = __reduce_get_next(reduce_pq, arcs);
+      const arc e_low  = __reduce_get_next(reduce_pq, arcs);
 
-      node n = node_of(e_low, e_high);
+      const node n = node_of(e_low, e_high);
 
       // Apply Reduction rule 1
-      node::ptr_t reduction_rule_ret = dd_policy::reduction_rule(n);
+      const node::ptr_t reduction_rule_ret = dd_policy::reduction_rule(n);
       if (reduction_rule_ret != n.uid()) {
         // Open red1_mapping first (and create file on disk) when at least one
         // element is written to it.
@@ -363,6 +364,7 @@ namespace adiar::internal
           ? flag(current_map.new_uid)
           : static_cast<ptr_uint64>(current_map.new_uid);
 
+        adiar_debug(t.is_terminal() || t.out_idx() == false, "Created target is without an index");
         reduce_pq.push({ s,t });
       }
 

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -344,9 +344,10 @@ namespace adiar::internal
     // Pass all the mappings to Q
     while (has_next_red1 || has_next_red2) {
       // Find the mapping with largest old_uid
-      bool is_red1_current = !has_next_red2 ||
-                              (has_next_red1 && next_red1.old_uid > next_red2.old_uid);
-      mapping current_map = is_red1_current ? next_red1 : next_red2;
+      const bool is_red1_current = !has_next_red2
+        || (has_next_red1 && next_red1.old_uid > next_red2.old_uid);
+
+      const mapping current_map = is_red1_current ? next_red1 : next_red2;
 
       adiar_invariant(!arcs.can_pull_internal()
                       || current_map.old_uid == arcs.peek_internal().target(),
@@ -355,10 +356,12 @@ namespace adiar::internal
       // Find all arcs that have sources that match the current mapping's old_uid
       while (arcs.can_pull_internal() && current_map.old_uid == arcs.peek_internal().target()) {
         // The is_high flag is included in arc.source() pulled from node_arcs.
-        ptr_uint64 s = arcs.pull_internal().source();
+        const ptr_uint64 s = arcs.pull_internal().source();
 
         // If Reduction Rule 1 was used, then tell the parents to add to the global cut.
-        ptr_uint64 t = is_red1_current ? flag(current_map.new_uid) : current_map.new_uid;
+        const ptr_uint64 t = is_red1_current
+          ? flag(current_map.new_uid)
+          : static_cast<ptr_uint64>(current_map.new_uid);
 
         reduce_pq.push({ s,t });
       }

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -208,13 +208,14 @@ namespace adiar::internal
   }
 
   template <typename dd_policy, typename pq_t, template<typename, typename> typename sorter_t>
-  void __reduce_level(arc_stream<> &arcs,
-                      const typename dd_policy::label_t label,
-                      pq_t &reduce_pq,
-                      node_writer &out_writer,
-                      cuts_t &global_1level_cut,
-                      const size_t sorters_memory,
-                      const size_t level_width)
+  void
+  __reduce_level(arc_stream<> &arcs,
+                 const typename dd_policy::label_t label,
+                 pq_t &reduce_pq,
+                 node_writer &out_writer,
+                 cuts_t &global_1level_cut,
+                 const size_t sorters_memory,
+                 const size_t level_width)
   {
     // Temporary file for Reduction Rule 1 mappings (opened later if need be)
     tpie::file_stream<mapping> red1_mapping;
@@ -387,9 +388,10 @@ namespace adiar::internal
   }
 
   template<typename dd_policy, typename pq_t>
-  typename dd_policy::reduced_t __reduce(const shared_levelized_file<arc> &in_file,
-                                         const size_t lpq_memory,
-                                         const size_t sorters_memory)
+  shared_levelized_file<typename dd_policy::node_t>
+  __reduce(const shared_levelized_file<arc> &in_file,
+           const size_t lpq_memory,
+           const size_t sorters_memory)
   {
 #ifdef ADIAR_STATS
     stats_reduce.sum_node_arcs += in_file->size(0);
@@ -499,7 +501,8 @@ namespace adiar::internal
   /// \return The reduced decision diagram in a node-based representation
   //////////////////////////////////////////////////////////////////////////////
   template<typename dd_policy>
-  typename dd_policy::reduced_t reduce(const typename dd_policy::unreduced_t &input)
+  typename dd_policy::reduced_t
+  reduce(const typename dd_policy::unreduced_t &input)
   {
     adiar_debug(!input.empty(), "Input for Reduce should always be non-empty");
 

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -545,7 +545,7 @@ namespace adiar::internal
 #ifdef ADIAR_STATS
       stats_reduce.lpq.unbucketed += 1u;
 #endif
-      return __reduce<dd_policy, reduce_priority_queue<ADIAR_LPQ_LOOKAHEAD, memory_mode_t::INTERNAL>>
+      return __reduce<dd_policy, reduce_priority_queue<0, memory_mode_t::INTERNAL>>
         (in_file, pq_memory, sorters_memory);
     } else if(!external_only && max_pq_size <= pq_memory_fits) {
 #ifdef ADIAR_STATS

--- a/src/adiar/internal/data_types/convert.h
+++ b/src/adiar/internal/data_types/convert.h
@@ -11,7 +11,7 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////
   inline arc low_arc_of(const node &n)
   {
-    return { n.uid(), n.low() };
+    return { n.uid()/*.with(false)*/, n.low() };
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -19,7 +19,7 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////
   inline arc high_arc_of(const node &n)
   {
-    return { flag(n.uid()), n.high() };
+    return { n.uid().with(true), n.high() };
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -30,11 +30,19 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////
   inline node node_of(const arc &low, const arc &high)
   {
-    adiar_debug(unflag(low.source()) == unflag(high.source()), "Arcs are not of the same node");
-    adiar_debug(!low.is_high(), "High flag is not set on low child");
-    adiar_debug(high.is_high(), "High flag is set on high child");
+    adiar_debug(essential(low.source()) == essential(high.source()),
+                "Source are the same origin");
 
-    return node(low.source(), low.target(), high.target());
+    adiar_debug(low.out_idx()  == false, "Out-index is correct on low arc");
+    adiar_debug(high.out_idx() == true,  "Out-index is correct on high arc");
+
+    adiar_debug(!low.target().is_node()  || low.target().out_idx()  == false, "Out-index is empty in low target");
+    adiar_debug(!high.target().is_node() || high.target().out_idx() == false, "Out-index is empty in high target");
+
+    adiar_debug(low.source().is_flagged()  == false, "Source is not flagged on low arc");
+    adiar_debug(high.source().is_flagged() == false, "Source is not flagged on high arc");
+
+    return node(essential(low.source()), low.target(), high.target());
   }
 }
 

--- a/src/adiar/internal/data_types/ptr.h
+++ b/src/adiar/internal/data_types/ptr.h
@@ -7,8 +7,16 @@
 
 namespace adiar::internal
 {
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Compute (at compile-time) the (ceiling) log2 of a number.
+  ////////////////////////////////////////////////////////////////////////////
+  constexpr uint8_t log2(size_t n)
+  {
+    return n == 0u ? 0u : log2(n / 2u) + 1u;
+  }
+
   // TODO (ADD (32-bit)):
-  //   template 'ptr_uint64' with 'value_t' of how to interpret the bits of a
+  //   Template 'ptr_uint64' with 'value_t' of how to interpret the bits of a
   //   terminal. To this end, one wants to use 'std::bit_cast' in the internal
   //   logic. Use 'static_assert' to ensure the desired type indeed fits into
   //   62 bits of memory.
@@ -23,14 +31,12 @@ namespace adiar::internal
   //   For ADDs it should furthermore be templated with 'value_t'.
 
   // TODO (LDD):
-  //   add new decorator class for 'ptr' templated with a 'data' struct and use
-  //   it to store the value. Use this as the an alternative type in the
-  //   'node::ptr_t'.
+  //   Extend 'ptr_t' to a 'weighted_ptr' with a templated `weight_t`.
 
   // TODO (QMDD):
-  //   add new decorator class for 'ptr' templated with a 'data' struct and use
-  //   it to store the complex-valued weight. Use this as the new type for the
-  //   'node::children_t'.
+  //   Same as for LDD but with the weight specifically being complex values.
+  //   Furthermore, template the `OUTDEGREE` to use an extra bit for the out
+  //   index.
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief A (possibly flagged) unique identifier of a terminal, an internal
@@ -53,72 +59,37 @@ namespace adiar::internal
     /// reserve specific parts of a single 64 bit unsigned integer to different
     /// variables.
     ///
-    ///   | S | ???????????????????????????????????????????????????? | F |
+    ///    `S______________________________________________________________F`
     ///
     /// Where these three parts represent the following variables:
     ///
-    ///  - S : the is_terminal flag. If the terminal flag is set, the L and I
-    ///        areas differ (see below for the terminal type description).
+    ///  - `S` : the is_terminal flag. If the terminal flag is set, the contents
+    ///          of the middle areas differ (see below).
     ///
-    ///  - ? : The layout of these 62 bits change based on whether it describes
-    ///        a terminal, an internal node, or NIL.
+    ///  - `_` : The layout of these 62 bits change based on whether it
+    ///          describes a terminal, an internal node, or NIL.
     ///
-    ///  - F : A boolean flag. This is currently only used in arcs to identify
-    ///        high and low arcs (see below).
+    ///  - `F` : A boolean flag. This is currently only used in arcs to identify
+    ///          high and low arcs (see below).
     ///
     /// We ensure, that the S and ? areas combined uniquely identify all
     /// terminals and nodes. We also notice, that sorting these pointers
     /// directly enforce terminal pointers are sorted after nodes. Finally, two
     /// pointers for the same uid will finally be sorted by the flag.
     ////////////////////////////////////////////////////////////////////////////
+    // TODO (128 bit integers):
+    //   Template with the desired uint type and the number of label bits.
     uint64_t _raw;
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Total number of bits.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint8_t TOTAL_BITS = sizeof(uint64_t)*8u;
 
     // --------------------------------------------------
     // befriend other functions that need access to 'raw'
     template <typename T>
     friend void output_dot(const T& nodes, std::ostream &out);
-
-  public:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief Type of terminal values.
-    ////////////////////////////////////////////////////////////////////////////
-    typedef bool value_t;
-
-  public:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief Type able to hold the label of a variable.
-    ////////////////////////////////////////////////////////////////////////////
-    typedef uint32_t label_t;
-
-  private:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief The number of bits for a label.
-    ////////////////////////////////////////////////////////////////////////////
-    static constexpr uint8_t LABEL_BITS = 24;
-
-  public:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief The maximal possible value for a unique identifier's label.
-    ////////////////////////////////////////////////////////////////////////////
-    static constexpr label_t MAX_LABEL = (1ull << LABEL_BITS) - 1;
-
-  public:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief Type of a level identifier.
-    ////////////////////////////////////////////////////////////////////////////
-    typedef uint64_t id_t;
-
-  private:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief The number of bits for a level identifier.
-    ////////////////////////////////////////////////////////////////////////////
-    static constexpr uint8_t ID_BITS = 64 - 2 - LABEL_BITS;
-
-  public:
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief The maximal possible value for a level identifier.
-    ////////////////////////////////////////////////////////////////////////////
-    static constexpr id_t MAX_ID = (1ull << ID_BITS) - 1;
 
   public:
     // Provide 'default' constructors to ensure it being a 'POD' inside of TPIE.
@@ -130,6 +101,9 @@ namespace adiar::internal
     constexpr ptr_uint64(const uint64_t raw) : _raw(raw)
     { }
 
+    template<typename ptr_t>
+    friend class __uid;
+
     /* ============================= ATTRIBUTES ============================= */
   public:
     friend ptr_uint64 flag(const ptr_uint64 &p);
@@ -137,9 +111,19 @@ namespace adiar::internal
 
   protected:
     ////////////////////////////////////////////////////////////////////////////
+    /// \brief Number of flags
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint8_t FLAG_BITS = 1u;
+
+    ////////////////////////////////////////////////////////////////////////////
     /// \brief Generic bit-flag.
     ////////////////////////////////////////////////////////////////////////////
-    static constexpr uint64_t FLAG_BIT = 0x0000000000000001ull;
+    static constexpr uint64_t FLAG_MASK = 0x0000000000000001ull;
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Generic bit-flag.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint64_t FLAG_BIT = FLAG_MASK;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -147,12 +131,13 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline bool is_flagged() const
     {
-      return _raw & ptr_uint64::FLAG_BIT;
+      return _raw & ptr_uint64::FLAG_MASK;
     }
 
     /* ================================= NIL ================================ */
   protected:
-    static constexpr uint64_t NIL_VAL = UINT64_MAX - 1;
+    static constexpr uint64_t NIL_VAL =
+      std::numeric_limits<uint64_t>::max() ^ FLAG_MASK;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -178,36 +163,134 @@ namespace adiar::internal
     }
 
     /* ================================ NODES =============================== */
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Type of the out-degree.
+    ////////////////////////////////////////////////////////////////////////////
+    using out_idx_t = uint64_t;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Number of out-going edges from a node
+    ///
+    /// \details As this 'ptr' class is used within the `arc` class, we need to
+    ///          store somewhere which index the arc is part of the node. To
+    ///          save on space, we reserve some of the bits.
+    ////////////////////////////////////////////////////////////////////////////
+    // TODO (QMDD):
+    //   Make into a template parameter
+    static constexpr size_t OUTDEGREE = 2u;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The maximal possible value for the out index.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr out_idx_t MAX_OUT_IDX = OUTDEGREE - 1;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Number of bits used to store the out0index.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint8_t OUT_IDX_BITS = log2(MAX_OUT_IDX);
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Type able to hold the label of a variable.
+    ////////////////////////////////////////////////////////////////////////////
+    typedef uint32_t label_t;
+
+  private:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The number of bits for a label.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint8_t LABEL_BITS = 24u;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The maximal possible value for a unique identifier's label.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr label_t MAX_LABEL = (1ull << LABEL_BITS) - 1;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Type of a level identifier.
+    ////////////////////////////////////////////////////////////////////////////
+    using id_t = uint64_t;
+
+  private:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The number of bits for a level identifier.
+    ///
+    /// \details Take up the remaining bits for the ID. This dictates the
+    ///          maximum width possible for a single level: a level cannot
+    ///          exceed \$2^{ID_BITS} \cdot 3 \cdot 8\$ bytes.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint8_t ID_BITS =
+      TOTAL_BITS - 1u - LABEL_BITS - OUT_IDX_BITS - FLAG_BITS;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The maximal possible value for a level identifier.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr id_t MAX_ID = (1ull << ID_BITS) - 1;
+
+  private:
+    friend ptr_uint64 essential(const ptr_uint64 &p);
+    friend ptr_uint64 with_out_idx(const ptr_uint64 &p, const out_idx_t out_idx);
 
     ////////////////////////////////////////////////////////////////////////////
     /// When the <tt>is_node</tt> flag is true, then it is a pointer to a node,
     /// which is identifiable by two variables:
     ///
-    ///  - L : the variable label. For nodes n1 and n2 with n1.label < n2.label,
-    ///        we guarantee that n1 comes before n2 in the stream reading order.
+    ///  - `L` : the variable label. For nodes n1 and n2 with n1.label <
+    ///          n2.label, we guarantee that n1 comes before n2 in the stream
+    ///          reading order.
     ///
-    ///  - I : a unique identifier for the nodes on the same level. For nodes n1
-    ///        and n2 with n1.label == n2.label but n1.id < n2.id, we guarantee
-    ///        that n1 comes before n2 in the stream reading order.
+    ///  - `I` : a unique identifier for the nodes on the same level. For nodes
+    ///          n1 and n2 with n1.label == n2.label but n1.id < n2.id, we
+    ///          guarantee that n1 comes before n2 in the stream reading order.
     ///
-    /// These are spaced out in the middle area as follows
+    ///  - `O` : bit with the out-index (used in `arc`).
     ///
-    ///   | S | LLLLLLLLLLLLLLLLLLLL | IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII | F |
+    /// These are spaced out in the middle area as follows (out-degree: 1)
     ///
-    /// That means that nodes are to be sorted first by their label, and then by
-    /// their level-identifier.
+    ///    `SLLLLLLLLLLLLLLLLLLLLLLLLIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIOF`
+    ///
+    /// That means that nodes are to be sorted first by their label, then by
+    /// their level-identifier, and finally by their .
     ////////////////////////////////////////////////////////////////////////////
+  protected:
+    static uint64_t encode_label(const label_t label)
+    {
+      adiar_debug(label <= MAX_LABEL, "Cannot represent given label");
+      return (uint64_t) label << (ID_BITS + OUT_IDX_BITS + FLAG_BITS);
+    }
+
+    static uint64_t encode_id(const id_t id)
+    {
+      adiar_debug(id <= MAX_ID, "Cannot represent given id");
+      return (uint64_t) id << (OUT_IDX_BITS + FLAG_BITS);
+    }
+
+    static uint64_t encode_out_idx(const out_idx_t out_idx)
+    { return (uint64_t) out_idx << (FLAG_BITS); }
 
   public:
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Constructor for a pointer to an internal node (label, id).
+    /// \brief Constructor for a pointer to an internal node (label, id) with
+    ///        weight 0.
     ////////////////////////////////////////////////////////////////////////////
     ptr_uint64(const label_t label, const id_t id)
-      : _raw(((uint64_t) label << (ID_BITS + 1)) | (id << 1))
-    {
-      adiar_debug(label <= MAX_LABEL, "Cannot represent given label");
-      adiar_debug(id <= MAX_ID, "Cannot represent given id");
-    }
+      : _raw(encode_label(label) | encode_id(id))
+    { }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Constructor for a pointer to an internal node (label, id) with
+    ///        given weight.
+    ////////////////////////////////////////////////////////////////////////////
+    ptr_uint64(const label_t label, const id_t id, const out_idx_t out_idx)
+      : _raw(encode_label(label) | encode_id(id) | encode_out_idx(out_idx))
+    { }
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -225,7 +308,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline label_t label() const
     {
-      return _raw >> (ID_BITS + 1);
+      return _raw >> (ID_BITS + OUT_IDX_BITS + FLAG_BITS);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -235,10 +318,28 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline id_t id() const
     {
-      return (_raw >> 1) & MAX_ID;
+      return (_raw >> (OUT_IDX_BITS + FLAG_BITS)) & MAX_ID;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Extract the out-index associated with this pointer.
+    ///
+    /// \pre `is_node()` evaluates to `true.`
+    ///
+    /// \sa arc
+    ////////////////////////////////////////////////////////////////////////////
+    inline out_idx_t out_idx() const
+    {
+      return (_raw >> FLAG_BITS) & MAX_OUT_IDX;
     }
 
     /* ============================== TERMINALS ============================= */
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Type of terminal values.
+    ////////////////////////////////////////////////////////////////////////////
+    typedef bool value_t;
+
   public:
     friend inline ptr_uint64 negate(ptr_uint64 p);
 
@@ -246,11 +347,12 @@ namespace adiar::internal
     /// When the terminal flag is set, then we interpret the middle bits as the
     /// value of the terminal.
     ///
-    ///     | S | VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV | F |
+    ///    `SVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVF`
     ///
-    /// Notice, that this means we will never have to actually visit to retrieve
-    /// its value. That is, the only time a terminal has to be explicitly
-    /// represented as a node is when the BDD only consists of said terminal.
+    /// Notice, that this means we will never have to actually visit the
+    /// terminal node to retrieve its value. That is, the only time a terminal
+    /// has to be explicitly represented as a node is when the BDD only consists
+    /// of said terminal.
     ////////////////////////////////////////////////////////////////////////////
 
   protected:
@@ -259,11 +361,16 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     static constexpr uint64_t TERMINAL_BIT = 0x8000000000000000ull;
 
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Terminal bit-flag mask.
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr uint64_t VALUE_MASK = 0x0000000000000002ull;
+
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Constructor for a pointer to a terminal node (v).
     ////////////////////////////////////////////////////////////////////////////
-    ptr_uint64(const value_t v) : _raw(TERMINAL_BIT | (v << 1))
+    ptr_uint64(const value_t v) : _raw(TERMINAL_BIT | (v << FLAG_BITS))
     { }
 
   public:
@@ -283,11 +390,12 @@ namespace adiar::internal
     inline value_t value() const
     {
       adiar_precondition(is_terminal());
+
       // TODO (Attributed Edges):
       //   Negate resulting value based on 'is_flagged()'? It might actually be
       //   better to completely ditch the flag for terminals; this will
       //   simplify quite a lot of the logic.
-      return (_raw & ~TERMINAL_BIT) >> 1;
+      return (_raw & ~TERMINAL_BIT) >> FLAG_BITS;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -346,10 +454,7 @@ namespace adiar::internal
     ptr_uint64 operator~ () const
     {
       adiar_precondition(this->is_terminal());
-
-      // TODO (ADD):
-      //   bit-flip all values inside of the 'value' area.
-      return ptr_uint64(2u ^ _raw);
+      return ptr_uint64(VALUE_MASK ^ _raw);
     }
 
     //////////////////////////////////////////////////////////////////////////////
@@ -410,7 +515,44 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////
   inline ptr_uint64 unflag(const ptr_uint64 &p)
   {
-    return p._raw & (~ptr_uint64::FLAG_BIT);
+    return p._raw & (~ptr_uint64::FLAG_MASK);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief The pointer with its flag set to false and out-index set to 0.
+  //////////////////////////////////////////////////////////////////////////////
+  inline ptr_uint64 essential(const ptr_uint64 &p)
+  {
+    // We can abuse the bit-layout to boil everything down to a bit mask, and a
+    // conditional move instruction. This should be optimisable to
+    // 'std::min<size_t>' into very few cpu instructions.
+    const uint64_t _raw = p._raw;
+
+    constexpr uint64_t main_mask =
+      ~((1ull << ptr_uint64::FLAG_BITS) - 1u);
+
+    constexpr uint64_t node_mask =
+      ~(((1ull << ptr_uint64::OUT_IDX_BITS) - 1u) << ptr_uint64::FLAG_BITS) & main_mask;
+
+    return _raw > ptr_uint64::TERMINAL_BIT
+      ? (_raw & main_mask)
+      : (_raw & node_mask);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief The pointer with the out-index changed to the given value.
+  ///
+  /// \pre `p.is_node() == true`
+  //////////////////////////////////////////////////////////////////////////////
+  inline ptr_uint64 with_out_idx(const ptr_uint64 &p,
+                                 const ptr_uint64::out_idx_t out_idx)
+  {
+    adiar_precondition(p.is_node());
+
+    constexpr uint64_t out_idx_mask =
+      ~(((1ull << ptr_uint64::OUT_IDX_BITS) - 1u) << ptr_uint64::FLAG_BITS);
+
+    return (p._raw & out_idx_mask) | ptr_uint64::encode_out_idx(out_idx);
   }
 
   /* ============================ TERMINAL NODES ============================ */

--- a/src/adiar/internal/data_types/uid.h
+++ b/src/adiar/internal/data_types/uid.h
@@ -27,11 +27,17 @@ namespace adiar::internal
     __uid(const __uid<ptr_t> &p) = default;
     ~__uid() = default;
 
+  private:
+    static ptr_t clean_ptr(const ptr_t &p)
+    {
+      return p.is_node() ? ptr_t(p.label(), p.id()) : unflag(p);
+    }
+
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Constructor for a uid of an internal node (label, id).
     ////////////////////////////////////////////////////////////////////////////
-    __uid(const ptr_t &p) : ptr_t(unflag(p))
+    __uid(const ptr_t &p) : ptr_t(essential(p))
     {
 #ifndef NDEBUG
       if (p.is_nil()) throw std::invalid_argument("Pointer must be non-NIL");
@@ -51,6 +57,19 @@ namespace adiar::internal
     bool is_nil() = delete;
 
     /* ================================ NODES =============================== */
+    // Remove anything related to out-index
+
+    typename ptr_t::out_idx_t out_idx() = delete;
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Obtain the `ptr` for this node uid with the given `out_idx`.
+    ////////////////////////////////////////////////////////////////////////////
+    inline ptr_t with(const typename ptr_t::out_idx_t out_idx) const
+    {
+      adiar_precondition(ptr_t::is_node());
+      return ptr_t(ptr_t::label(), ptr_t::id(), out_idx);
+    }
+
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Constructor for a pointer to an internal node (label, id).
@@ -69,22 +88,35 @@ namespace adiar::internal
     { }
 
   public:
-    //////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////
     /// \brief Whether this uid identifies a terminal node.
-    //////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////
     inline bool is_terminal() const
     { return ptr_t::is_terminal(); }
   };
 
+  //////////////////////////////////////////////////////////////////////////////
+  // Specialization for the single-integer pointer `ptr_uint64`.
+
   template<>
-  inline bool __uid<ptr_uint64>::is_terminal() const
+  inline ptr_uint64
+  __uid<ptr_uint64>::with(const ptr_uint64::out_idx_t out_idx) const
+  {
+    // Based on the bit-layout, we can do this much faster than the one above.
+    constexpr uint64_t out_idx_mask = ~(MAX_OUT_IDX << ptr_t::FLAG_BITS);
+    return ptr_uint64((_raw & out_idx_mask) | ptr_t::encode_out_idx(out_idx));
+  }
+
+  template<>
+  inline bool
+  __uid<ptr_uint64>::is_terminal() const
   {
     // Since uid never is nil, then this is a slightly a faster logic than the
     // one in 'ptr' itself.
     return _raw >= ptr_t::TERMINAL_BIT;
   }
 
-  typedef __uid<ptr_uint64> uid_uint64;
+  using uid_uint64 = __uid<ptr_uint64>;
 }
 
 #endif // ADIAR_INTERNAL_DATA_TYPES_UID_H

--- a/src/adiar/internal/dot.h
+++ b/src/adiar/internal/dot.h
@@ -106,7 +106,7 @@ namespace adiar::internal
           << "n" << a.target().label() << "_" << a.target().id()
           << " -> "
           << "n" << a.source().label() << "_" << a.source().id()
-          << " [style=" << (a.is_high() ? "solid" : "dashed") << ", color=blue];"
+          << " [style=" << (a.out_idx() ? "solid" : "dashed") << ", color=blue];"
           << std::endl;
     }
 
@@ -121,7 +121,7 @@ namespace adiar::internal
           << "n" << a.source().label() << "_" << a.source().id()
           << " -> "
           << "s" << a.target().value()
-          << " [style=" << (a.is_high() ? "solid" : "dashed") << ", color=red];"
+          << " [style=" << (a.out_idx() ? "solid" : "dashed") << ", color=red];"
           << std::endl;
     }
 

--- a/src/adiar/zdd/pred.cpp
+++ b/src/adiar/zdd/pred.cpp
@@ -98,7 +98,7 @@ namespace adiar
       // and not the right, which would contradict being an implication (i.e.
       // representing a subset).
       if (rp[0].is_terminal() && rp[1].is_terminal()) {
-        return unflag(rp[0]) > unflag(rp[1]);
+        return essential(rp[0]) > essential(rp[1]);
       }
 
       // Has the left-hand side fallen out of its set?

--- a/test/adiar/bdd/test_apply.cpp
+++ b/test/adiar/bdd/test_apply.cpp
@@ -37,15 +37,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_1;
     /*
-            1        ---- x0
-           / \
-           | 2       ---- x1
-           |/ \
-           3   4     ---- x2
-          / \ / \
-          F T T 5    ---- x3
-               / \
-               F T
+    //        1        ---- x0
+    //       / \
+    //       | 2       ---- x1
+    //       |/ \
+    //       3   4     ---- x2
+    //      / \ / \
+    //      F T T 5    ---- x3
+    //           / \
+    //           F T
     */
 
     node n1_5 = node(3, node::MAX_ID, terminal_F, terminal_T);
@@ -61,15 +61,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_2;
     /*
-                   ---- x0
-
-             1     ---- x1
-            / \
-            | T    ---- x2
-            |
-            2      ---- x3
-           / \
-           T F
+    //               ---- x0
+    //
+    //         1     ---- x1
+    //        / \
+    //        | T    ---- x2
+    //        |
+    //        2      ---- x3
+    //       / \
+    //       T F
     */
 
     node n2_2 = node(3, node::MAX_ID, terminal_T, terminal_F);
@@ -82,19 +82,18 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_3;
     /*
-                1         ---- x0
-               / \
-               2 3        ---- x1
-             _/ X \_
-            | _/ \_ |
-             X     X
-            / \   / \
-           4  5  6  7     ---- x2
-          / \/ \/ \/ \
-          F T  8  T  F    ---- x3
-              / \
-              F T
-
+    //            1         ---- x0
+    //           / \
+    //           2 3        ---- x1
+    //         _/ X \_
+    //        | _/ \_ |
+    //         X     X
+    //        / \   / \
+    //       4  5  6  7     ---- x2
+    //      / \/ \/ \/ \
+    //      F T  8  T  F    ---- x3
+    //          / \
+    //          F T
     */
 
     node n3_8 = node(3, node::MAX_ID, terminal_F, terminal_T);
@@ -112,27 +111,27 @@ go_bandit([]() {
     }
 
     /* The product construction of bbd_1 and bdd_2 above is as follows in sorted order.
-
-                                            (1,1)                       ---- x0
-                                            \_ _/
-                                             _X_                        // Match in fst, but not coordinatewise
-                                            /   \
-                                        (3,1)   (2,1)                   ---- x1
-                                       /    \_ _/    \
-                                      /       X       \
-                                     /_______/ \       \
-                                     |          \       \
-                                 (3,2)          (3,T)   (4,T)           ---- x2
-                                  \ \           /   \   /   \
-                                   \ \      (F,T)   (T,T)   /
-                                    \ \________ ___________/
-                                     \________ X________
-                                              X_________\ _______
-                                             /           \       \
-                                            /             \       \
-                                         (5,T)         (F,2)     (T,2)   ---- x3
-                                         /   \         /   \     /   \
-                                      (F,T) (T,T)   (F,T)(F,F)  (T,T)(T,F)
+    //
+    //                                        (1,1)                       ---- x0
+    //                                        \_ _/
+    //                                         _X_                        // Match in fst, but not coordinatewise
+    //                                        /   \
+    //                                    (3,1)   (2,1)                   ---- x1
+    //                                   /    \_ _/    \
+    //                                  /       X       \
+    //                                 /_______/ \       \
+    //                                 |          \       \
+    //                             (3,2)          (3,T)   (4,T)           ---- x2
+    //                              \ \           /   \   /   \
+    //                               \ \      (F,T)   (T,T)   /
+    //                                \ \________ ___________/
+    //                                 \________ X________
+    //                                          X_________\ _______
+    //                                         /           \       \
+    //                                        /             \       \
+    //                                     (5,T)         (F,2)     (T,2)   ---- x3
+    //                                     /   \         /   \     /   \
+    //                                  (F,T) (T,T)   (F,T)(F,F)  (T,T)(T,F)
     */
 
     describe("bdd_and(f,g)", [&]() {
@@ -212,9 +211,9 @@ go_bandit([]() {
 
       it("should x0 and !x0", [&]() {
         /*
-                   1     ---- x0
-                  / \
-                  F F
+        //           1     ---- x0
+        //          / \
+        //          F F
         */
 
         __bdd out = bdd_and(bdd_x0, bdd_not_x0);
@@ -224,10 +223,10 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -267,19 +266,19 @@ go_bandit([]() {
 
       it("should compute (and shortcut) BBD 1 /\\ [2]", [&]() {
         /*
-                            1                        ---- x0
-                            X
-                           / \
-                          2   3                      ---- x1
-                         / \ / \
-                        /   X   \
-                       /___/ \   \
-                      /      |    \
-                     4       5     6                 ---- x2
-                    / \     / \_ _/ \
-                    F 7     F   T   8                ---- x3
-                     / \           / \
-                     T F           F T
+        //                    1                        ---- x0
+        //                    X
+        //                   / \
+        //                  2   3                      ---- x1
+        //                 / \ / \
+        //                /   X   \
+        //               /___/ \   \
+        //              /      |    \
+        //             4       5     6                 ---- x2
+        //            / \     / \_ _/ \
+        //            F 7     F   T   8                ---- x3
+        //             / \           / \
+        //             T F           F T
         */
 
         __bdd out = bdd_and(bdd_1, bdd_2);
@@ -287,47 +286,47 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,1) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,2) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  ptr_uint64(3,0) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -370,16 +369,16 @@ go_bandit([]() {
         // which all are tied, and hence the prior version would create
         // three nodes on this level rather than just two.
 
-        //TODO: This drawing seems to not fit - fix it?
+        // TODO: This drawing seems to not fit - fix it?
 
         /*
-                 1    ---- x0
-                / \
-                2 |   ---- x1
-               / \|
-               3  4   ---- x2
-              / \/ \
-              T  F T
+        //         1    ---- x0
+        //        / \
+        //        2 |   ---- x1
+        //       / \|
+        //       3  4   ---- x2
+        //      / \/ \
+        //      T  F T
         */
 
         // The second version is the same but has the nodes 3 and 4 mirrored
@@ -406,34 +405,34 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (T,5) i.e. the added node
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -561,13 +560,13 @@ go_bandit([]() {
 
       it("should shortcut on x0 \\/ x2", [&]() {
         /*
-                   1     ---- x0
-                  / \
-                  | T
-                  |
-                  2      ---- x2
-                 / \
-                 F T
+        //           1     ---- x0
+        //          / \
+        //          | T
+        //          |
+        //          2      ---- x2
+        //         / \
+        //         F T
         */
 
         __bdd out = bdd_or(bdd_x0, bdd_x2);
@@ -575,18 +574,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -650,17 +649,17 @@ go_bandit([]() {
 
       it("should compute (and shortcut) [1] \\/ [2]", [&]() {
         /*
-                           1       ---- x0
-                          / \
-                         2   3     ---- x1
-                        / \ / \
-                        | T | T
-                        \_ _/
-                          4        ---- x2
-                         / \
-                         5  T      ---- x3
-                        / \
-                        T F
+        //                   1       ---- x0
+        //                  / \
+        //                 2   3     ---- x1
+        //                / \ / \
+        //                | T | T
+        //                \_ _/
+        //                  4        ---- x2
+        //                 / \
+        //                 5  T      ---- x3
+        //                / \
+        //                T F
         */
 
         __bdd out = bdd_or(bdd_1, bdd_2);
@@ -668,36 +667,36 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -806,13 +805,13 @@ go_bandit([]() {
 
       it("should compute x0 ^ x1", [&]() {
         /* The order on the leaves are due to the sorting of terminal requests
-           after evaluating x0
-
-                   1     ---- x0
-                  / \
-                 2   3   ---- x1
-                / \ / \
-                F T T F
+        //   after evaluating x0
+        //
+        //           1     ---- x0
+        //          / \
+        //         2   3   ---- x1
+        //        / \ / \
+        //        F T T F
         */
 
         __bdd out = bdd_xor(bdd_x0, bdd_x1);
@@ -820,24 +819,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -859,52 +858,52 @@ go_bandit([]() {
 
       it("should compute [2] ^ x2", [&]() {
         /*
-                                         ---- x0
-
-                         (1,1)           ---- x1
-                         /   \
-                     (2,1)   (T,1)       ---- x2
-                     /   \   /   \
-                    /     \  T   F
-                    |     |
-                (2,F)     (2,T)          ---- x3
-                /   \     /   \
-                T   F     F   T
+        //                                 ---- x0
+        //
+        //                 (1,1)           ---- x1
+        //                 /   \
+        //             (2,1)   (T,1)       ---- x2
+        //             /   \   /   \
+        //            /     \  T   F
+        //            |     |
+        //        (2,F)     (2,T)          ---- x3
+        //        /   \     /   \
+        //        T   F     F   T
         */
         __bdd out = bdd_xor(bdd_2, bdd_x2);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -936,60 +935,60 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1017,29 +1016,29 @@ go_bandit([]() {
 
       it("should compute [3] ^ [1]", [&]() {
         /* The queue appD_data is used to forward data across the level. When
-           [1] and 3 are combined, this is needed
-
-                  The product between the [3] and [1] then is
-
-                                   (1,1)                      ---- x0
-                           ________/   \_______
-                          /                    \
-                        (2,3)                  (3,2)          ---- x1
-                        /   \_________ ________/   \
-                        |             X            |          //      (5,3) (7,3) (4,3) (6,4)
-                        \__ _________/ \__________ /          // min:   0     0     0     1
-                        ___X___                   X           // max:   1     3     0     2
-                       /       \            _____/ \          // coord: 2     3     1     4
-                      /         \          /        \
-                   (4,3)       (5,3)    (6,4)     (7,3)       ---- x2
-                   /   \       /   \    /   \     /   \
-                (F,F) (T,T) (T,F)  |   /     \  (T,F) (F,T)
-                                   |  /       \
-                                   | /        |
-                                   |/         |
-                                 (8,T)      (T,5)             ---- x3
-                                 /   \      /   \
-                              (F,T) (T,T) (T,F) (T,T)
+        // [1] and 3 are combined, this is needed
+        //
+        //          The product between the [3] and [1] then is
+        //
+        //                           (1,1)                      ---- x0
+        //                   ________/   \_______
+        //                  /                    \
+        //                (2,3)                  (3,2)          ---- x1
+        //                /   \_________ ________/   \
+        //                |             X            |          //      (5,3) (7,3) (4,3) (6,4)
+        //                \__ _________/ \__________ /          // min:   0     0     0     1
+        //                ___X___                   X           // max:   1     3     0     2
+        //               /       \            _____/ \          // coord: 2     3     1     4
+        //              /         \          /        \
+        //           (4,3)       (5,3)    (6,4)     (7,3)       ---- x2
+        //           /   \       /   \    /   \     /   \
+        //        (F,F) (T,T) (T,F)  |   /     \  (T,F) (F,T)
+        //                           |  /       \
+        //                           | /        |
+        //                           |/         |
+        //                         (8,T)      (T,5)             ---- x3
+        //                         /   \      /   \
+        //                      (F,T) (T,T) (T,F) (T,T)
         */
 
         __bdd out = bdd_xor(bdd_3, bdd_1);
@@ -1047,60 +1046,60 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (6,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (7,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (8,T)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (T,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,3)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1245,13 +1244,13 @@ go_bandit([]() {
 
       it("should shortcut on x0 -> x1", [&]() {
         /* The order on the leaves are due to the sorting of terminal requests
-           after evaluating x0
-
-                   1     ---- x0
-                  / \
-                  T 2    ---- x1
-                   / \
-                   F T
+        // after evaluating x0
+        //
+        //           1     ---- x0
+        //          / \
+        //          T 2    ---- x1
+        //           / \
+        //           F T
         */
 
         __bdd out = bdd_imp(bdd_x0, bdd_x1);
@@ -1259,18 +1258,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/bdd/test_bdd.cpp
+++ b/test/adiar/bdd/test_bdd.cpp
@@ -93,11 +93,11 @@ go_bandit([]() {
 
       {
         arc_writer aw(af);
-        aw.push_internal(arc {flag(ptr_uint64(0,0)), ptr_uint64(1,0)});
+        aw.push_internal(arc {ptr_uint64(0,0), true,   ptr_uint64(1,0)});
 
-        aw.push_terminal(arc {ptr_uint64(0,0), ptr_uint64(false)});
-        aw.push_terminal(arc {ptr_uint64(1,0), ptr_uint64(true)});
-        aw.push_terminal(arc {flag(ptr_uint64(1,0)), ptr_uint64(true)});
+        aw.push_terminal(arc {ptr_uint64(0,0), false, ptr_uint64(false)});
+        aw.push_terminal(arc {ptr_uint64(1,0), false, ptr_uint64(true)});
+        aw.push_terminal(arc {ptr_uint64(1,0), true,  ptr_uint64(true)});
 
         aw.push(level_info(0,1u));
         aw.push(level_info(1,1u));

--- a/test/adiar/bdd/test_if_then_else.cpp
+++ b/test/adiar/bdd/test_if_then_else.cpp
@@ -50,15 +50,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_1;
     /*
-                            _1_              ---- x0
-                           /   \
-                           2   3             ---- x1
-                          / \ / \
-                          6  5  4            ---- x2
-                         / \/ \/ \
-                         F T  7  T           ---- x3
-                             / \
-                             F T
+    //                        _1_              ---- x0
+    //                       /   \
+    //                       2   3             ---- x1
+    //                      / \ / \
+    //                      6  5  4            ---- x2
+    //                     / \/ \/ \
+    //                     F T  7  T           ---- x3
+    //                         / \
+    //                         F T
     */
 
     { // Garbage collect writers to free write-lock
@@ -75,15 +75,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_2;
     /*
-                               __1__         ---- x0
-                              /     \
-                            _2_     _3_      ---- x1
-                           /   \   /   \
-                           4   5   6   7     ---- x2
-                          / \ / \ / \ / \
-                          F 8 F 9 T F F T    ---- x3
-                           / \ / \
-                           T F F T
+    //                           __1__         ---- x0
+    //                          /     \
+    //                        _2_     _3_      ---- x1
+    //                       /   \   /   \
+    //                       4   5   6   7     ---- x2
+    //                      / \ / \ / \ / \
+    //                      F 8 F 9 T F F T    ---- x3
+    //                       / \ / \
+    //                       T F F T
     */
 
     { // Garbage collect writers to free write-lock
@@ -102,15 +102,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_3;
     /*
-                              __1__         ---- x0
-                             /     \
-                           _2_      \       ---- x1
-                          /   \      \
-                          3   4      5      ---- x2
-                         / \ / \    / \
-                         T F F 6    F T     ---- x3
-                              / \
-                              F T
+    //                          __1__         ---- x0
+    //                         /     \
+    //                       _2_      \       ---- x1
+    //                      /   \      \
+    //                      3   4      5      ---- x2
+    //                     / \ / \    / \
+    //                     T F F 6    F T     ---- x3
+    //                          / \
+    //                          F T
     */
 
     { // Garbage collect writers to free write-lock
@@ -126,15 +126,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_4;
     /*
-                               __1__         ---- x0
-                              /     \
-                            _2_      \       ---- x1
-                           /   \      \
-                           4   5      3      ---- x2
-                          / \ / \    / \
-                          6 T F 7    T F     ---- x3
-                         / \   / \
-                         T F   F T
+    //                           __1__         ---- x0
+    //                          /     \
+    //                        _2_      \       ---- x1
+    //                       /   \      \
+    //                       4   5      3      ---- x2
+    //                      / \ / \    / \
+    //                      6 T F 7    T F     ---- x3
+    //                     / \   / \
+    //                     T F   F T
     */
     { // Garbage collect writers to free write-lock
       node_writer nw_4(bdd_4);
@@ -150,15 +150,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_5;
     /*
-                               __1__         ---- x0
-                              /     \
-                            _2_      \       ---- x1
-                           /   \      \
-                           5   3      4      ---- x2
-                          / \ / \    / \
-                          F 6 T F    F T     ---- x3
-                           / \
-                           T F
+    //                           __1__         ---- x0
+    //                          /     \
+    //                        _2_      \       ---- x1
+    //                       /   \      \
+    //                       5   3      4      ---- x2
+    //                      / \ / \    / \
+    //                      F 6 T F    F T     ---- x3
+    //                       / \
+    //                       T F
     */
     { // Garbage collect writers to free write-lock
       node_writer nw_5(bdd_5);
@@ -173,14 +173,13 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_6;
     /*
-                                    1         ---- x0
-                                   / \
-                                   F _2_      ---- x1
-                                    /   \
-                                    3   4     ---- x2
-                                   / \ / \
-                                   F T T F
-
+    //                                1         ---- x0
+    //                               / \
+    //                               F _2_      ---- x1
+    //                                /   \
+    //                                3   4     ---- x2
+    //                               / \ / \
+    //                               F T T F
     */
     { // Garbage collect writers to free write-lock
       node_writer nw_6(bdd_6);
@@ -193,14 +192,13 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_not_6;
     /*
-                                    1         ---- x0
-                                   / \
-                                   T _2_      ---- x1
-                                    /   \
-                                    3   4     ---- x2
-                                   / \ / \
-                                   T F F T
-
+    //                                1         ---- x0
+    //                               / \
+    //                               T _2_      ---- x1
+    //                                /   \
+    //                                3   4     ---- x2
+    //                               / \ / \
+    //                               T F F T
     */
     { // Garbage collect writers to free write-lock
       node_writer nw_not_6(bdd_not_6);
@@ -213,15 +211,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_7;
     /*
-                                     1         ---- x0
-                                    / \
-                                    2__\       ---- x1
-                                   /   |
-                                   3   4       ---- x2
-                                  / \ / \
-                                  F  5  T      ---- x3
-                                    / \
-                                    F T
+    //                                 1         ---- x0
+    //                                / \
+    //                                2__\       ---- x1
+    //                               /   |
+    //                               3   4       ---- x2
+    //                              / \ / \
+    //                              F  5  T      ---- x3
+    //                                / \
+    //                                F T
     */
 
     {
@@ -236,15 +234,15 @@ go_bandit([]() {
 
     shared_levelized_file<bdd::node_t> bdd_8;
     /*
-                                   1         ---- x0
-                                  / \
-                                  2 |        ---- x1
-                                 / \|
-                                 3  |        ---- x2
-                                / \/
-                                T 4          ---- x3
-                                 / \
-                                 T F
+    //                               1         ---- x0
+    //                              / \
+    //                              2 |        ---- x1
+    //                             / \|
+    //                             3  |        ---- x2
+    //                            / \/
+    //                            T 4          ---- x3
+    //                             / \
+    //                             T F
     */
     {
       node_writer nw_8(bdd_8);
@@ -312,24 +310,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -355,24 +353,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -398,18 +396,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -435,18 +433,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -472,18 +470,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -509,18 +507,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -546,18 +544,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -583,18 +581,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -620,18 +618,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -657,18 +655,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -692,37 +690,37 @@ go_bandit([]() {
     describe("Inputs that require the cross-product of all three BDDs", [&]() {
       it("should compute x0 ? ~x1 : x1", [&]() {
         /*
-                       (x0, ~x1, x1)             ---- x0
-                        /         \
-                 (F, Nil, x1)  (T, ~x1, Nil)     ---- x1
-                  /        \    /         \
-                  F        T    T         F
-
-                  The low arc is resolved first, since F < T
+        //               (x0, ~x1, x1)             ---- x0
+        //                /         \
+        //         (F, Nil, x1)  (T, ~x1, Nil)     ---- x1
+        //          /        \    /         \
+        //          F        T    T         F
+        //
+        //      The low arc is resolved first, since F < T
         */
         __bdd out = bdd_ite(bdd_x0, bdd_not_x1, bdd_x1);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -744,37 +742,37 @@ go_bandit([]() {
 
       it("should compute x1 ? ~x0 : x0", [&]() {
         /*
-                      (x1, ~x0, x0)          ---- x0
-                       /         \
-                 (x1, T, F)  (x1, F, T)      ---- x1
-                  /      \    /      \
-                  F      T    T      F
-
-                  The high arc is resolved first, since T > F on the second coordinate
+        //              (x1, ~x0, x0)          ---- x0
+        //               /         \
+        //         (x1, T, F)  (x1, F, T)      ---- x1
+        //          /      \    /      \
+        //          F      T    T      F
+        //
+        //        The high arc is resolved first, since T > F on the second coordinate
         */
         __bdd out = bdd_ite(bdd_x1, bdd_not_x0, bdd_x0);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -796,37 +794,37 @@ go_bandit([]() {
 
       it("should compute x1 ? x0 : ~x0", [&]() {
         /*
-                       (x1, x0, ~x0)         ---- x0
-                        /         \
-                 (x1, F, T)  (x1, T, F)      ---- x1
-                  /      \    /       \
-                  T      F    F       T
-
-                  The low arc is resolved first, since F < T on the second coordinate.
+        //               (x1, x0, ~x0)         ---- x0
+        //                /         \
+        //         (x1, F, T)  (x1, T, F)      ---- x1
+        //          /      \    /       \
+        //          T      F    F       T
+        //
+        //    The low arc is resolved first, since F < T on the second coordinate.
         */
         __bdd out = bdd_ite(bdd_x1, bdd_x0, bdd_not_x0);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -858,49 +856,49 @@ go_bandit([]() {
         }
 
         /*
-                                  ((2,0),(0,0),(0,0))                 ---- x0
-                                   /               \
-                        ((2,0),(1,0),(1,1))  ((2,0),(1,1),(1,0))      ---- x1
-                               /   \              /      \
-                              /     \             \ _____/
-                              |      \ ____________X
-                              |       X________     \
-                              |      /         \     \
-                             ((2,0),F,T)      ((2,0),T,F)             ---- x2
-                                 / \               / \
-                                 F T               T F
+        //                          ((2,0),(0,0),(0,0))                 ---- x0
+        //                           /               \
+        //                ((2,0),(1,0),(1,1))  ((2,0),(1,1),(1,0))      ---- x1
+        //                       /   \              /      \
+        //                      /     \             \ _____/
+        //                      |      \ ____________X
+        //                      |       X________     \
+        //                      |      /         \     \
+        //                     ((2,0),F,T)      ((2,0),T,F)             ---- x2
+        //                         / \               / \
+        //                         F T               T F
         */
         __bdd out = bdd_ite(bdd_not(bdd_x2), bdd_x0_xor_x1, bdd_x0_xnor_x1);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // ((2,0),(1,0),(1,1))
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // ((2,0),(1,1),(1,0))
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // ((2,0),F,T)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // ((2,0),T,F)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // ((2,0),F,T)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // ((2,0),T,F)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -926,9 +924,9 @@ go_bandit([]() {
       it("should compute x3 ? (x1 & x2) : bdd_1", [&]() {
         shared_levelized_file<bdd::node_t> bdd_x3;
         /*
-                      1     ---- x3
-                      / \
-                      F T
+        //               1     ---- x3
+        //              / \
+        //              F T
         */
         {
           node_writer nw_x3(bdd_x3);
@@ -937,108 +935,108 @@ go_bandit([]() {
 
         shared_levelized_file<bdd::node_t> bdd_x1_and_x2;
         /*
-                      1     ---- x1
-                      / \
-                      F 2    ---- x2
-                      / \
-                      F T
+        //               1     ---- x1
+        //              / \
+        //              F 2    ---- x2
+        //              / \
+        //              F T
         */
         {
           node_writer nw_x1_and_x2(bdd_x1_and_x2);
           nw_x1_and_x2 << node(2,1,terminal_F,terminal_T)
-                      << node(1,0,terminal_F,ptr_uint64(2,1));
+                       << node(1,0,terminal_F,ptr_uint64(2,1));
         }
 
         /*
-                                          (1,1,1)                          ---- x0
-                               ____________/   \___________
-                              /                            \
-                          (1,1,2)                      (1,1,3)            ---- x1
-                        ____/   \____                ____/   \____
-                      /             \              /             \
-                    (1,F,6)       (1,2,5)       (1,F,5)        (1,2,4)     ---- x2
-                    /   \         /   \         /   \          /   \
-                    F    \       /     \       /     \        /    T
-                          \     /       \     /       \_______\
-                           \___/________ \ __/                 \
-                            \             \                     \
-                          (1,F,T)       (1,T,7)              (1,F,7)      ---- x3
-                            /   \         /   \                /   \
-                            T   F         F   T                F   F
-
-                The drawing above is in-order for all but x2 and x3 where the
-                order actually is.
-
-                              (1,2,4), (1,2,5), (1,F,5), (1,F,6)   ---- x2
-
-                                  (1,F,7), (1,F,T), (1,T,7)       ---- x3
-
-                No forwarding across the level is needed due to the ids
-
-                Furthermore notice, the F terminal of (1,F,6) is due to both the
-                'then' and the 'else' case agree, so we don't recurse to obtain
-                the value of the 'if' conditional. The same goes for T terminal of
-                (1,2,4).
+        //                                  (1,1,1)                          ---- x0
+        //                       ____________/   \___________
+        //                      /                            \
+        //                  (1,1,2)                      (1,1,3)            ---- x1
+        //                ____/   \____                ____/   \____
+        //              /             \              /             \
+        //            (1,F,6)       (1,2,5)       (1,F,5)        (1,2,4)     ---- x2
+        //            /   \         /   \         /   \          /   \
+        //            F    \       /     \       /     \        /    T
+        //                  \     /       \     /       \_______\
+        //                   \___/________ \ __/                 \
+        //                    \             \                     \
+        //                  (1,F,T)       (1,T,7)              (1,F,7)      ---- x3
+        //                    /   \         /   \                /   \
+        //                    T   F         F   T                F   F
+        //
+        //        The drawing above is in-order for all but x2 and x3 where the
+        //        order actually is.
+        //
+        //                      (1,2,4), (1,2,5), (1,F,5), (1,F,6)   ---- x2
+        //
+        //                          (1,F,7), (1,F,T), (1,T,7)       ---- x3
+        //
+        //        No forwarding across the level is needed due to the ids
+        //
+        //        Furthermore notice, the F terminal of (1,F,6) is due to both the
+        //        'then' and the 'else' case agree, so we don't recurse to obtain
+        //        the value of the 'if' conditional. The same goes for T terminal of
+        //        (1,2,4).
         */
         __bdd out = bdd_ite(bdd_x3, bdd_x1_and_x2, bdd_1);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,1,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,1,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,2,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,2,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,F,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,F,6)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,F,7)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,F,T)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,1) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), false, ptr_uint64(3,1) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,3)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,3), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,T,7)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,2,4)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,F,6)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,F,7)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,F,T)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,T,7)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1066,26 +1064,26 @@ go_bandit([]() {
 
       it("should compute bdd_3 ? bdd_4 : bdd_5", [&]() {
         /*
-                                      (1,1,1)               ---- x0
-                                  ______/ \______
-                                 /               \
-                             (2,2,2)              \         ---- x1
-                          ____/   \____            \
-                         /             \            \
-                      (3,4,5)        (4,5,3)     (5,3,4)    ---- x2
-                        \ /           /   \       /   \
-                         X            T   |       F   F
-                       _/ \_              |
-                      /     \             |
-                  (T,6,_) (F,_,6)      (6,7,F)              ---- x3
-                   /   \   /   \        /   \
-                   T   F   T   F        F   T
-
-                  Forwarding for each node is needed for level x2 twice, but due
-                  to the ids involved one will only obtain the nodes in question
-                  one at a time.
-
-                  The level for x3 equires to forward (6) in (6,7,F) once.
+        //                              (1,1,1)               ---- x0
+        //                          ______/ \______
+        //                         /               \
+        //                     (2,2,2)              \         ---- x1
+        //                  ____/   \____            \
+        //                 /             \            \
+        //              (3,4,5)        (4,5,3)     (5,3,4)    ---- x2
+        //                \ /           /   \       /   \
+        //                 X            T   |       F   F
+        //               _/ \_              |
+        //              /     \             |
+        //          (T,6,_) (F,_,6)      (6,7,F)              ---- x3
+        //           /   \   /   \        /   \
+        //           T   F   T   F        F   T
+        //
+        //          Forwarding for each node is needed for level x2 twice, but due
+        //          to the ids involved one will only obtain the nodes in question
+        //          one at a time.
+        //
+        //          The level for x3 equires to forward (6) in (6,7,F) once.
         */
 
         __bdd out = bdd_ite(bdd_3, bdd_4, bdd_5);
@@ -1093,50 +1091,50 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,2,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,5,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,3,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,6)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (T,6,_)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (6,7,F)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,5,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,3,4)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,6)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (T,6,_)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (6,7,F)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1164,25 +1162,25 @@ go_bandit([]() {
 
       it("should compute bdd_6 ? x0^x2 : bdd_not_6", [&]() {
         /*                      bdd_x0_xor_x2
-                      _1_       ---- x1
-                     /   \
-                     2   3      ---- x2
-                    / \ / \
-                    F T T F
+        //              _1_       ---- x1
+        //             /   \
+        //             2   3      ---- x2
+        //            / \ / \
+        //            F T T F
         */
 
         /*
-                                  (1,1,1)               ---- x0
-                                    /   \
-                                   T  (2,2,3)           ---- x1
-                                        /   \
-                                  (3,3,3) (4,4,3)       ---- x2
-                                    /   \   /   \
-                                    T   F   T   T
-
-                  On level x2 forwarding happens for (3,3,3) with the two nodes
-                  3, 3 from the if-case and else-case. Both of these are
-                  encountered simultaneously, so they are in one-go forwarded.
+        //                           (1,1,1)              ---- x0
+        //                            /   \
+        //                           T  (2,2,3)           ---- x1
+        //                                /   \
+        //                          (3,3,3) (4,4,3)       ---- x2
+        //                            /   \   /   \
+        //                            T   F   T   T
+        //
+        //          On level x2 forwarding happens for (3,3,3) with the two nodes
+        //          3, 3 from the if-case and else-case. Both of these are
+        //          encountered simultaneously, so they are in one-go forwarded.
         */
 
         __bdd out = bdd_ite(bdd_6, bdd_x0_xor_x2, bdd_not_6);
@@ -1190,28 +1188,28 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,2,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,3,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,4,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,1,1)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,3,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,4,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1237,25 +1235,25 @@ go_bandit([]() {
 
       it("should compute bdd_not_6 ? bdd_6 : x0^x2", [&]() {
         /*                      bdd_x0_xor_x2
-                      _1_       ---- x1
-                     /   \
-                     2   3      ---- x2
-                    / \ / \
-                    F T T F
+        //              _1_       ---- x1
+        //              /   \
+        //              2   3      ---- x2
+        //             / \ / \
+        //             F T T F
         */
 
         /*
-                                   (1,1,1)               ---- x0
-                                    /   \
-                                    F  (2,3,2)           ---- x1
-                                        /   \
-                                  (3,3,3) (4,3,4)       ---- x2
-                                    /   \   /   \
-                                    F   F   T   F
-
-                  On level x2 forwarding happens for (3,3,3) with the two nodes
-                  3, 3 from the if-case and then-case. Both of these are
-                  encountered simultaneously, so they are in one-go forwarded.
+        //                           (1,1,1)               ---- x0
+        //                            /   \
+        //                            F  (2,3,2)           ---- x1
+        //                                /   \
+        //                          (3,3,3) (4,3,4)       ---- x2
+        //                            /   \   /   \
+        //                            F   F   T   F
+        //
+        //          On level x2 forwarding happens for (3,3,3) with the two nodes
+        //          3, 3 from the if-case and then-case. Both of these are
+        //          encountered simultaneously, so they are in one-go forwarded.
         */
 
         __bdd out = bdd_ite(bdd_not_6, bdd_6, bdd_x0_xor_x2);
@@ -1263,28 +1261,28 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,3,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,3,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,3,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (1,1,1)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,3,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,4,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1310,11 +1308,11 @@ go_bandit([]() {
       it("should compute ~(x0^x2) ? ~x2 : bdd_1", [&]() {
         shared_levelized_file<bdd::node_t> bdd_x0_xnor_x2;
         /*
-                                  _1_
-                                 /   \
-                                 3   2
-                                / \ / \
-                                T F F T
+        //                          _1_
+        //                         /   \
+        //                         3   2
+        //                        / \ / \
+        //                        T F F T
         */
         {
           node_writer nw_x0_xnor_x2(bdd_x0_xnor_x2);
@@ -1324,27 +1322,27 @@ go_bandit([]() {
         }
 
         /*
-                                   (1,1,1)                   ---- x0
-                             _______/   \________
-                            /                    \
-                        (3,1,2)                (2,1,3)       ---- x1
-                        /   \                  /   \
-                    (3,1,6) (3,1,5)        (2,1,5) (2,1,4)   ---- x2
-                    /   \   /   \          /   \   /   \
-                    T   T   T    \         T   F  /    F
-                                  \______   _____/
-                                         \ /
-                                        (F,_,7)              ---- x3
-                                        /   \
-                                        F   T
-
-                Where the order for x2 is:
-
-                        (2,1,4), (2,1,5), (3,1,5), (3,1,6)
-
-                and (2,1,4) is resolved without forwarding, (2,1,5) forwards two
-                elements (2 and 1) at once, and finally (3,1,5) and (3,1,6)
-                require forwarding two elements one at a time.
+        //                           (1,1,1)                   ---- x0
+        //                     _______/   \________
+        //                    /                    \
+        //                (3,1,2)                (2,1,3)       ---- x1
+        //                /   \                  /   \
+        //            (3,1,6) (3,1,5)        (2,1,5) (2,1,4)   ---- x2
+        //            /   \   /   \          /   \   /   \
+        //            T   T   T    \         T   F  /    F
+        //                          \______   _____/
+        //                                 \ /
+        //                                (F,_,7)              ---- x3
+        //                                 /   \
+        //                                 F   T
+        //
+        //        Where the order for x2 is:
+        //
+        //                (2,1,4), (2,1,5), (3,1,5), (3,1,6)
+        //
+        //        and (2,1,4) is resolved without forwarding, (2,1,5) forwards two
+        //        elements (2 and 1) at once, and finally (3,1,5) and (3,1,6)
+        //        require forwarding two elements one at a time.
         */
 
         __bdd out = bdd_ite(bdd_x0_xnor_x2, bdd_not(bdd_x2), bdd_1);
@@ -1352,50 +1350,50 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,1,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,1,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,1,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,1,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,1,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,1,6)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,7)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (2,1,4)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (2,1,5)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,1,5)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,1,6)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,3)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,7)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1424,90 +1422,90 @@ go_bandit([]() {
       it("should compute (x1^x2) ? bdd_1 : bdd_2", [&]() {
         shared_levelized_file<bdd::node_t> bdd_x1_xor_x2_2;
         /*
-                              _1_      ---- x1
-                             /   \
-                             3   2     ---- x2
-                            / \ / \
-                            F T T F
+        //                      _1_      ---- x1
+        //                     /   \
+        //                     3   2     ---- x2
+        //                    / \ / \
+        //                    F T T F
         */
 
         {
           node_writer nw_x1_xor_x2(bdd_x1_xor_x2_2);
           nw_x1_xor_x2 << node(2,1,terminal_F,terminal_T)                              // 3
-                      << node(2,0,terminal_T,terminal_F)                              // 2
-                      << node(1,0,ptr_uint64(2,1),ptr_uint64(2,0)); // 1
+                       << node(2,0,terminal_T,terminal_F)                              // 2
+                       << node(1,0,ptr_uint64(2,1),ptr_uint64(2,0)); // 1
         }
 
         /*
-                                   (1,1,1)                   ---- x0
-                              ______/   \_____
-                             /                \
-                        (1,2,2)             (1,3,3)          ---- x1
-                        /   \               /   \
-                    (3,6,4) (2,5,5)     (3,5,6) (2,4,7)      ---- x2  Order of resolvement:
-                    /   \   /   \       /   \   /   \                    (2,5,5)**, (3,5,6)***, (3,6,4)*, (2,4,7)*
-                    F   T   T   |       T    \ /    T                        *   Forwarding two item once
-                                |             |                              **  Forwarding one item once
-                                |             |                              *** Forwarding one item twice
-                              (F,_,9)       (T,7,_)          ---- x3
-                              /   \         /   \                    (To reproduce: look at actual ids and sorting)
-                              F   T         F   T
+        //                           (1,1,1)                   ---- x0
+        //                      ______/   \_____
+        //                     /                \
+        //                (1,2,2)             (1,3,3)          ---- x1
+        //                /   \               /   \
+        //            (3,6,4) (2,5,5)     (3,5,6) (2,4,7)      ---- x2  Order of resolvement:
+        //            /   \   /   \       /   \   /   \                    (2,5,5)**, (3,5,6)***, (3,6,4)*, (2,4,7)*
+        //            F   T   T   |       T    \ /    T                        *   Forwarding two item once
+        //                        |             |                              **  Forwarding one item once
+        //                        |             |                              *** Forwarding one item twice
+        //                      (F,_,9)       (T,7,_)          ---- x3
+        //                       /   \         /   \                    (To reproduce: look at actual ids and sorting)
+        //                       F   T         F   T
         */
         __bdd out = bdd_ite(bdd_x1_xor_x2_2, bdd_1, bdd_2);
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,2,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1,3,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,5,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,5,6)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,6,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,4,7)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (T,7,_)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,3), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,3), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,9)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (2,5,5)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,5,6)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,6,4)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (2,4,7)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,3)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (T,7,_)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,9)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1536,13 +1534,13 @@ go_bandit([]() {
       it("should compute (~x0 & ~x1 & x2) ? bdd_2 : bdd_4", [&]() {
         shared_levelized_file<bdd::node_t> bdd_if;
         /*
-                              1       ---- x0
-                             / \
-                             2 F      ---- x1
-                             / \
-                             3 F       ---- x2
-                            / \
-                            F T
+        //                      1       ---- x0
+        //                     / \
+        //                     2 F      ---- x1
+        //                     / \
+        //                     3 F       ---- x2
+        //                    / \
+        //                    F T
         */
 
         {
@@ -1553,19 +1551,19 @@ go_bandit([]() {
         }
 
         /*
-                                        (1,1,1)                  ---- x0
-                                 ________/   \
-                                /             \
-                            (2,2,2)            \                 ---- x1
-                            /     \             \
-                      (3,4,4)     (F,_,5)     (F,_,3)            ---- x2
-                       /   \       /   \       /   \
-                  (F,_,6) (T,8,_) F (F,_,7)    T   F             ---- x3
-                    /   \   /   \     /   \
-                    T   F   T   F     F   T
-
-                  Where the order for x2 is (F,_,3), (3,4,4), (F,_,5) because the
-                  (3,4,4) node needs to forward (3,4,_) information once.
+        //                                (1,1,1)                  ---- x0
+        //                         ________/   \
+        //                        /             \
+        //                    (2,2,2)            \                 ---- x1
+        //                    /     \             \
+        //              (3,4,4)     (F,_,5)     (F,_,3)            ---- x2
+        //               /   \       /   \       /   \
+        //          (F,_,6) (T,8,_) F (F,_,7)    T   F             ---- x3
+        //           /   \   /   \     /   \
+        //           T   F   T   F     F   T
+        //
+        //          Where the order for x2 is (F,_,3), (3,4,4), (F,_,5) because the
+        //          (3,4,4) node needs to forward (3,4,_) information once.
         */
 
         __bdd out = bdd_ite(bdd_if, bdd_2, bdd_4);
@@ -1573,50 +1571,50 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,2,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,6)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (T,8,_)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,7)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,5)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,6)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (T,8,_)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,7)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1645,13 +1643,13 @@ go_bandit([]() {
       it("should compute (x0 | (x1 & x2)) ? bdd_8 : bdd_7", [&]() {
         shared_levelized_file<bdd::node_t> bdd_if;
         /*
-                                1        ---- x0
-                               / \
-                               2 T       ---- x1
-                              / \
-                              F 3        ---- x2
-                               / \
-                               F T
+        //                        1        ---- x0
+        //                       / \
+        //                       2 T       ---- x1
+        //                      / \
+        //                      F 3        ---- x2
+        //                       / \
+        //                       F T
         */
         {
           node_writer nw_if(bdd_if);
@@ -1662,16 +1660,16 @@ go_bandit([]() {
         }
 
         /*
-                                      (1,1,1)        ---- x0
-                              _________/   \
-                             /             |
-                         (2,2,2)           |         ---- x1
-                          /   \            |
-                     (F,_,3) (3,4,4)       |         ---- x2
-                      /   \   /   \________|
-                      F  (F,_,5)        (T,4,_)      ---- x3
-                          /   \          /   \
-                          F   T          T   F
+        //                              (1,1,1)        ---- x0
+        //                      _________/   \
+        //                     /             |
+        //                 (2,2,2)           |         ---- x1
+        //                  /   \            |
+        //             (F,_,3) (3,4,4)       |         ---- x2
+        //              /   \   /   \________|
+        //              F  (F,_,5)        (T,4,_)      ---- x3
+        //                  /   \          /   \
+        //                  F   T          T   F
         */
 
         __bdd out = bdd_ite(bdd_if, bdd_8, bdd_7);
@@ -1679,38 +1677,38 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,2,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (T,4,_)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,1) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,3)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,5)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (T,4,_)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1738,16 +1736,16 @@ go_bandit([]() {
 
       it("should compute bdd_6 ? bdd_4 : bdd_2", [&]() {
         /*
-                                        (1,1,1)                           ---- x0
-                               __________/   \___________
-                              /                          \
-                           (F,_,2)                    (2,3,3)             ---- x1
-                            /     \                     /   \
-                      (F,_,4)   (F,_,5)           (3,3,6) (4,3,7)         ---- x2
-                        /   \     /   \             /   \   /   \
-                       F (F,_,8) F (F,_,9)         T   F   T   T          ---- x3
-                          /   \     /   \
-                          T   F     F   T
+        //                                (1,1,1)                           ---- x0
+        //                       __________/   \___________
+        //                      /                          \
+        //                   (F,_,2)                    (2,3,3)             ---- x1
+        //                    /     \                     /   \
+        //              (F,_,4)   (F,_,5)           (3,3,6) (4,3,7)         ---- x2
+        //                /   \     /   \             /   \   /   \
+        //               F (F,_,8) F (F,_,9)         T   F   T   T          ---- x3
+        //                  /   \     /   \
+        //                  T   F     F   T
         */
 
         __bdd out = bdd_ite(bdd_6, bdd_4, bdd_2);
@@ -1755,56 +1753,56 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2,3,3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,4)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,5)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,3,6)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,3,7)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,8)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (F,_,9)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,4)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,5)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,3,6)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,2)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,2), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,3,7)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,3)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,3), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,8)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (F,_,9)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         level_info_test_stream levels(out);
 
@@ -1833,11 +1831,11 @@ go_bandit([]() {
       it("should merely zip disjunct levels if possible [1]", [&]() {
         shared_levelized_file<bdd::node_t> bdd_x1_and_x3;
         /*
-                           1      ---- x1
-                          / \
-                          F 2     ---- x3
-                           / \
-                           T F
+        //                   1      ---- x1
+        //                  / \
+        //                  F 2     ---- x3
+        //                   / \
+        //                   T F
         */
 
         {
@@ -1853,23 +1851,23 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3,42,
-                                                       terminal_F,
-                                                       terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2,0,
-                                                       terminal_F,
-                                                       terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1,0,
-                                                       terminal_F,
-                                                       ptr_uint64(3,42))));
+                                                terminal_F,
+                                                ptr_uint64(3,42))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(0,0,
-                                                       ptr_uint64(1,0),
-                                                       ptr_uint64(2,0))));
+                                                ptr_uint64(1,0),
+                                                ptr_uint64(2,0))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -1906,15 +1904,15 @@ go_bandit([]() {
       it("should merely zip disjunct levels if possible [2]", [&]() {
         shared_levelized_file<bdd::node_t> bdd_then;
         /*
-                           _1_      ---- x2
-                          /   \
-                          2   3     ---- x3
-                         / \ / \
-                         T 4 T 5    ---- x4
-                          / \ / \
-                          F T T 6   ---- x6
-                               / \
-                               T F
+        //                   _1_      ---- x2
+        //                  /   \
+        //                  2   3     ---- x3
+        //                 / \ / \
+        //                 T 4 T 5    ---- x4
+        //                  / \ / \
+        //                  F T T 6   ---- x6
+        //                       / \
+        //                       T F
         */
 
         {
@@ -1929,11 +1927,11 @@ go_bandit([]() {
 
         shared_levelized_file<bdd::node_t> bdd_else;
         /*
-                          _1_      ---- x5
-                         /   \
-                         2   3     ---- x8
-                        / \ / \
-                        T F F T
+        //                  _1_      ---- x5
+        //                 /   \
+        //                 2   3     ---- x8
+        //                / \ / \
+        //                T F F T
         */
 
         {
@@ -1951,63 +1949,63 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(8,1,
-                                                       terminal_T,
-                                                       terminal_F)));
+                                                terminal_T,
+                                                terminal_F)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(8,0,
-                                                       terminal_F,
-                                                       terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(6,1,
-                                                       terminal_T,
-                                                       terminal_F)));
+                                                terminal_T,
+                                                terminal_F)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(5,0,
-                                                       ptr_uint64(8,0),
-                                                       ptr_uint64(8,1))));
+                                                ptr_uint64(8,0),
+                                                ptr_uint64(8,1))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(4,1,
-                                                       terminal_T,
-                                                       ptr_uint64(6,1))));
+                                                terminal_T,
+                                                ptr_uint64(6,1))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(4,0,
-                                                       terminal_F,
-                                                       terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3,2,
-                                                       terminal_T,
-                                                       ptr_uint64(4,1))));
+                                                terminal_T,
+                                                ptr_uint64(4,1))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3,0,
-                                                       terminal_T,
-                                                       ptr_uint64(4,0))));
+                                                terminal_T,
+                                                ptr_uint64(4,0))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2,0,
-                                                       ptr_uint64(3,0),
-                                                       ptr_uint64(3,2))));
+                                                ptr_uint64(3,0),
+                                                ptr_uint64(3,2))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1,1,
-                                                       ptr_uint64(5,0),
-                                                       ptr_uint64(2,0))));
+                                                ptr_uint64(5,0),
+                                                ptr_uint64(2,0))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1,0,
-                                                       ptr_uint64(2,0),
-                                                       ptr_uint64(5,0))));
+                                                ptr_uint64(2,0),
+                                                ptr_uint64(5,0))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(0,0,
-                                                       ptr_uint64(1,0),
-                                                       ptr_uint64(1,1))));
+                                                ptr_uint64(1,0),
+                                                ptr_uint64(1,1))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -2105,8 +2103,8 @@ go_bandit([]() {
         {
           node_writer nw_b(bdd_b);
           nw_b << node(3, node::MAX_ID,   terminal_F, terminal_T)
-              << node(3, node::MAX_ID-1, terminal_T, terminal_F)
-              << node(1, node::MAX_ID,   ptr_uint64(3, ptr_uint64::MAX_ID), ptr_uint64(3, ptr_uint64::MAX_ID));
+               << node(3, node::MAX_ID-1, terminal_T, terminal_F)
+               << node(1, node::MAX_ID,   ptr_uint64(3, ptr_uint64::MAX_ID), ptr_uint64(3, ptr_uint64::MAX_ID));
         }
         AssertThat(adiar::is_canonical(bdd(bdd_b)), Is().True());
 
@@ -2167,30 +2165,30 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -2219,30 +2217,30 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -305,11 +305,11 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -333,29 +333,29 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (4,5)
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (5,_)
-                   Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -382,29 +382,29 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,   ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (4,5)
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,   ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (5,_)
-                   Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -431,29 +431,29 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,   ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high()
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high()
-                   Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to its own leaf
-                   Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -482,29 +482,29 @@ go_bandit([]() {
         // request without forwarding n3 through the secondary priority queue
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // n3
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // n3
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.high()
-                   Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -533,21 +533,21 @@ go_bandit([]() {
         // request without forwarding n3 through the secondary priority queue
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.high()
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -576,21 +576,21 @@ go_bandit([]() {
         // request without forwarding n3 through the secondary priority queue
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.high()
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -629,20 +629,20 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to quantification of x2
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -669,42 +669,42 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (8,F)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,1) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(true) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (8,F)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,1), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,1)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
@@ -734,19 +734,19 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,5)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,5)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,5)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
@@ -773,27 +773,27 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
 
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
@@ -824,27 +824,27 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
 
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
@@ -1485,11 +1485,11 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1513,29 +1513,29 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1562,29 +1562,29 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to 5.low()
-                   Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high() and 4.high()
-                   Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1614,42 +1614,42 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (8,T)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (8,T)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,1), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,1)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
@@ -1679,27 +1679,27 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
         AssertThat(arcs.pull_terminal(), // false due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(false) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(true) }));
+                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
 
 
         AssertThat(arcs.can_pull_terminal(), Is().False());

--- a/test/adiar/bdd/test_restrict.cpp
+++ b/test/adiar/bdd/test_restrict.cpp
@@ -55,24 +55,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n2.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n2.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2.uid()), n5.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), true,  n5.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n5.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), true,  terminal_T }));
 
       level_info_test_stream meta_arcs(out);
 
@@ -116,18 +116,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n3.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n3.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n3.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n3.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_T }));
 
       level_info_test_stream meta_arcs(out);
 
@@ -170,30 +170,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n3.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n3.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n4.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n4.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n4.uid()), n5.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n4.uid(), true,  n5.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n5.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), true,  terminal_T }));
 
       level_info_test_stream meta_arcs(out);
 
@@ -237,24 +237,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), n3.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), false, n3.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2.uid()), n4.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), true,  n4.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n4.uid()), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), true,  terminal_F }));
 
       level_info_test_stream meta_arcs(out);
 
@@ -295,10 +295,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_T }));
 
       level_info_test_stream meta_arcs(out);
 
@@ -480,24 +480,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n2.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n2.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n3.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n3.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2.uid()), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), true,  terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -555,24 +555,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n2.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n2.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n3.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n3.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2.uid()), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), true,  terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_F} ));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_F} ));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -636,36 +636,36 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n5.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n5.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n7.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n7.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n5.uid()), n8.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n5.uid(), true,  n8.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n7.uid(), n9.uid() }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n7.uid(), false, n9.uid() }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n7.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n7.uid(), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n8.uid(), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n8.uid(), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n8.uid()), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n8.uid(), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n9.uid(), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n9.uid(), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n9.uid()), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n9.uid(), true,  terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/internal/algorithms/test_convert.cpp
+++ b/test/adiar/internal/algorithms/test_convert.cpp
@@ -151,18 +151,18 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                              terminal_T,
-                                                              terminal_F)));
+                                                       terminal_T,
+                                                       terminal_F)));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                              ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                              terminal_F)));
+                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       terminal_F)));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                              ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                              terminal_F)));
+                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
+                                                       terminal_F)));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -194,16 +194,16 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -227,24 +227,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -288,18 +288,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -320,18 +320,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -352,18 +352,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -430,13 +430,13 @@ go_bandit([]() {
 
       it("bridges internal arcs on { { 0,2 }, { 1,2 } { 0,1,2 } } with dom = { 0,1,2 } ", [&]() {
         /*
-                  _1_     ---- x0
-                /   \
-                2   3    ---- x1
-                / \ //
-                F  4      ---- x2
-                  / \
-                  F T
+        //          _1_     ---- x0
+        //         /   \
+        //         2   3    ---- x1
+        //        / \ //
+        //        F  4      ---- x2
+        //          / \
+        //          F T
         */
 
         shared_levelized_file<zdd::node_t> nf;
@@ -453,36 +453,36 @@ go_bandit([]() {
 
         __bdd out = bdd_from(in, dom_012);
         /*
-                _1_     ---- x0
-              /   \
-              2   /    ---- x1
-              / \ /
-              F  4      ---- x2
-                / \
-                F T
+        //        _1_     ---- x0
+        //       /   \
+        //       2   /    ---- x1
+        //      / \ /
+        //      F  4      ---- x2
+        //        / \
+        //        F T
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -507,30 +507,30 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -554,36 +554,36 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -620,30 +620,30 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // produced out-of-order
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -680,36 +680,36 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1) -> (2)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (1) -- * -> (3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2) -> (3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // * -> (3)
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (2) -- * -> T
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -732,13 +732,13 @@ go_bandit([]() {
         shared_levelized_file<zdd::node_t> nf_in;
         // In dom = { 0,1,2 }
         /*
-              _1_      ---- x0
-            /   \
-            2   3     ---- x1
-            / \ / \
-            T  4  T    ---- x2
-              / \
-              F T
+        //      _1_      ---- x0
+        //     /   \
+        //     2   3     ---- x1
+        //    / \ / \
+        //    T  4  T    ---- x2
+        //      / \
+        //      F T
         */
         {
           const node n4 = node(2, node::MAX_ID,   terminal_F, terminal_T);
@@ -757,36 +757,36 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -813,21 +813,21 @@ go_bandit([]() {
 
         shared_levelized_file<zdd::node_t> in;
         /*
-                              ---- x0
-
-                    1        ---- x1
-                    / \
-                    | |       ---- x2
-                    \ /
-                    _2_       ---- x3
-                  /   \
-                  3   4      ---- x4
-                  / \ / \
-                  5  6  T     ---- x5
-                / \//
-                F  7         ---- x6
-                  / \
-                  T T
+        //                      ---- x0
+        //
+        //             1        ---- x1
+        //            / \
+        //            | |       ---- x2
+        //            \ /
+        //            _2_       ---- x3
+        //           /   \
+        //           3   4      ---- x4
+        //          / \ / \
+        //          5  6  T     ---- x5
+        //         / \//
+        //         F  7         ---- x6
+        //           / \
+        //           T T
         */
         {
           const node n7 = node(6, node::MAX_ID,   terminal_T, terminal_T);
@@ -844,74 +844,74 @@ go_bandit([]() {
 
         __bdd out = bdd_from(in, dom);
         /*
-                      1       ---- x0
-                     / \
-                     | F      ---- x1
-                     |
-                    _2_       ---- x2
-                   /   \
-                  _3_  F      ---- x3
-                 /   \
-                 4   5        ---- x4
-                / \ / \
-                6 T T 7       ---- x5
-               / \   / \
-               F T   8 F      ---- x6
-                    / \
-                    T F
+        //              1       ---- x0
+        //             / \
+        //             | F      ---- x1
+        //             |
+        //            _2_       ---- x2
+        //           /   \
+        //          _3_  F      ---- x3
+        //         /   \
+        //         4   5        ---- x4
+        //        / \ / \
+        //        6 T T 7       ---- x5
+        //       / \   / \
+        //       F T   8 F      ---- x6
+        //            / \
+        //            T F
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 6
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,0), ptr_uint64(5,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,0), false, ptr_uint64(5,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 7
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(4,1)), ptr_uint64(5,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,1), true,  ptr_uint64(5,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 8
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,1), ptr_uint64(6,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,1), false, ptr_uint64(6,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 1
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 2
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 4
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 5
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 6
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(5,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(5,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(5,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(5,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 7
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(5,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(5,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 8
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(6,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(6,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(6,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(6,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -949,18 +949,18 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                              terminal_T,
-                                                              terminal_F)));
+                                                       terminal_T,
+                                                       terminal_F)));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                              ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                              terminal_F)));
+                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       terminal_F)));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                              ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                              terminal_F)));
+                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
+                                                       terminal_F)));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -986,18 +986,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1065,18 +1065,18 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                              terminal_T,
-                                                              terminal_T)));
+                                                       terminal_T,
+                                                       terminal_T)));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                              ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                              ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                              ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                              ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
+                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1100,24 +1100,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1141,24 +1141,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1189,18 +1189,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1286,18 +1286,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1336,13 +1336,13 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1375,24 +1375,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1429,24 +1429,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1475,18 +1475,18 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                              terminal_T,
-                                                              terminal_T)));
+                                                       terminal_T,
+                                                       terminal_T)));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                              ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                              ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                              ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                              ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
+                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1532,4 +1532,4 @@ go_bandit([]() {
       });
     });
   });
-});
+ });

--- a/test/adiar/internal/algorithms/test_reduce.cpp
+++ b/test/adiar/internal/algorithms/test_reduce.cpp
@@ -71,15 +71,15 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n4 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n4 });
 
-          aw.push_terminal({ flag(n2),terminal_T });
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n4,terminal_F });
-          aw.push_terminal({ flag(n4),terminal_T });
+          aw.push_terminal({ n2, true,  terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -173,17 +173,17 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1, n2 });
-          aw.push_internal({ flag(n1), n3 });
-          aw.push_internal({ n3, n4 });
-          aw.push_internal({ flag(n2), n5 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n3, false, n4 });
+          aw.push_internal({ n2, true,  n5 });
 
-          aw.push_terminal({ n2, terminal_F });
-          aw.push_terminal({ flag(n3), terminal_T });
-          aw.push_terminal({ n4, terminal_F });
-          aw.push_terminal({ flag(n4), terminal_T });
-          aw.push_terminal({ n5, terminal_F });
-          aw.push_terminal({ flag(n5), terminal_T });
+          aw.push_terminal({ n2, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(2,2u));
@@ -279,19 +279,19 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ n4,n5 });
-          aw.push_internal({ flag(n3),n6 });
-          aw.push_internal({ flag(n4),n6 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n3, false, n5 });
+          aw.push_internal({ n4, false, n5 });
+          aw.push_internal({ n3, true,  n6 });
+          aw.push_internal({ n4, true,  n6 });
 
-          aw.push_terminal({ flag(n2),terminal_T });
-          aw.push_terminal({ n5,terminal_F });
-          aw.push_terminal({ flag(n5),terminal_T });
-          aw.push_terminal({ n6,terminal_T });
-          aw.push_terminal({ flag(n6),terminal_F });
+          aw.push_terminal({ n2, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
+          aw.push_terminal({ n6, false, terminal_T });
+          aw.push_terminal({ n6, true,  terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -398,17 +398,17 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ n4,n5 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n3, false, n5 });
+          aw.push_internal({ n4, false, n5 });
 
-          aw.push_terminal({ flag(n2),terminal_T });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ flag(n4),terminal_T });
-          aw.push_terminal({ n5,terminal_F });
-          aw.push_terminal({ flag(n5),terminal_T });
+          aw.push_terminal({ n2, true,  terminal_T });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -518,21 +518,21 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n5 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ flag(n3),n6 });
-          aw.push_internal({ n5,n7 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n2, true,  n5 });
+          aw.push_internal({ n3, false, n5 });
+          aw.push_internal({ n3, true,  n6 });
+          aw.push_internal({ n5, false, n7 });
 
-          aw.push_terminal({ n4,terminal_F });
-          aw.push_terminal({ flag(n4),terminal_T });
-          aw.push_terminal({ flag(n5),terminal_T });
-          aw.push_terminal({ n6,terminal_F });
-          aw.push_terminal({ flag(n6),terminal_T });
-          aw.push_terminal({ n7,terminal_F });
-          aw.push_terminal({ flag(n7),terminal_T });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
+          aw.push_terminal({ n5, true,  terminal_T });
+          aw.push_terminal({ n6, false, terminal_F });
+          aw.push_terminal({ n6, true,  terminal_T });
+          aw.push_terminal({ n7, false, terminal_F });
+          aw.push_terminal({ n7, true, terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -651,19 +651,19 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n5 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ flag(n3),n6 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n2, true,  n5 });
+          aw.push_internal({ n3, false, n5 });
+          aw.push_internal({ n3, true,  n6 });
 
-          aw.push_terminal({ n4,terminal_F });
-          aw.push_terminal({ flag(n4),terminal_T });
-          aw.push_terminal({ n5,terminal_F });
-          aw.push_terminal({ flag(n5),terminal_T });
-          aw.push_terminal({ n6,terminal_T });
-          aw.push_terminal({ flag(n6),terminal_F });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
+          aw.push_terminal({ n6, false, terminal_T });
+          aw.push_terminal({ n6, true,  terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -761,19 +761,19 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n5 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ flag(n3),n6 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n2, true,  n5 });
+          aw.push_internal({ n3, false, n5 });
+          aw.push_internal({ n3, true,  n6 });
 
-          aw.push_terminal({ n4,terminal_T });
-          aw.push_terminal({ flag(n4),terminal_F });
-          aw.push_terminal({ n5,terminal_T });
-          aw.push_terminal({ flag(n5),terminal_F });
-          aw.push_terminal({ n6,terminal_F });
-          aw.push_terminal({ flag(n6),terminal_T });
+          aw.push_terminal({ n4, false, terminal_T });
+          aw.push_terminal({ n4, true,  terminal_F });
+          aw.push_terminal({ n5, false, terminal_T });
+          aw.push_terminal({ n5, true,  terminal_F });
+          aw.push_terminal({ n6, false, terminal_F });
+          aw.push_terminal({ n6, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -870,15 +870,15 @@ go_bandit([]() {
         { // Garbage collect writer early
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n3 });
-          aw.push_internal({ flag(n2),n4 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n3 });
+          aw.push_internal({ n2, true,  n4 });
 
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n4,terminal_T });
-          aw.push_terminal({ flag(n4),terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_T });
+          aw.push_terminal({ n4, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -973,17 +973,17 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n3 });
-          aw.push_internal({ flag(n2),n4 });
-          aw.push_internal({ n4,n5 });
-          aw.push_internal({ flag(n4),n5 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n3 });
+          aw.push_internal({ n2, true,  n4 });
+          aw.push_internal({ n4, false, n5 });
+          aw.push_internal({ n4, true,  n5 });
 
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n5,terminal_F });
-          aw.push_terminal({ flag(n5),terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -1086,17 +1086,17 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n4 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ flag(n3),n5 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n2, true,  n4 });
+          aw.push_internal({ n3, false, n5 });
+          aw.push_internal({ n3, true,  n5 });
 
-          aw.push_terminal({ n4,terminal_F });
-          aw.push_terminal({ flag(n4),terminal_T });
-          aw.push_terminal({ n5,terminal_T });
-          aw.push_terminal({ flag(n5),terminal_F });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_T });
+          aw.push_terminal({ n5, true,  terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -1185,15 +1185,15 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ n2,n3 });
-          aw.push_internal({ flag(n2),n4 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n2, false, n3 });
+          aw.push_internal({ n2, true,  n4 });
 
-          aw.push_terminal({ flag(n1),terminal_T });
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n4,terminal_F });
-          aw.push_terminal({ flag(n4),terminal_T });
+          aw.push_terminal({ n1, true,  terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -1283,19 +1283,19 @@ go_bandit([]() {
           { // Garbage collect writer to free write-lock
             arc_writer aw(in);
 
-            aw.push_internal({ n1, n2 });
-            aw.push_internal({ flag(n1), n3 });
-            aw.push_internal({ flag(n2), n4 });
-            aw.push_internal({ n3, n4 });
-            aw.push_internal({ flag(n3), n5 });
-            aw.push_internal({ n2, n6 });
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+            aw.push_internal({ n2, true,  n4 });
+            aw.push_internal({ n3, false, n4 });
+            aw.push_internal({ n3, true,  n5 });
+            aw.push_internal({ n2, false, n6 });
 
-            aw.push_terminal({ n4, terminal_F });
-            aw.push_terminal({ flag(n4), terminal_T });
-            aw.push_terminal({ n5, terminal_F });
-            aw.push_terminal({ flag(n5), terminal_T });
-            aw.push_terminal({ n6, terminal_F });
-            aw.push_terminal({ flag(n6), terminal_T });
+            aw.push_terminal({ n4, false, terminal_F });
+            aw.push_terminal({ n4, true,  terminal_T });
+            aw.push_terminal({ n5, false, terminal_F });
+            aw.push_terminal({ n5, true,  terminal_T });
+            aw.push_terminal({ n6, false, terminal_F });
+            aw.push_terminal({ n6, true,  terminal_T });
 
             aw.push(level_info(0,1u));
             aw.push(level_info(1,2u));
@@ -1406,15 +1406,15 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n3 });
-          aw.push_internal({ flag(n2),n4 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n3 });
+          aw.push_internal({ n2, true,  n4 });
 
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n4,terminal_F });
-          aw.push_terminal({ flag(n4),terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -1490,25 +1490,25 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ n3,n4 });
-          aw.push_internal({ flag(n2),n5 });
-          aw.push_internal({ flag(n3),n5 });
-          aw.push_internal({ n4,n6 });
-          aw.push_internal({ flag(n4),n7 });
-          aw.push_internal({ n5,n7 });
-          aw.push_internal({ flag(n5),n8 });
-          aw.push_internal({ flag(n6),n9 });
-          aw.push_internal({ n7,n9 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n3, false, n4 });
+          aw.push_internal({ n2, true,  n5 });
+          aw.push_internal({ n3, true,  n5 });
+          aw.push_internal({ n4, false, n6 });
+          aw.push_internal({ n4, true,  n7 });
+          aw.push_internal({ n5, false, n7 });
+          aw.push_internal({ n5, true,  n8 });
+          aw.push_internal({ n6, true,  n9 });
+          aw.push_internal({ n7, false, n9 });
 
-          aw.push_terminal({ n6,terminal_F });
-          aw.push_terminal({ flag(n7),terminal_T });
-          aw.push_terminal({ n8,terminal_F });
-          aw.push_terminal({ flag(n8),terminal_T });
-          aw.push_terminal({ n9,terminal_F });
-          aw.push_terminal({ flag(n9),terminal_T });
+          aw.push_terminal({ n6, false, terminal_F });
+          aw.push_terminal({ n7, true,  terminal_T });
+          aw.push_terminal({ n8, false, terminal_F });
+          aw.push_terminal({ n8, true,  terminal_T });
+          aw.push_terminal({ n9, false, terminal_F });
+          aw.push_terminal({ n9, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -1628,19 +1628,19 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ n2,n3 });
-          aw.push_internal({ n3,n4 });
-          aw.push_internal({ flag(n3),n5 });
-          aw.push_internal({ flag(n1),n6 });
-          aw.push_internal({ flag(n2),n6 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n2, false, n3 });
+          aw.push_internal({ n3, false, n4 });
+          aw.push_internal({ n3, true,  n5 });
+          aw.push_internal({ n1, true,  n6 });
+          aw.push_internal({ n2, true,  n6 });
 
-          aw.push_terminal({ n4,terminal_T });
-          aw.push_terminal({ flag(n4),terminal_F });
-          aw.push_terminal({ n5,terminal_F });
-          aw.push_terminal({ flag(n5),terminal_T });
-          aw.push_terminal({ n6,terminal_T });
-          aw.push_terminal({ flag(n6),terminal_T });
+          aw.push_terminal({ n4, false, terminal_T });
+          aw.push_terminal({ n4, true,  terminal_F });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
+          aw.push_terminal({ n6, false, terminal_T });
+          aw.push_terminal({ n6, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -1744,8 +1744,8 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_terminal({ n1,terminal_F });
-          aw.push_terminal({ flag(n1),terminal_F });
+          aw.push_terminal({ n1, false, terminal_F });
+          aw.push_terminal({ n1, true,  terminal_F });
 
           aw.push(level_info(0,1u));
         }
@@ -1802,11 +1802,11 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
+          aw.push_internal({ n1, true,  n2 });
 
-          aw.push_terminal({ n1,terminal_T });
-          aw.push_terminal({ n2,terminal_T });
-          aw.push_terminal({ flag(n2),terminal_T });
+          aw.push_terminal({ n1, false, terminal_T });
+          aw.push_terminal({ n2, false, terminal_T });
+          aw.push_terminal({ n2, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -1859,8 +1859,8 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_terminal({ n1,terminal_F });
-          aw.push_terminal({ flag(n1),terminal_T });
+          aw.push_terminal({ n1, false, terminal_F });
+          aw.push_terminal({ n1, true,  terminal_T });
 
           aw.push(level_info(0u,1u));
         }
@@ -1935,29 +1935,29 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n4 });
-          aw.push_internal({ n3,n4 });
-          aw.push_internal({ flag(n3),n5 });
-          aw.push_internal({ n4,n6 });
-          aw.push_internal({ flag(n4),n6 });
-          aw.push_internal({ n5,n6 });
-          aw.push_internal({ flag(n5),n7 });
-          aw.push_internal({ n6,n8 });
-          aw.push_internal({ flag(n6),n8 });
-          aw.push_internal({ n7,n8 });
-          aw.push_internal({ flag(n7),n9 });
-          aw.push_internal({ n8,n10 });
-          aw.push_internal({ flag(n8),n10 });
-          aw.push_internal({ n9,n10 });
-          aw.push_internal({ flag(n9),n11 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, false, n4 });
+          aw.push_internal({ n2, true,  n4 });
+          aw.push_internal({ n3, false, n4 });
+          aw.push_internal({ n3, true,  n5 });
+          aw.push_internal({ n4, false, n6 });
+          aw.push_internal({ n4, true,  n6 });
+          aw.push_internal({ n5, false, n6 });
+          aw.push_internal({ n5, true,  n7 });
+          aw.push_internal({ n6, false, n8 });
+          aw.push_internal({ n6, true,  n8 });
+          aw.push_internal({ n7, false, n8 });
+          aw.push_internal({ n7, true,  n9 });
+          aw.push_internal({ n8, false, n10 });
+          aw.push_internal({ n8, true,  n10 });
+          aw.push_internal({ n9, false, n10 });
+          aw.push_internal({ n9, true,  n11 });
 
-          aw.push_terminal({ n10,terminal_T });
-          aw.push_terminal({ flag(n10),terminal_F });
-          aw.push_terminal({ n11,terminal_F });
-          aw.push_terminal({ flag(n11),terminal_T });
+          aw.push_terminal({ n10, false, terminal_T });
+          aw.push_terminal({ n10, true,  terminal_F });
+          aw.push_terminal({ n11, false, terminal_F });
+          aw.push_terminal({ n11, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -2098,35 +2098,35 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n5 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ flag(n3),n6 });
-          aw.push_internal({ n4,n7 });
-          aw.push_internal({ flag(n4),n8 });
-          aw.push_internal({ n5,n8 });
-          aw.push_internal({ flag(n5),n8 });
-          aw.push_internal({ n6,n8 });
-          aw.push_internal({ flag(n6),n9 });
-          aw.push_internal({ n7,n10 });
-          aw.push_internal({ flag(n7),n11 });
-          aw.push_internal({ n8,n11 });
-          aw.push_internal({ flag(n8),n11 });
-          aw.push_internal({ n9,n11 });
-          aw.push_internal({ flag(n9),n12 });
-          aw.push_internal({ flag(n10),n13 });
-          aw.push_internal({ n11,n13 });
-          aw.push_internal({ flag(n11),n13 });
-          aw.push_internal({ n12,n13 });
-          aw.push_internal({ n10,n14 });
-          aw.push_internal({ flag(n12),n14 });
+          aw.push_internal({ n1,  false, n2 });
+          aw.push_internal({ n1,  true,  n3 });
+          aw.push_internal({ n2,  false, n4 });
+          aw.push_internal({ n2,  true,  n5 });
+          aw.push_internal({ n3,  false, n5 });
+          aw.push_internal({ n3,  true,  n6 });
+          aw.push_internal({ n4,  false, n7 });
+          aw.push_internal({ n4,  true,  n8 });
+          aw.push_internal({ n5,  false, n8 });
+          aw.push_internal({ n5,  true,  n8 });
+          aw.push_internal({ n6,  false, n8 });
+          aw.push_internal({ n6,  true,  n9 });
+          aw.push_internal({ n7,  false, n10 });
+          aw.push_internal({ n7,  true,  n11 });
+          aw.push_internal({ n8,  false, n11 });
+          aw.push_internal({ n8,  true,  n11 });
+          aw.push_internal({ n9,  false, n11 });
+          aw.push_internal({ n9,  true,  n12 });
+          aw.push_internal({ n10, true,  n13 });
+          aw.push_internal({ n11, false, n13 });
+          aw.push_internal({ n11, true,  n13 });
+          aw.push_internal({ n12, false, n13 });
+          aw.push_internal({ n10, false, n14 });
+          aw.push_internal({ n12, true,  n14 });
 
-          aw.push_terminal({ n13,terminal_T });
-          aw.push_terminal({ flag(n13),terminal_F });
-          aw.push_terminal({ n14,terminal_F });
-          aw.push_terminal({ flag(n14),terminal_T });
+          aw.push_terminal({ n13, false, terminal_T });
+          aw.push_terminal({ n13, true,  terminal_F });
+          aw.push_terminal({ n14, false, terminal_F });
+          aw.push_terminal({ n14, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -2270,15 +2270,15 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ flag(n2),n4 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, true,  n4 });
 
-          aw.push_terminal({ n2,terminal_F });
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n4,terminal_T });
-          aw.push_terminal({ flag(n4),terminal_T });
+          aw.push_terminal({ n2, false, terminal_F });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_T });
+          aw.push_terminal({ n4, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -2342,11 +2342,11 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
+          aw.push_internal({ n1, true,  n2 });
 
-          aw.push_terminal({ n1,terminal_T });
-          aw.push_terminal({ n2,terminal_T });
-          aw.push_terminal({ flag(n2),terminal_F });
+          aw.push_terminal({ n1, false, terminal_T });
+          aw.push_terminal({ n2, false, terminal_T });
+          aw.push_terminal({ n2, true,  terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -2414,17 +2414,17 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
-          aw.push_internal({ n1,n3 });
-          aw.push_internal({ n2,n3 });
-          aw.push_internal({ flag(n2),n4 });
-          aw.push_internal({ n4,n5 });
+          aw.push_internal({ n1, true,  n2 });
+          aw.push_internal({ n1, false, n3 });
+          aw.push_internal({ n2, false, n3 });
+          aw.push_internal({ n2, true,  n4 });
+          aw.push_internal({ n4, false, n5 });
 
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ flag(n4),terminal_F });
-          aw.push_terminal({ n5,terminal_F });
-          aw.push_terminal({ flag(n5),terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, true,  terminal_F });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -2530,15 +2530,15 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ flag(n3),n4 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n3, true,  n4 });
 
-          aw.push_terminal({ n2,terminal_F });
-          aw.push_terminal({ flag(n2),terminal_T });
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ n4,terminal_T });
-          aw.push_terminal({ flag(n4),terminal_F });
+          aw.push_terminal({ n2, false, terminal_F });
+          aw.push_terminal({ n2, true,  terminal_T });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n4, false, terminal_T });
+          aw.push_terminal({ n4, true,terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -2619,8 +2619,8 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_terminal({ n1,terminal_T });
-          aw.push_terminal({ flag(n1),terminal_F });
+          aw.push_terminal({ n1, false, terminal_T });
+          aw.push_terminal({ n1, true,  terminal_F });
 
           aw.push(level_info(0,1u));
         }
@@ -2679,9 +2679,9 @@ go_bandit([]() {
 
           aw.push_internal({ n1,n2 });
 
-          aw.push_terminal({ flag(n1),terminal_F });
-          aw.push_terminal({ n2,terminal_F });
-          aw.push_terminal({ flag(n2),terminal_T });
+          aw.push_terminal({ n1, true,  terminal_F });
+          aw.push_terminal({ n2, false, terminal_F });
+          aw.push_terminal({ n2, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -2743,11 +2743,11 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ flag(n1),n2 });
+          aw.push_internal({ n1, true,  n2 });
 
-          aw.push_terminal({ n1,terminal_F });
-          aw.push_terminal({ n2,terminal_F });
-          aw.push_terminal({ flag(n2),terminal_F });
+          aw.push_terminal({ n1, false, terminal_F });
+          aw.push_terminal({ n2, false, terminal_F });
+          aw.push_terminal({ n2, true,  terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,1u));
@@ -2800,8 +2800,8 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_terminal({ n1,terminal_F });
-          aw.push_terminal({ flag(n1),terminal_T });
+          aw.push_terminal({ n1, false, terminal_F });
+          aw.push_terminal({ n1, true,  terminal_T });
 
           aw.push(level_info(42,1u));
         }
@@ -2857,8 +2857,8 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_terminal({ n1,terminal_T });
-          aw.push_terminal({ flag(n1),terminal_T });
+          aw.push_terminal({ n1, false, terminal_T });
+          aw.push_terminal({ n1, true,  terminal_T });
 
           aw.push(level_info(12,1u));
         }
@@ -2935,29 +2935,29 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ n2,n4 });
-          aw.push_internal({ flag(n2),n5 });
-          aw.push_internal({ n3,n5 });
-          aw.push_internal({ n4,n6 });
-          aw.push_internal({ flag(n4),n7 });
-          aw.push_internal({ n5,n7 });
-          aw.push_internal({ n6,n8 });
-          aw.push_internal({ flag(n6),n9 });
-          aw.push_internal({ n7,n9 });
-          aw.push_internal({ n8,n10 });
-          aw.push_internal({ flag(n8),n11 });
-          aw.push_internal({ n9,n11 });
+          aw.push_internal({ n1,  false, n2 });
+          aw.push_internal({ n1,  true,  n3 });
+          aw.push_internal({ n2,  false, n4 });
+          aw.push_internal({ n2,  true,  n5 });
+          aw.push_internal({ n3,  false, n5 });
+          aw.push_internal({ n4,  false, n6 });
+          aw.push_internal({ n4,  true,  n7 });
+          aw.push_internal({ n5,  false, n7 });
+          aw.push_internal({ n6,  false, n8 });
+          aw.push_internal({ n6,  true,  n9 });
+          aw.push_internal({ n7,  false, n9 });
+          aw.push_internal({ n8,  false, n10 });
+          aw.push_internal({ n8,  true,  n11 });
+          aw.push_internal({ n9,  false, n11 });
 
-          aw.push_terminal({ flag(n3),terminal_F });
-          aw.push_terminal({ flag(n5),terminal_F });
-          aw.push_terminal({ flag(n7),terminal_F });
-          aw.push_terminal({ flag(n9),terminal_F });
-          aw.push_terminal({ n10,terminal_F });
-          aw.push_terminal({ flag(n10),terminal_T });
-          aw.push_terminal({ n11,terminal_T });
-          aw.push_terminal({ flag(n11),terminal_T });
+          aw.push_terminal({ n3,  true,  terminal_F });
+          aw.push_terminal({ n5,  true,  terminal_F });
+          aw.push_terminal({ n7,  true,  terminal_F });
+          aw.push_terminal({ n9,  true,  terminal_F });
+          aw.push_terminal({ n10, false, terminal_F });
+          aw.push_terminal({ n10, true,  terminal_T });
+          aw.push_terminal({ n11, false, terminal_T });
+          aw.push_terminal({ n11, true,  terminal_T });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));
@@ -3082,15 +3082,15 @@ go_bandit([]() {
         { // Garbage collect writer to free write-lock
           arc_writer aw(in);
 
-          aw.push_internal({ n1,n2 });
-          aw.push_internal({ flag(n1),n3 });
-          aw.push_internal({ flag(n2),n4 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, true,  n4 });
 
-          aw.push_terminal({ n2,terminal_F });
-          aw.push_terminal({ n3,terminal_F });
-          aw.push_terminal({ flag(n3),terminal_T });
-          aw.push_terminal({ n4,terminal_T });
-          aw.push_terminal({ flag(n4),terminal_F });
+          aw.push_terminal({ n2, false, terminal_F });
+          aw.push_terminal({ n3, false, terminal_F });
+          aw.push_terminal({ n3, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_T });
+          aw.push_terminal({ n4, true,  terminal_F });
 
           aw.push(level_info(0,1u));
           aw.push(level_info(1,2u));

--- a/test/adiar/internal/data_types/test_arc.cpp
+++ b/test/adiar/internal/data_types/test_arc.cpp
@@ -1,85 +1,196 @@
 #include "../../../test.h"
 
 go_bandit([]() {
-    describe("adiar/internal/data_types/arc.h", []() {
-        describe("arc", [&]() {
-            const ptr_uint64 terminal_F = ptr_uint64(false);
-            const ptr_uint64 terminal_T = ptr_uint64(true);
+  describe("adiar/internal/data_types/arc.h", []() {
+    describe("arc", []() {
+      const ptr_uint64 terminal_F = ptr_uint64(false);
+      const ptr_uint64 terminal_T = ptr_uint64(true);
 
-            it("should be equal by their content", [&]() {
-                const ptr_uint64 source = ptr_uint64(4,2);
-                const ptr_uint64 target = ptr_uint64(42,3);
-
-                const arc arc_1 = { source, target };
-                const arc arc_2 = { source, target };
-
-                AssertThat(arc_1 == arc_2, Is().True());
-                AssertThat(arc_1 != arc_2, Is().False());
-              });
-
-            it("should unequal by their content", [&]() {
-                const ptr_uint64 node_ptr_1 = ptr_uint64(4,2);
-                const ptr_uint64 node_ptr_2 = ptr_uint64(4,3);
-                const ptr_uint64 node_ptr_3 = ptr_uint64(3,2);
-
-                const arc arc_1 = { node_ptr_1, node_ptr_2 };
-                const arc arc_2 = { node_ptr_1, node_ptr_3 };
-
-                AssertThat(arc_1 == arc_2, Is().False());
-                AssertThat(arc_1 != arc_2, Is().True());
-
-                const arc arc_3 = { node_ptr_1, node_ptr_2 };
-                const arc arc_4 = { flag(node_ptr_1), node_ptr_2 };
-
-                AssertThat(arc_3 == arc_4, Is().False());
-                AssertThat(arc_3 != arc_4, Is().True());
-
-                const arc arc_5 = { node_ptr_1, node_ptr_2 };
-                const arc arc_6 = { node_ptr_3, node_ptr_2 };
-
-                AssertThat(arc_5 == arc_6, Is().False());
-                AssertThat(arc_5 != arc_6, Is().True());
-              });
-
-            it("should recognise low arcs from bit-flag on source", [&]() {
-                const ptr_uint64 node_ptr_1 = ptr_uint64(4,2);
-                const ptr_uint64 node_ptr_2 = ptr_uint64(4,3);
-
-                const arc arc_low = { node_ptr_1, node_ptr_2 };
-                AssertThat(arc_low.is_high(), Is().False());
-              });
-
-            it("should recognise high arcs from bit-flag on source", [&]() {
-                const ptr_uint64 node_ptr_1 = ptr_uint64(4,2);
-                const ptr_uint64 node_ptr_2 = ptr_uint64(4,3);
-
-                const arc arc_high = { flag(node_ptr_1), node_ptr_2 };
-                AssertThat(arc_high.is_high(), Is().True());
-              });
-
-            it("should leave node_ptr target unchanged", [&]() {
-                const arc a = { ptr_uint64(1,0), ptr_uint64(2,0) };
-                AssertThat(~a, Is().EqualTo(a));
-              });
-
-            it("should negate unflagged terminal_ptr target", [&]() {
-                const arc a = { ptr_uint64(1,0), terminal_T };
-                AssertThat(~a, Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
-              });
-
-            it("should negate flagged terminal_ptr target", [&]() {
-                const arc a = { ptr_uint64(1,0), flag(terminal_F) };
-                AssertThat(~a, Is().EqualTo(arc { ptr_uint64(1,0), flag(terminal_T) }));
-              });
-
-            it("should be a POD", [&]() {
-                AssertThat(std::is_pod<arc>::value, Is().True());
-              });
-
-            it("should take up 16 bytes of memory", [&]() {
-                const arc arc = { ptr_uint64(42,2), terminal_F };
-                AssertThat(sizeof(arc), Is().EqualTo(2u * 8u));
-              });
-          });
+      it("should be a POD", []() {
+        AssertThat(std::is_pod<arc>::value, Is().True());
       });
+
+      it("should take up 16 bytes of memory", [&]() {
+        const arc arc = { ptr_uint64(42,2), terminal_F };
+        AssertThat(sizeof(arc), Is().EqualTo(2u * 8u));
+      });
+
+      describe("arc(ptr_t &s, ptr_t &t)", [&] {
+        it("creates arc (42,2) - -> F", [&]() {
+          const arc a = { ptr_uint64(42,2,0), terminal_F };
+
+          AssertThat(a.source().is_node(), Is().True());
+          AssertThat(a.source().label(), Is().EqualTo(42u));
+          AssertThat(a.source().id(), Is().EqualTo(2u));
+
+          AssertThat(a.out_idx(), Is().EqualTo(0u));
+
+          AssertThat(a.target().is_terminal(), Is().True());
+          AssertThat(a.target().value(), Is().EqualTo(false));
+        });
+
+        it("creates arc '(2,0) ---> T'", [&]() {
+          const arc a = { ptr_uint64(2,0,1), terminal_T };
+
+          AssertThat(a.source().is_node(), Is().True());
+          AssertThat(a.source().label(), Is().EqualTo(2u));
+          AssertThat(a.source().id(), Is().EqualTo(0u));
+
+          AssertThat(a.out_idx(), Is().EqualTo(1u));
+
+          AssertThat(a.target().is_terminal(), Is().True());
+          AssertThat(a.target().value(), Is().EqualTo(true));
+        });
+
+        it("creates arc '(2,0) ---> (3,1)'", [&]() {
+          const arc a = { ptr_uint64(2,0,1), ptr_uint64(3,1) };
+
+          AssertThat(a.source().is_node(), Is().True());
+          AssertThat(a.source().label(), Is().EqualTo(2u));
+          AssertThat(a.source().id(), Is().EqualTo(0u));
+
+          AssertThat(a.out_idx(), Is().EqualTo(1u));
+
+          AssertThat(a.target().is_node(), Is().True());
+          AssertThat(a.target().label(), Is().EqualTo(3u));
+          AssertThat(a.target().id(), Is().EqualTo(1u));
+        });
+      });
+
+      describe("arc(ptr_t &s, ptr_t::out_idx o, ptr_t &t)", [&] {
+        it("creates arc '(42,2) - -> F'", [&]() {
+          const arc a = { uid_uint64(42,2), 0, terminal_F };
+
+          AssertThat(a.source().is_node(), Is().True());
+          AssertThat(a.source().label(), Is().EqualTo(42u));
+          AssertThat(a.source().id(), Is().EqualTo(2u));
+
+          AssertThat(a.out_idx(), Is().EqualTo(0u));
+
+          AssertThat(a.target().is_terminal(), Is().True());
+          AssertThat(a.target().value(), Is().EqualTo(false));
+        });
+
+        it("creates arc '(2,0) ---> T'", [&]() {
+          const arc a = { uid_uint64(2,0), 1, terminal_T };
+
+          AssertThat(a.source().is_node(), Is().True());
+          AssertThat(a.source().label(), Is().EqualTo(2u));
+          AssertThat(a.source().id(), Is().EqualTo(0u));
+
+          AssertThat(a.out_idx(), Is().EqualTo(1u));
+
+          AssertThat(a.target().is_terminal(), Is().True());
+          AssertThat(a.target().value(), Is().EqualTo(true));
+        });
+
+        it("creates arc '(2,0) ---> (3,1)'", [&]() {
+          const arc a = { uid_uint64(2,0), 1, ptr_uint64(3,1) };
+
+          AssertThat(a.source().is_node(), Is().True());
+          AssertThat(a.source().label(), Is().EqualTo(2u));
+          AssertThat(a.source().id(), Is().EqualTo(0u));
+
+          AssertThat(a.out_idx(), Is().EqualTo(1u));
+
+          AssertThat(a.target().is_node(), Is().True());
+          AssertThat(a.target().label(), Is().EqualTo(3u));
+          AssertThat(a.target().id(), Is().EqualTo(1u));
+        });
+      });
+
+      describe(".out_idx()", [&] {
+        it("should have the out-index stored in source [{ ptr, ptr }]", [&]() {
+          const arc arc_low = { uid_uint64(0,0).with(false), ptr_uint64(3,2) };
+          AssertThat(arc_low.out_idx(), Is().False());
+        });
+
+        it("should have the out-index stored in source [{ uid, idx, ptr }]", [&]() {
+          const arc arc_low = { uid_uint64(0,0), false, ptr_uint64(3,2) };
+          AssertThat(arc_low.out_idx(), Is().False());
+        });
+
+        it("should have the out-index stored in source [{ ptr, ptr }]", [&]() {
+          const arc arc_high = { uid_uint64(3,2).with(true), ptr_uint64(4,3) };
+          AssertThat(arc_high.out_idx(), Is().True());
+        });
+
+        it("should have the out-index stored in source [{ uid, idx, ptr }]", [&]() {
+          const arc arc_high = { uid_uint64(3,2), true, ptr_uint64(4,3) };
+          AssertThat(arc_high.out_idx(), Is().True());
+        });
+      });
+
+      describe("equality (== / !=)", [&] {
+        it("should be equal by their content [idx = 0]", [&]() {
+          const ptr_uint64 s = ptr_uint64(4,2);
+          const ptr_uint64 t = ptr_uint64(42,3);
+
+          const arc arc_1 = { s, false, t };
+          const arc arc_2 = { s, false, t };
+
+          AssertThat(arc_1 == arc_2, Is().True());
+          AssertThat(arc_1 != arc_2, Is().False());
+        });
+
+        it("should be equal by their content [idx = 1]", [&]() {
+          const ptr_uint64 s = ptr_uint64(0,0);
+          const ptr_uint64 t = ptr_uint64(1,0);
+
+          const arc arc_1 = { s, true, t };
+          const arc arc_2 = { s, true, t };
+
+          AssertThat(arc_1 == arc_2, Is().True());
+          AssertThat(arc_1 != arc_2, Is().False());
+        });
+
+        it("should unequal by their source", [&]() {
+          const uid_uint64 u1 = ptr_uint64(4,2);
+          const uid_uint64 u2 = ptr_uint64(4,3);
+          const uid_uint64 u3 = ptr_uint64(3,2);
+
+          const arc arc_1 = { u1, u2 };
+          const arc arc_2 = { u3, u2 };
+
+          AssertThat(arc_1 == arc_2, Is().False());
+          AssertThat(arc_1 != arc_2, Is().True());
+        });
+
+        it("should unequal based on out index by their content", [&]() {
+          const uid_uint64 u1 = ptr_uint64(4,2);
+          const uid_uint64 u2 = ptr_uint64(4,3);
+
+          const arc arc_1 = { u1.with(false), u2 };
+          const arc arc_2 = { u1.with(true), u2 };
+
+          AssertThat(arc_1 == arc_2, Is().False());
+          AssertThat(arc_1 != arc_2, Is().True());
+        });
+
+        it("should unequal by their target", [&]() {
+          const uid_uint64 u1 = ptr_uint64(4,2);
+          const uid_uint64 u2 = ptr_uint64(4,3);
+          const uid_uint64 u3 = ptr_uint64(3,2);
+
+          const arc arc_1 = { u1, u2 };
+          const arc arc_2 = { u1, u3 };
+
+          AssertThat(arc_1 == arc_2, Is().False());
+          AssertThat(arc_1 != arc_2, Is().True());
+        });
+      });
+
+      describe("negation (~)", [&] {
+        it("should leave node_ptr target unchanged", [&]() {
+          const arc a = { ptr_uint64(1,0), ptr_uint64(2,0) };
+          AssertThat(~a, Is().EqualTo(a));
+        });
+
+        it("should negate terminal_ptr target", [&]() {
+          const arc a = { ptr_uint64(1,0), terminal_T };
+          AssertThat(~a, Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        });
+      });
+    });
   });
+ });

--- a/test/adiar/internal/data_types/test_convert.cpp
+++ b/test/adiar/internal/data_types/test_convert.cpp
@@ -2,50 +2,71 @@
 #include <adiar/internal/data_types/convert.h>
 
 go_bandit([]() {
-    describe("adiar/internal/data_types/convert.h", []() {
-        describe("low_arc_of", []() {
-            it("should extract low arc from node", [&]() {
-                const node n = node(7,42,
-                                      ptr_uint64(8,21),
-                                      ptr_uint64(9,8));
+  describe("adiar/internal/data_types/convert.h", []() {
+    // TODO: more than one unit test per function, please...
 
-                const arc arc = low_arc_of(n);
+    describe("low_arc_of", []() {
+      it("should extract low arc from node", [&]() {
+        const node n(7,42, ptr_uint64(8,21), ptr_uint64(9,8));
+        const arc a = low_arc_of(n);
 
-                AssertThat(arc.source().label(), Is().EqualTo(7u));
-                AssertThat(arc.source().id(), Is().EqualTo(42u));
-                AssertThat(arc.target().label(), Is().EqualTo(8u));
-                AssertThat(arc.target().id(), Is().EqualTo(21u));
-              });
-          });
+        AssertThat(a.source().is_flagged(), Is().False());
+        AssertThat(a.source().label(), Is().EqualTo(7u));
+        AssertThat(a.source().id(), Is().EqualTo(42u));
 
-        describe("high_arc_of", []() {
-            it("should extract high arc from node", [&]() {
-                const node n = node(6,13,
-                                      ptr_uint64(8,21),
-                                      ptr_uint64(9,8));
+        AssertThat(a.out_idx(), Is().EqualTo(0u));
+        AssertThat(a.source().out_idx(), Is().EqualTo(0u));
 
-                const arc arc = high_arc_of(n);
-
-                AssertThat(arc.source().label(), Is().EqualTo(6u));
-                AssertThat(arc.source().id(), Is().EqualTo(13u));
-                AssertThat(arc.target().label(), Is().EqualTo(9u));
-                AssertThat(arc.target().id(), Is().EqualTo(8u));
-              });
-          });
-
-        describe("node_of", []() {
-            it("should combine low and high arcs into single node", [&]() {
-                const arc low_arc = arc(ptr_uint64(17,42), ptr_uint64(9,8));
-                const arc high_arc = arc(flag(ptr_uint64(17,42)), ptr_uint64(8,21));
-
-                const node n = node_of(low_arc, high_arc);
-
-                AssertThat(n.label(), Is().EqualTo(17u));
-                AssertThat(n.id(), Is().EqualTo(42u));
-
-                AssertThat(n.low(), Is().EqualTo(low_arc.target()));
-                AssertThat(n.high(), Is().EqualTo(high_arc.target()));
-              });
-          });
+        AssertThat(a.target().is_flagged(), Is().False());
+        AssertThat(a.target().label(), Is().EqualTo(8u));
+        AssertThat(a.target().id(), Is().EqualTo(21u));
       });
+    });
+
+    describe("high_arc_of", []() {
+      it("should extract high arc from node", [&]() {
+        const node n(6,13, ptr_uint64(8,21), ptr_uint64(9,8));
+        const arc a = high_arc_of(n);
+
+        AssertThat(a.source().is_flagged(), Is().False());
+        AssertThat(a.source().label(), Is().EqualTo(6u));
+        AssertThat(a.source().id(), Is().EqualTo(13u));
+
+        AssertThat(a.out_idx(), Is().EqualTo(1u));
+        AssertThat(a.source().out_idx(), Is().EqualTo(1u));
+
+        AssertThat(a.target().is_flagged(), Is().False());
+        AssertThat(a.target().label(), Is().EqualTo(9u));
+        AssertThat(a.target().id(), Is().EqualTo(8u));
+      });
+    });
+
+    describe("node_of", []() {
+      it("should combine low and high arcs to nodes into single node", [&]() {
+        const arc l_arc(uid_uint64(17,42), false, ptr_uint64(9,8));
+        const arc h_arc(uid_uint64(17,42), true,  ptr_uint64(8,21));
+
+        const node n = node_of(l_arc, h_arc);
+
+        AssertThat(n.label(), Is().EqualTo(17u));
+        AssertThat(n.id(), Is().EqualTo(42u));
+
+        AssertThat(n.low(),  Is().EqualTo(l_arc.target()));
+        AssertThat(n.high(), Is().EqualTo(h_arc.target()));
+      });
+
+      it("should combine low and high arcs to terminals into single node", [&]() {
+        const arc l_arc(uid_uint64(17,42), false, ptr_uint64(false));
+        const arc h_arc(uid_uint64(17,42), true,  ptr_uint64(true));
+
+        const node n = node_of(l_arc, h_arc);
+
+        AssertThat(n.label(), Is().EqualTo(17u));
+        AssertThat(n.id(), Is().EqualTo(42u));
+
+        AssertThat(n.low(),  Is().EqualTo(l_arc.target()));
+        AssertThat(n.high(), Is().EqualTo(h_arc.target()));
+      });
+    });
   });
+ });

--- a/test/adiar/internal/data_types/test_ptr.cpp
+++ b/test/adiar/internal/data_types/test_ptr.cpp
@@ -1,229 +1,240 @@
 #include "../../../test.h"
 
 go_bandit([]() {
-  describe("adiar/internal/data_types/ptr_uint64.h", []() {
-    describe("NIL", [&](){
+  describe("adiar/internal/data_types/ptr.h", []() {
+    describe("ptr_uint64", []() {
       it("should recognise NIL (unflagged)", [&]() {
         const ptr_uint64 some_value = ptr_uint64::NIL();
         AssertThat(some_value.is_nil(), Is().True());
       });
 
-      it("should recognise NIL (flagged)", [&]() {
-        const ptr_uint64 some_value = flag(ptr_uint64::NIL());
-        AssertThat(some_value.is_nil(), Is().True());
-      });
-
-      it("can see whether the flag is set", [&]() {
-        AssertThat(flag(ptr_uint64::NIL()).is_flagged(), Is().True());
-      });
-
-      it("can see whether the flag is not set", [&]() {
-        AssertThat(ptr_uint64::NIL().is_flagged(), Is().False());
-      });
-    });
-
-    describe("terminals", [&](){
-      it("should take up 8 bytes of memory", [&]() {
-        const ptr_uint64 terminal = ptr_uint64(false);
-        AssertThat(sizeof(terminal), Is().EqualTo(8u));
-      });
-
-      describe("flag, unflag, is_flagged", []() {
-        it("is unflagged by default", [&]() {
-          ptr_uint64 p = ptr_uint64(true);
-          AssertThat(p.is_flagged(), Is().False());
-
-          p = ptr_uint64(true);
-          AssertThat(p.is_flagged(), Is().False());
+      describe("NIL", [&](){
+        it("should recognise NIL (unflagged)", [&]() {
+          const ptr_uint64 some_value = ptr_uint64::NIL();
+          AssertThat(some_value.is_nil(), Is().True());
         });
 
-        it("can set the flag", [&]() {
-          ptr_uint64 p = flag(ptr_uint64(false));
-          AssertThat(p.is_flagged(), Is().True());
-
-          p = flag(ptr_uint64(true));
-          AssertThat(p.is_flagged(), Is().True());
+        it("should recognise NIL (flagged)", [&]() {
+          const ptr_uint64 some_value = flag(ptr_uint64::NIL());
+          AssertThat(some_value.is_nil(), Is().True());
         });
 
-        it("can unset the flag", [&]() {
-          ptr_uint64 p = flag(ptr_uint64(false));
-          p = unflag(p);
-          AssertThat(p.is_flagged(), Is().False());
+        it("can see whether the flag is set", [&]() {
+          AssertThat(flag(ptr_uint64::NIL()).is_flagged(), Is().True());
+        });
 
-          p = flag(ptr_uint64(true));
-          p = unflag(p);
-          AssertThat(p.is_flagged(), Is().False());
+        it("can see whether the flag is not set", [&]() {
+          AssertThat(ptr_uint64::NIL().is_flagged(), Is().False());
         });
       });
 
-      describe("is_terminal", []() {
-        it("should recognise Sinks as such", [&]() {
-          const ptr_uint64 terminal_F = ptr_uint64(false);
-          const ptr_uint64 terminal_T = ptr_uint64(true);
-
-          AssertThat(terminal_F.is_terminal(), Is().True());
-          AssertThat(terminal_T.is_terminal(), Is().True());
+      describe("terminals", [&](){
+        it("should take up 8 bytes of memory", [&]() {
+          const ptr_uint64 terminal = ptr_uint64(false);
+          AssertThat(sizeof(terminal), Is().EqualTo(8u));
         });
 
-        it("should not be confused with Node Ptr (unflagged)", [&]() {
-          ptr_uint64 arc_node_max = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
-          AssertThat(arc_node_max.is_terminal(), Is().False());
-          AssertThat(arc_node_max.is_false(), Is().False());
-          AssertThat(arc_node_max.is_true(), Is().False());
+        describe("flag, unflag, is_flagged", []() {
+          it("is unflagged by default", [&]() {
+            ptr_uint64 p = ptr_uint64(true);
+            AssertThat(p.is_flagged(), Is().False());
 
-          ptr_uint64 arc_node_min = ptr_uint64(0,0);
-          AssertThat(arc_node_min.is_terminal(), Is().False());
-          AssertThat(arc_node_min.is_false(), Is().False());
-          AssertThat(arc_node_min.is_true(), Is().False());
+            p = ptr_uint64(true);
+            AssertThat(p.is_flagged(), Is().False());
+          });
 
-          ptr_uint64 arc_node = ptr_uint64(42,18);
-          AssertThat(arc_node.is_terminal(), Is().False());
-          AssertThat(arc_node.is_false(), Is().False());
-          AssertThat(arc_node.is_true(), Is().False());
+          it("can set the flag", [&]() {
+            ptr_uint64 p = flag(ptr_uint64(false));
+            AssertThat(p.is_flagged(), Is().True());
+
+            p = flag(ptr_uint64(true));
+            AssertThat(p.is_flagged(), Is().True());
+          });
+
+          it("can unset the flag", [&]() {
+            ptr_uint64 p = flag(ptr_uint64(false));
+            p = unflag(p);
+            AssertThat(p.is_flagged(), Is().False());
+
+            p = flag(ptr_uint64(true));
+            p = unflag(p);
+            AssertThat(p.is_flagged(), Is().False());
+          });
         });
 
-        it("should not be confused with Node Ptr (flagged)", [&]() {
-          ptr_uint64 arc_node_max = flag(ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID));
-          AssertThat(arc_node_max.is_terminal(), Is().False());
-          AssertThat(arc_node_max.is_false(), Is().False());
-          AssertThat(arc_node_max.is_true(), Is().False());
+        describe("is_terminal", []() {
+          it("should recognise Sinks as such", [&]() {
+            const ptr_uint64 terminal_F = ptr_uint64(false);
+            const ptr_uint64 terminal_T = ptr_uint64(true);
 
-          ptr_uint64 arc_node_min = flag(ptr_uint64(0,0));
-          AssertThat(arc_node_min.is_terminal(), Is().False());
-          AssertThat(arc_node_min.is_false(), Is().False());
-          AssertThat(arc_node_min.is_true(), Is().False());
+            AssertThat(terminal_F.is_terminal(), Is().True());
+            AssertThat(terminal_T.is_terminal(), Is().True());
+          });
 
-          ptr_uint64 arc_node = flag(ptr_uint64(42,18));
-          AssertThat(arc_node.is_terminal(), Is().False());
-          AssertThat(arc_node.is_false(), Is().False());
-          AssertThat(arc_node.is_true(), Is().False());
+          it("should not be confused with Node Ptr (unflagged)", [&]() {
+            ptr_uint64 arc_node_max = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                                 ptr_uint64::MAX_ID);
+
+            AssertThat(arc_node_max.is_terminal(), Is().False());
+            AssertThat(arc_node_max.is_false(), Is().False());
+            AssertThat(arc_node_max.is_true(), Is().False());
+
+            ptr_uint64 arc_node_min = ptr_uint64(0,0);
+            AssertThat(arc_node_min.is_terminal(), Is().False());
+            AssertThat(arc_node_min.is_false(), Is().False());
+            AssertThat(arc_node_min.is_true(), Is().False());
+
+            ptr_uint64 arc_node = ptr_uint64(42,18);
+            AssertThat(arc_node.is_terminal(), Is().False());
+            AssertThat(arc_node.is_false(), Is().False());
+            AssertThat(arc_node.is_true(), Is().False());
+          });
+
+          it("should not be confused with Node Ptr (flagged)", [&]() {
+            ptr_uint64 arc_node_max = flag(ptr_uint64(ptr_uint64::MAX_LABEL,
+                                                      ptr_uint64::MAX_ID));
+
+            AssertThat(arc_node_max.is_terminal(), Is().False());
+            AssertThat(arc_node_max.is_false(), Is().False());
+            AssertThat(arc_node_max.is_true(), Is().False());
+
+            ptr_uint64 arc_node_min = flag(ptr_uint64(0,0));
+            AssertThat(arc_node_min.is_terminal(), Is().False());
+            AssertThat(arc_node_min.is_false(), Is().False());
+            AssertThat(arc_node_min.is_true(), Is().False());
+
+            ptr_uint64 arc_node = flag(ptr_uint64(42,18));
+            AssertThat(arc_node.is_terminal(), Is().False());
+            AssertThat(arc_node.is_false(), Is().False());
+            AssertThat(arc_node.is_true(), Is().False());
+          });
+
+          it("should not be confused with Nil (unflagged)", [&]() {
+            AssertThat(ptr_uint64::NIL().is_terminal(), Is().False());
+          });
+
+          it("should not be confused with Nil (flagged)", [&]() {
+            AssertThat(flag(ptr_uint64::NIL()).is_terminal(), Is().False());
+          });
         });
 
-        it("should not be confused with Nil (unflagged)", [&]() {
-          AssertThat(ptr_uint64::NIL().is_terminal(), Is().False());
+        describe("value", []() {
+          it("retrieves value from false terminal", [&]() {
+            ptr_uint64 p = ptr_uint64(false);
+            AssertThat(p.value(), Is().False());
+          });
+
+          it("retrieves value from true terminal", [&]() {
+            ptr_uint64 p = ptr_uint64(true);
+            AssertThat(p.value(), Is().True());
+          });
         });
 
-        it("should not be confused with Nil (flagged)", [&]() {
-          AssertThat(flag(ptr_uint64::NIL()).is_terminal(), Is().False());
-        });
-      });
+        describe("is_false", []() {
+          it("should accept false terminal", [&]() {
+            ptr_uint64 terminal_F = ptr_uint64(false);
+            AssertThat(terminal_F.is_false(), Is().True());
+          });
 
-      describe("value", []() {
-        it("retrieves value from false terminal", [&]() {
-          ptr_uint64 p = ptr_uint64(false);
-          AssertThat(p.value(), Is().False());
-        });
+          it("should accept false terminal (flagged)", [&]() {
+            ptr_uint64 terminal_F = flag(ptr_uint64(false));
+            AssertThat(terminal_F.is_false(), Is().True());
+          });
 
-        it("retrieves value from true terminal", [&]() {
-          ptr_uint64 p = ptr_uint64(true);
-          AssertThat(p.value(), Is().True());
-        });
-      });
+          it("should reject terminal", [&]() {
+            ptr_uint64 terminal_T = ptr_uint64(true);
+            AssertThat(terminal_T.is_false(), Is().False());
+          });
 
-      describe("is_false", []() {
-        it("should accept false terminal", [&]() {
-          ptr_uint64 terminal_F = ptr_uint64(false);
-          AssertThat(terminal_F.is_false(), Is().True());
-        });
+          it("should reject non-terminal", [&]() {
+            ptr_uint64 p = ptr_uint64(0,0);
+            AssertThat(p.is_false(), Is().False());
+          });
 
-        it("should accept false terminal (flagged)", [&]() {
-          ptr_uint64 terminal_F = flag(ptr_uint64(false));
-          AssertThat(terminal_F.is_false(), Is().True());
-        });
-
-        it("should reject terminal", [&]() {
-          ptr_uint64 terminal_T = ptr_uint64(true);
-          AssertThat(terminal_T.is_false(), Is().False());
+          it("should reject NIL", [&]() {
+            ptr_uint64 p = ptr_uint64::NIL();
+            AssertThat(p.is_false(), Is().False());
+          });
         });
 
-        it("should reject non-terminal", [&]() {
-          ptr_uint64 p = ptr_uint64(0,0);
-          AssertThat(p.is_false(), Is().False());
+        describe("is_true", []() {
+          it("should reject false terminal", [&]() {
+            ptr_uint64 terminal_F = ptr_uint64(false);
+            AssertThat(terminal_F.is_true(), Is().False());
+          });
+
+          it("should accept true terminal", [&]() {
+            ptr_uint64 terminal_T = ptr_uint64(true);
+            AssertThat(terminal_T.is_true(), Is().True());
+          });
+
+          it("should accept true terminal (flagged)", [&]() {
+            ptr_uint64 terminal_T = flag(ptr_uint64(true));
+            AssertThat(terminal_T.is_true(), Is().True());
+          });
+
+          it("should reject non-terminal", [&]() {
+            ptr_uint64 p = ptr_uint64(0,1);
+            AssertThat(p.is_true(), Is().False());
+          });
+
+          it("should reject NIL", [&]() {
+            ptr_uint64 p = ptr_uint64::NIL();
+            AssertThat(p.is_true(), Is().False());
+          });
         });
 
-        it("should reject NIL", [&]() {
-          ptr_uint64 p = ptr_uint64::NIL();
-          AssertThat(p.is_false(), Is().False());
-        });
-      });
+        describe("negate", []() {
+          it("should negate terminal (unflagged)", [&]() {
+            ptr_uint64 p1 = ptr_uint64(false);
+            AssertThat(negate(p1), Is().EqualTo(ptr_uint64(true)));
 
-      describe("is_true", []() {
-        it("should reject false terminal", [&]() {
-          ptr_uint64 terminal_F = ptr_uint64(false);
-          AssertThat(terminal_F.is_true(), Is().False());
-        });
+            ptr_uint64 p2 = ptr_uint64(true);
+            AssertThat(negate(p2), Is().EqualTo(ptr_uint64(false)));
+          });
 
-        it("should accept true terminal", [&]() {
-          ptr_uint64 terminal_T = ptr_uint64(true);
-          AssertThat(terminal_T.is_true(), Is().True());
-        });
+          it("should negate terminal into terminal (flagged)", [&]() {
+            ptr_uint64 p1 = flag(ptr_uint64(false));
+            AssertThat(negate(p1), Is().EqualTo(flag(ptr_uint64(true))));
 
-        it("should accept true terminal (flagged)", [&]() {
-          ptr_uint64 terminal_T = flag(ptr_uint64(true));
-          AssertThat(terminal_T.is_true(), Is().True());
-        });
-
-        it("should reject non-terminal", [&]() {
-          ptr_uint64 p = ptr_uint64(0,1);
-          AssertThat(p.is_true(), Is().False());
-        });
-
-        it("should reject NIL", [&]() {
-          ptr_uint64 p = ptr_uint64::NIL();
-          AssertThat(p.is_true(), Is().False());
-        });
-      });
-
-      describe("negate", []() {
-        it("should negate terminal (unflagged)", [&]() {
-          ptr_uint64 p1 = ptr_uint64(false);
-          AssertThat(negate(p1), Is().EqualTo(ptr_uint64(true)));
-
-          ptr_uint64 p2 = ptr_uint64(true);
-          AssertThat(negate(p2), Is().EqualTo(ptr_uint64(false)));
-        });
-
-        it("should negate terminal into terminal (flagged)", [&]() {
-          ptr_uint64 p1 = flag(ptr_uint64(false));
-          AssertThat(negate(p1), Is().EqualTo(flag(ptr_uint64(true))));
-
-          ptr_uint64 p2 = flag(ptr_uint64(true));
-          AssertThat(negate(p2), Is().EqualTo(flag(ptr_uint64(false))));
-        });
-      });
-    });
-
-    describe("internal nodes", [&]() {
-      const ptr_uint64 terminal_F = ptr_uint64(false);
-      const ptr_uint64 terminal_T = ptr_uint64(true);
-
-      it("should take up 8 bytes of memory", [&]() {
-        const ptr_uint64 node_ptr = ptr_uint64(42,2);
-        AssertThat(sizeof(node_ptr), Is().EqualTo(8u));
-      });
-
-      describe("flag, unflag, is_flagged", [&]() {
-        it("can recognise the flag is set", [&]() {
-          ptr_uint64 p = flag(ptr_uint64(42,2));
-          AssertThat(p.is_flagged(), Is().True());
-
-          p = flag(ptr_uint64(17,3));
-          AssertThat(p.is_flagged(), Is().True());
-        });
-
-        it("can recognise the flag is not set", [&]() {
-          ptr_uint64 p = ptr_uint64(42,2);
-          AssertThat(p.is_flagged(), Is().False());
-
-          p = ptr_uint64(17,3);
-          AssertThat(p.is_flagged(), Is().False());
+            ptr_uint64 p2 = flag(ptr_uint64(true));
+            AssertThat(negate(p2), Is().EqualTo(flag(ptr_uint64(false))));
+          });
         });
       });
 
       describe("internal nodes", [&]() {
+        const ptr_uint64 terminal_F = ptr_uint64(false);
+        const ptr_uint64 terminal_T = ptr_uint64(true);
+
+        it("should take up 8 bytes of memory", [&]() {
+          const ptr_uint64 node_ptr = ptr_uint64(42,2);
+          AssertThat(sizeof(node_ptr), Is().EqualTo(8u));
+        });
+
+        describe("flag, unflag, is_flagged", [&]() {
+          it("can recognise the flag is set", [&]() {
+            ptr_uint64 p = flag(ptr_uint64(42,2));
+            AssertThat(p.is_flagged(), Is().True());
+
+            p = flag(ptr_uint64(17,3));
+            AssertThat(p.is_flagged(), Is().True());
+          });
+
+          it("can recognise the flag is not set", [&]() {
+            ptr_uint64 p = ptr_uint64(42,2);
+            AssertThat(p.is_flagged(), Is().False());
+
+            p = ptr_uint64(17,3);
+            AssertThat(p.is_flagged(), Is().False());
+          });
+        });
+
         describe("is_node", [&]() {
           it("should recognise Node Ptr (unflagged)", [&]() {
-            const ptr_uint64 p_node_max = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+            const ptr_uint64 p_node_max = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                                     ptr_uint64::MAX_ID);
+
             AssertThat(p_node_max.is_node(), Is().True());
 
             const ptr_uint64 p_node_min = ptr_uint64(0,0);
@@ -234,7 +245,9 @@ go_bandit([]() {
           });
 
           it("should recognise Node Ptr (flagged)", [&]() {
-            const ptr_uint64 p_node_max = flag(ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID));
+            const ptr_uint64 p_node_max = flag(ptr_uint64(ptr_uint64::MAX_LABEL,
+                                                          ptr_uint64::MAX_ID));
+
             AssertThat(p_node_max.is_node(), Is().True());
 
             const ptr_uint64 p_node_min = flag(ptr_uint64(0,0));
@@ -278,7 +291,9 @@ go_bandit([]() {
           });
 
           it("should store and retrieve MAX label Ptr (unflagged)", [&]() {
-            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                            ptr_uint64::MAX_ID);
+
             AssertThat(p.label(), Is().EqualTo(ptr_uint64::MAX_LABEL));
           });
 
@@ -298,7 +313,9 @@ go_bandit([]() {
           });
 
           it("should store and retrieve MAX label Ptr (flagged)", [&]() {
-            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                            ptr_uint64::MAX_ID);
+
             AssertThat(p.label(), Is().EqualTo(ptr_uint64::MAX_LABEL));
           });
         });
@@ -315,7 +332,9 @@ go_bandit([]() {
           });
 
           it("should store and retrieve MAX id (unflagged)", [&]() {
-            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                            ptr_uint64::MAX_ID);
+
             AssertThat(p.id(), Is().EqualTo(ptr_uint64::MAX_ID));
           });
 
@@ -330,40 +349,142 @@ go_bandit([]() {
           });
 
           it("should store and retrieve MAX id (flagged)", [&]() {
-            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+            const ptr_uint64 p = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                            ptr_uint64::MAX_ID);
+
             AssertThat(p.id(), Is().EqualTo(ptr_uint64::MAX_ID));
           });
         });
-      });
 
-      describe("ordering ( < )", [&]() {
-        it("should sort by label, then by id", [&]() {
-          const ptr_uint64 node_1_2 = ptr_uint64(1,2);
-          const ptr_uint64 node_2_1 = ptr_uint64(2,1);
-          const ptr_uint64 node_2_2 = ptr_uint64(2,2);
+        describe("out-index", [&]() {
+          it("has default value of 0 (unflagged)", [&]() {
+            const ptr_uint64 p = ptr_uint64(2,42);
+            AssertThat(p.out_idx(), Is().EqualTo(0u));
+          });
 
-          AssertThat(node_1_2 < node_2_1, Is().True());
-          AssertThat(node_2_1 < node_2_2, Is().True());
+          it("has default value of 0 (flagged)", [&]() {
+            const ptr_uint64 p = flag(ptr_uint64(2,42));
+            AssertThat(p.out_idx(), Is().EqualTo(0u));
+          });
+
+          it("has default value of 0 (max-id)", [&]() {
+            const ptr_uint64 p = flag(ptr_uint64(2,ptr_uint64::MAX_ID));
+            AssertThat(p.out_idx(), Is().EqualTo(0u));
+          });
+
+          it("has maximum out-index be 1", [&]() {
+            AssertThat(ptr_uint64::MAX_OUT_IDX, Is().EqualTo(1u));
+          });
+
+          it("should store and retrieve 'false' out-index (unflagged)", [&]() {
+            const ptr_uint64 p = ptr_uint64(2,42,false);
+            AssertThat(p.out_idx(), Is().EqualTo(0u));
+          });
+
+          it("should store and retrieve 'false' out-index (flagged)", [&]() {
+            const ptr_uint64 p = flag(ptr_uint64(2,42,false));
+            AssertThat(p.out_idx(), Is().EqualTo(0u));
+          });
+
+          it("should store and retrieve 'true' out-index (unflagged)", [&]() {
+            const ptr_uint64 p = ptr_uint64(2,42,true);
+            AssertThat(p.out_idx(), Is().EqualTo(1u));
+          });
+
+          it("should store and retrieve 'true' out-index (flagged)", [&]() {
+            const ptr_uint64 p = flag(ptr_uint64(2,42,true));
+            AssertThat(p.out_idx(), Is().EqualTo(1u));
+          });
         });
 
-        it("should sort F terminal after internal node", [&]() {
-          // Create a node pointer with the highest possible raw value
-          const ptr_uint64 p_node = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+        describe("ordering ( < )", [&]() {
+          it("should sort by label, then by id", [&]() {
+            const ptr_uint64 node_1_2 = ptr_uint64(1,2);
+            const ptr_uint64 node_2_1 = ptr_uint64(2,1);
+            const ptr_uint64 node_2_2 = ptr_uint64(2,2);
 
-          AssertThat(p_node < terminal_F, Is().True());
-          AssertThat(flag(p_node) < terminal_F, Is().True());
-          AssertThat(p_node < flag(terminal_F), Is().True());
-          AssertThat(flag(p_node) < flag(terminal_F), Is().True());
-        });
+            AssertThat(node_1_2 < node_2_1, Is().True());
+            AssertThat(node_2_1 < node_2_2, Is().True());
+          });
 
-        it("should sort T terminal after internal node (unflagged)", [&]() {
-          // Create a node pointer with the highest possible raw value
-          const ptr_uint64 p_node = ptr_uint64(ptr_uint64::MAX_LABEL, ptr_uint64::MAX_ID);
+          it("should sort by label and id independent of the flag", [&]() {
+            const ptr_uint64 node_1_2 = ptr_uint64(1,2);
+            const ptr_uint64 node_2_1 = ptr_uint64(2,1);
 
-          AssertThat(p_node < terminal_T, Is().True());
-          AssertThat(flag(p_node) < terminal_T, Is().True());
-          AssertThat(p_node < flag(terminal_T), Is().True());
-          AssertThat(flag(p_node) < flag(terminal_T), Is().True());
+            AssertThat(node_1_2 < flag(node_2_1), Is().True());
+            AssertThat(flag(node_1_2) < node_2_1, Is().True());
+            AssertThat(flag(node_1_2) < flag(node_2_1), Is().True());
+          });
+
+          it("should sort by id, then by out-index", [&]() {
+            const ptr_uint64 node_1_T = ptr_uint64(0,1,true);
+            const ptr_uint64 node_2_F = ptr_uint64(0,2,false);
+            const ptr_uint64 node_2_T = ptr_uint64(0,2,true);
+
+            AssertThat(node_1_T < node_2_F, Is().True());
+            AssertThat(node_2_F < node_2_T, Is().True());
+          });
+
+          it("should sort by id and out-index independent of the flag", [&]() {
+            const ptr_uint64 node_1_T = ptr_uint64(0,1,true);
+            const ptr_uint64 node_2_F = ptr_uint64(0,2,false);
+
+            AssertThat(node_1_T < flag(node_2_F), Is().True());
+            AssertThat(flag(node_1_T) < node_2_F, Is().True());
+            AssertThat(flag(node_1_T) < flag(node_2_F), Is().True());
+          });
+
+          it("should sort by label, then id, and finally out-index", [&]() {
+            const ptr_uint64 node_a = ptr_uint64(0,3,true);
+            const ptr_uint64 node_b = ptr_uint64(1,2,false);
+
+            AssertThat(node_a < node_b, Is().True());
+
+            const ptr_uint64 node_c = ptr_uint64(2,0,false);
+            const ptr_uint64 node_d = ptr_uint64(2,0,true);
+
+            AssertThat(node_c < node_d, Is().True());
+          });
+
+          it("should sort by label id, and out-index independent of the flag", [&]() {
+            const ptr_uint64 node_a = ptr_uint64(0,3,true);
+            const ptr_uint64 node_b = ptr_uint64(1,2,false);
+
+            AssertThat(node_a < flag(node_b), Is().True());
+            AssertThat(flag(node_a) < node_b, Is().True());
+            AssertThat(flag(node_a) < flag(node_b), Is().True());
+
+            const ptr_uint64 node_c = ptr_uint64(2,0,false);
+            const ptr_uint64 node_d = ptr_uint64(2,0,true);
+
+            AssertThat(flag(node_c) < node_d, Is().True());
+            AssertThat(node_c < flag(node_d), Is().True());
+            AssertThat(flag(node_c) < flag(node_d), Is().True());
+          });
+
+          it("should sort F terminal after (largest) internal node", [&]() {
+            // Create a node pointer with the highest possible raw value
+            const ptr_uint64 p_node = flag(ptr_uint64(ptr_uint64::MAX_LABEL,
+                                                      ptr_uint64::MAX_ID,
+                                                      ptr_uint64::MAX_OUT_IDX));
+
+            AssertThat(p_node < terminal_F, Is().True());
+            AssertThat(flag(p_node) < terminal_F, Is().True());
+            AssertThat(p_node < flag(terminal_F), Is().True());
+            AssertThat(flag(p_node) < flag(terminal_F), Is().True());
+          });
+
+          it("should sort T terminal after (largest) internal node", [&]() {
+            // Create a node pointer with the highest possible raw value
+            const ptr_uint64 p_node = ptr_uint64(ptr_uint64::MAX_LABEL,
+                                                 ptr_uint64::MAX_ID,
+                                                 ptr_uint64::MAX_OUT_IDX);
+
+            AssertThat(p_node < terminal_T, Is().True());
+            AssertThat(flag(p_node) < terminal_T, Is().True());
+            AssertThat(p_node < flag(terminal_T), Is().True());
+            AssertThat(flag(p_node) < flag(terminal_T), Is().True());
+          });
         });
       });
     });

--- a/test/adiar/internal/data_types/test_uid.cpp
+++ b/test/adiar/internal/data_types/test_uid.cpp
@@ -28,6 +28,38 @@ go_bandit([]() {
       });
     });
 
+    describe("out-index", []() {
+      it("should strip away out-index from 'internal node' pointer [1]", [&]() {
+        const ptr_uint64 p1(53, 4, false);
+        const uid_uint64 u1 = p1;
+
+        const ptr_uint64 p2(53, 4, true);
+        const uid_uint64 u2 = p2;
+
+        AssertThat(u1, Is().EqualTo(u2));
+      });
+
+      it("should strip away out-index 'internal node' pointer [2]", [&]() {
+        const ptr_uint64 p1(42, 0, false);
+        const uid_uint64 u1 = p1;
+
+        const ptr_uint64 p2(42, 0, true);
+        const uid_uint64 u2 = p2;
+
+        AssertThat(u1, Is().EqualTo(u2));
+      });
+
+      it("can provide a pointer with out-index 0", [&]() {
+        const uid_uint64 u(42, 0);
+        AssertThat(u.with(false), Is().EqualTo(ptr_uint64(42, 0, false)));
+      });
+
+      it("can provide a pointer with out-index 1", [&]() {
+        const uid_uint64 u(42, 0);
+        AssertThat(u.with(true), Is().EqualTo(ptr_uint64(42, 0, true)));
+      });
+    });
+
     describe("NIL", [&](){
 #ifndef NDEBUG
       it("throws 'std::illegal_argument' when given NIL [unflagged]", [&]() {

--- a/test/adiar/internal/io/test_arc_file.cpp
+++ b/test/adiar/internal/io/test_arc_file.cpp
@@ -28,9 +28,9 @@ go_bandit([]() {
         levelized_file<arc> af;
 
         arc_writer aw(af);
-        aw.push_internal(arc(arc::ptr_t(0,0),       arc::ptr_t(1,0)));
-        aw.push_internal(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(1,0)));
-        aw.push_internal(arc(arc::ptr_t(1,0),       arc::ptr_t(2,0)));
+        aw.push_internal(arc(arc::ptr_t(0,0), false, arc::ptr_t(1,0)));
+        aw.push_internal(arc(arc::ptr_t(0,0), true,  arc::ptr_t(1,0)));
+        aw.push_internal(arc(arc::ptr_t(1,0), false, arc::ptr_t(2,0)));
         aw.detach();
 
         AssertThat(af.size(),   Is().EqualTo(3u));
@@ -52,8 +52,8 @@ go_bandit([]() {
         levelized_file<arc> af;
 
         arc_writer aw(af);
-        aw.push_terminal(arc(arc::ptr_t(0,0),       arc::ptr_t(true)));
-        aw.push_terminal(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(true)));
+        aw.push_terminal(arc(arc::ptr_t(0,0), false, arc::ptr_t(true)));
+        aw.push_terminal(arc(arc::ptr_t(0,0), true,  arc::ptr_t(true)));
         aw.detach();
 
         AssertThat(af.size(),   Is().EqualTo(2u));
@@ -72,9 +72,9 @@ go_bandit([]() {
         AssertThat(lfs.can_pull<0>(), Is().False());
 
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(0,0), arc::ptr_t(true))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(0,0), false, arc::ptr_t(true))));
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(true))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(0,0), true,  arc::ptr_t(true))));
         AssertThat(lfs.can_pull<1>(), Is().False());
 
         AssertThat(lfs.can_pull<2>(), Is().False());
@@ -84,8 +84,8 @@ go_bandit([]() {
         levelized_file<arc> af;
 
         arc_writer aw(af);
-        aw.push_terminal(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(true)));
-        aw.push_terminal(arc(arc::ptr_t(0,0), arc::ptr_t(false)));
+        aw.push_terminal(arc(arc::ptr_t(0,0), true,  arc::ptr_t(true)));
+        aw.push_terminal(arc(arc::ptr_t(0,0), false, arc::ptr_t(false)));
         aw.detach();
 
         AssertThat(af.size(),   Is().EqualTo(2u));
@@ -102,11 +102,11 @@ go_bandit([]() {
         AssertThat(lfs.can_pull<0>(), Is().False());
 
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(true))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(0,0), true,  arc::ptr_t(true))));
         AssertThat(lfs.can_pull<1>(), Is().False());
 
         AssertThat(lfs.can_pull<2>(), Is().True());
-        AssertThat(lfs.pull<2>(),     Is().EqualTo(arc(arc::ptr_t(0,0), arc::ptr_t(false))));
+        AssertThat(lfs.pull<2>(),     Is().EqualTo(arc(arc::ptr_t(0,0), false, arc::ptr_t(false))));
         AssertThat(lfs.can_pull<2>(), Is().False());
       });
 
@@ -115,14 +115,14 @@ go_bandit([]() {
 
         arc_writer aw(af);
 
-        aw << arc(arc::ptr_t(0,0),       arc::ptr_t(1,0))
-           << arc(flag(arc::ptr_t(1,0)), arc::ptr_t(true))   // <-- in-order
-           << arc(arc::ptr_t(1,1),       arc::ptr_t(true))   // <-- in-order
-           << arc(flag(arc::ptr_t(0,0)), arc::ptr_t(1,1))
-           << arc(arc::ptr_t(1,0),       arc::ptr_t(2,0))
-           << arc(arc::ptr_t(2,0),       arc::ptr_t(false))  // <-- in-order
-           << arc(flag(arc::ptr_t(2,0)), arc::ptr_t(true))   // <-- in-order
-           << arc(flag(arc::ptr_t(1,1)), arc::ptr_t(true));  // <-- out-of-order
+        aw << arc(arc::ptr_t(0,0), false, arc::ptr_t(1,0))
+           << arc(arc::ptr_t(1,0), true,  arc::ptr_t(true))   // <-- in-order
+           << arc(arc::ptr_t(1,1), false, arc::ptr_t(true))   // <-- in-order
+           << arc(arc::ptr_t(0,0), true,  arc::ptr_t(1,1))
+           << arc(arc::ptr_t(1,0), false, arc::ptr_t(2,0))
+           << arc(arc::ptr_t(2,0), false, arc::ptr_t(false))  // <-- in-order
+           << arc(arc::ptr_t(2,0), true,  arc::ptr_t(true))   // <-- in-order
+           << arc(arc::ptr_t(1,1), true,  arc::ptr_t(true));  // <-- out-of-order
 
         aw.detach();
 
@@ -138,25 +138,25 @@ go_bandit([]() {
 
         levelized_file_stream<arc> lfs(af);
         AssertThat(lfs.can_pull<0>(), Is().True());
-        AssertThat(lfs.pull<0>(),     Is().EqualTo(arc(arc::ptr_t(0,0), arc::ptr_t(1,0))));
+        AssertThat(lfs.pull<0>(),     Is().EqualTo(arc(arc::ptr_t(0,0), false, arc::ptr_t(1,0))));
         AssertThat(lfs.can_pull<0>(), Is().True());
-        AssertThat(lfs.pull<0>(),     Is().EqualTo(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(1,1))));
+        AssertThat(lfs.pull<0>(),     Is().EqualTo(arc(arc::ptr_t(0,0), true,  arc::ptr_t(1,1))));
         AssertThat(lfs.can_pull<0>(), Is().True());
-        AssertThat(lfs.pull<0>(),     Is().EqualTo(arc(arc::ptr_t(1,0), arc::ptr_t(2,0))));
+        AssertThat(lfs.pull<0>(),     Is().EqualTo(arc(arc::ptr_t(1,0), false, arc::ptr_t(2,0))));
         AssertThat(lfs.can_pull<0>(), Is().False());
 
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(flag(arc::ptr_t(1,0)), arc::ptr_t(true))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(1,0), true,  arc::ptr_t(true))));
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(1,1), arc::ptr_t(true))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(1,1), false, arc::ptr_t(true))));
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(2,0), arc::ptr_t(false))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(2,0), false, arc::ptr_t(false))));
         AssertThat(lfs.can_pull<1>(), Is().True());
-        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(flag(arc::ptr_t(2,0)), arc::ptr_t(true))));
+        AssertThat(lfs.pull<1>(),     Is().EqualTo(arc(arc::ptr_t(2,0), true,  arc::ptr_t(true))));
         AssertThat(lfs.can_pull<1>(), Is().False());
 
         AssertThat(lfs.can_pull<2>(), Is().True());
-        AssertThat(lfs.pull<2>(),     Is().EqualTo(arc(flag(arc::ptr_t(1,1)), arc::ptr_t(true))));
+        AssertThat(lfs.pull<2>(),     Is().EqualTo(arc(arc::ptr_t(1,1), true,  arc::ptr_t(true))));
         AssertThat(lfs.can_pull<2>(), Is().False());
       });
     });
@@ -174,29 +174,29 @@ go_bandit([]() {
        */
       {
         arc_writer aw(af);
-        aw << arc(arc::ptr_t(0,0),       arc::ptr_t(1,0));
-        aw << arc(flag(arc::ptr_t(1,0)), arc::ptr_t(true));  // <-- in-order
-        aw << arc(arc::ptr_t(1,1),       arc::ptr_t(true));  // <-- in-order
-        aw << arc(flag(arc::ptr_t(0,0)), arc::ptr_t(1,1));
-        aw << arc(arc::ptr_t(1,0),       arc::ptr_t(2,0));
-        aw << arc(arc::ptr_t(2,0),       arc::ptr_t(false)); // <-- in-order
-        aw << arc(flag(arc::ptr_t(2,0)), arc::ptr_t(true));  // <-- in-order
-        aw << arc(flag(arc::ptr_t(1,1)), arc::ptr_t(true));  // <-- out-of-order
+        aw << arc(arc::ptr_t(0,0), false, arc::ptr_t(1,0));
+        aw << arc(arc::ptr_t(1,0), true,  arc::ptr_t(true));  // <-- in-order
+        aw << arc(arc::ptr_t(1,1), false, arc::ptr_t(true));  // <-- in-order
+        aw << arc(arc::ptr_t(0,0), true,  arc::ptr_t(1,1));
+        aw << arc(arc::ptr_t(1,0), false, arc::ptr_t(2,0));
+        aw << arc(arc::ptr_t(2,0), false, arc::ptr_t(false)); // <-- in-order
+        aw << arc(arc::ptr_t(2,0), true,  arc::ptr_t(true));  // <-- in-order
+        aw << arc(arc::ptr_t(1,1), true,  arc::ptr_t(true));  // <-- out-of-order
       }
 
       it("Merges terminal arcs on 'pull' [default: backwards]", [&af]() {
         arc_stream<> as(af);
 
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(flag(arc::ptr_t(2,0)), arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(2,0), true,  arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(2,0),       arc::ptr_t(false))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(2,0), false, arc::ptr_t(false))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(flag(arc::ptr_t(1,1)), arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,1), true,  arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,1),       arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,1), false, arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(flag(arc::ptr_t(1,0)), arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,0), true,  arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().False());
       });
 
@@ -204,15 +204,15 @@ go_bandit([]() {
         arc_stream<true> as(af);
 
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(flag(arc::ptr_t(1,0)), arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,0), true,  arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,1),       arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,1), false, arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(flag(arc::ptr_t(1,1)), arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(1,1), true,  arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(2,0),       arc::ptr_t(false))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(2,0), false, arc::ptr_t(false))));
         AssertThat(as.can_pull_terminal(), Is().True());
-        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(flag(arc::ptr_t(2,0)), arc::ptr_t(true))));
+        AssertThat(as.pull_terminal(),     Is().EqualTo(arc(arc::ptr_t(2,0), true,  arc::ptr_t(true))));
         AssertThat(as.can_pull_terminal(), Is().False());
       });
 
@@ -220,11 +220,11 @@ go_bandit([]() {
         arc_stream<> as(af);
 
         AssertThat(as.can_pull_internal(), Is().True());
-        AssertThat(as.pull_internal(),     Is().EqualTo(arc(arc::ptr_t(1,0), arc::ptr_t(2,0))));
+        AssertThat(as.pull_internal(),     Is().EqualTo(arc(arc::ptr_t(1,0), false, arc::ptr_t(2,0))));
         AssertThat(as.can_pull_internal(), Is().True());
-        AssertThat(as.pull_internal(),     Is().EqualTo(arc(flag(arc::ptr_t(0,0)), arc::ptr_t(1,1))));
+        AssertThat(as.pull_internal(),     Is().EqualTo(arc(arc::ptr_t(0,0), true,  arc::ptr_t(1,1))));
         AssertThat(as.can_pull_internal(), Is().True());
-        AssertThat(as.pull_internal(),     Is().EqualTo(arc(arc::ptr_t(0,0), arc::ptr_t(1,0))));
+        AssertThat(as.pull_internal(),     Is().EqualTo(arc(arc::ptr_t(0,0), false, arc::ptr_t(1,0))));
         AssertThat(as.can_pull_internal(), Is().False());
       });
 

--- a/test/adiar/internal/test_util.cpp
+++ b/test/adiar/internal/test_util.cpp
@@ -138,22 +138,22 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true, n3.uid() }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2.uid()), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), true, n3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n2
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, true_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n3
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, false_ptr }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true, true_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -209,33 +209,33 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true, n2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n3.uid() }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), false, n3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2.uid()), n4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), true, n4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n3.uid()), n5.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n3.uid(), true, n5.uid() }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n4.uid(), n5.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n4.uid(), false, n5.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n3
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, false_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n4
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n4.uid()), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), true, true_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n5
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), false_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), false, false_ptr }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n5.uid()), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), true, true_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -295,33 +295,33 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), n2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), false, n2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n3.uid(), n4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n3.uid(), false, n4.uid() }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n3.uid()), n4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n3.uid(), true,  n4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // n5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2.uid()), n5.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), true,  n5.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n2
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, false_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n4
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), false_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), false, false_ptr }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n4.uid()), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), true,  true_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // n5
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), false, true_ptr }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n5.uid()), true_ptr }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n5.uid(), true,  true_ptr }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/zdd/test_binop.cpp
+++ b/test/adiar/zdd/test_binop.cpp
@@ -92,9 +92,9 @@ go_bandit([]() {
 
       it("should shortcut on irrelevance for { {0} } U Ø", [&]() {
         /*
-                   1     ---- x0
-                  / \
-                  F T
+        //           1     ---- x0
+        //          / \
+        //          F T
         */
 
         __zdd out_1 = zdd_union(zdd_x0, zdd_F);
@@ -106,9 +106,9 @@ go_bandit([]() {
 
       it("computes { {0} } U { Ø }", [&]() {
         /*
-                   1     ---- x0
-                  / \
-                  T T
+        //           1     ---- x0
+        //          / \
+        //          T T
         */
 
         __zdd out = zdd_union(zdd_x0, zdd_T);
@@ -117,10 +117,10 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -139,11 +139,11 @@ go_bandit([]() {
 
       it("computes { {0} } U { {1} }", [&]() {
         /*
-                     1     ---- x0
-                    / \
-                    2 T    ---- x1
-                   / \
-                   F T
+        //             1     ---- x0
+        //            / \
+        //            2 T    ---- x1
+        //           / \
+        //           F T
         */
 
         __zdd out = zdd_union(zdd_x0, zdd_x1);
@@ -151,18 +151,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -184,15 +184,15 @@ go_bandit([]() {
 
       it("computes { {0,1}, {0,3} } U { {0,2}, {2} }", [&]() {
         /*
-                    1           1                (1,1)         ---- x0
-                   / \         / \                 X
-                   F 2         | |            (2,2) \          ---- x1
-                    / \        \ /   ==>      /   \  \
-                    | T         2          (3,2)  T (F,2)      ---- x2
-                    |          / \         /   \     / \
-                    3          F T       (3,F) T     F T       ---- x3
-                   / \                    / \
-                   F T                    F T
+        //            1           1                (1,1)         ---- x0
+        //           / \         / \                 X
+        //           F 2         | |            (2,2) \          ---- x1
+        //            / \        \ /   ==>      /   \  \
+        //            | T         2          (3,2)  T (F,2)      ---- x2
+        //            |          / \         /   \     / \
+        //            3          F T       (3,F) T     F T       ---- x3
+        //           / \                    / \
+        //           F T                    F T
         */
         shared_levelized_file<zdd::node_t> zdd_a;
         shared_levelized_file<zdd::node_t> zdd_b;
@@ -215,36 +215,36 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -272,13 +272,13 @@ go_bandit([]() {
 
       it("computes { {0,1}, {1} } U { {0,2}, {2} }", [&]() {
         /*
-                   1           1             (1,1)
-                   ||         / \             | |
-                   2          | |            (2,2)
-                  / \         \ /   ==>       / \
-                  F T          2          (F,2) (T,F) <-- since 2nd (2) skipped level
-                              / \          / \
-                              F T          F T
+        //           1           1             (1,1)
+        //           ||         / \             | |
+        //           2          | |            (2,2)
+        //          / \         \ /   ==>       / \
+        //          F T          2          (F,2) (T,F) <-- since 2nd (2) skipped level
+        //                      / \          / \
+        //                      F T          F T
         */
         shared_levelized_file<zdd::node_t> zdd_a;
         shared_levelized_file<zdd::node_t> zdd_b;
@@ -300,24 +300,24 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -342,18 +342,18 @@ go_bandit([]() {
 
       it("computes { {0}, {1,3}, {2,3}, {1} } U { {0,3}, {3} }", [&]() {
         /*
-                        1        1                        (1,1)         ---- x0
-                       / \      / \                       /   \
-                       2 T      | |                    (2,2)   \        ---- x1
-                      / \       | |                    /   \    \
-                      3  \      | |     ==>         (3,2)  |     \      ---- x2
-                      \\ /      \ /                 /   \  |     |
-                        4        2              (4,2)   (4,F)  (T,2)    ---- x3
-                       / \      / \              / \     / \    / \
-                       F T      F T              T T     T T    T T
-
-                   The high arc on (2) and (3) on the left is shortcutting the
-                   second ZDD, to compensate for the omitted nodes.
+        //                1        1                        (1,1)         ---- x0
+        //               / \      / \                       /   \
+        //               2 T      | |                    (2,2)   \        ---- x1
+        //              / \       | |                    /   \    \
+        //              3  \      | |     ==>         (3,2)  |     \      ---- x2
+        //              \\ /      \ /                 /   \  |     |
+        //                4        2              (4,2)   (4,F)  (T,2)    ---- x3
+        //               / \      / \              / \     / \    / \
+        //               F T      F T              T T     T T    T T
+        //
+        //           The high arc on (2) and (3) on the left is shortcutting the
+        //           second ZDD, to compensate for the omitted nodes.
         */
         shared_levelized_file<zdd::node_t> zdd_a;
         shared_levelized_file<zdd::node_t> zdd_b;
@@ -377,39 +377,39 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -487,9 +487,9 @@ go_bandit([]() {
 
       it("computes (and shortcut) { {0} } ∩ Ø", [&]() {
         /*
-                   1       F              F          ---- x0
-                  / \           ==>
-                  F T
+        //           1       F              F          ---- x0
+        //          / \           ==>
+        //          F T
         */
 
         __zdd out = zdd_intsec(zdd_x0, zdd_F);
@@ -535,9 +535,9 @@ go_bandit([]() {
 
       it("computes { {0} } ∩ { Ø }", [&]() {
         /*
-                   1       T              F       ---- x0
-                  / \           ==>
-                  F T
+        //           1       T              F       ---- x0
+        //          / \           ==>
+        //          F T
         */
 
         __zdd out = zdd_intsec(zdd_x0, zdd_T);
@@ -562,9 +562,9 @@ go_bandit([]() {
 
       it("computes { Ø, {0} } ∩ { Ø }", [&]() {
         /*
-                   1       T              T       ---- x0
-                  / \           ==>
-                  T T
+        //           1       T              T       ---- x0
+        //          / \           ==>
+        //          T T
         */
         shared_levelized_file<zdd::node_t> zdd_a;
 
@@ -595,11 +595,11 @@ go_bandit([]() {
 
       it("computes { {0}, {1} } ∩ { Ø }", [&]() {
         /*
-                       1        T             F          ---- x0
-                      / \
-                      2 T             ==>                ---- x1
-                     / \
-                     F T
+        //               1        T             F          ---- x0
+        //              / \
+        //              2 T             ==>                ---- x1
+        //             / \
+        //             F T
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -633,11 +633,11 @@ go_bandit([]() {
 
       it("computes (and shortcut) { {0,1}, {1} } ∩ { {0,1} }", [&]() {
         /*
-                    _1_        1            1        ---- x0
-                   /   \      / \          / \
-                   2   3      F 2    ==>   F 2       ---- x1
-                  / \ / \      / \          / \
-                  T T F T      F T          F T
+        //            _1_        1            1        ---- x0
+        //           /   \      / \          / \
+        //           2   3      F 2    ==>   F 2       ---- x1
+        //          / \ / \      / \          / \
+        //          T T F T      F T          F T
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -661,17 +661,17 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -693,12 +693,12 @@ go_bandit([]() {
 
       it("computes (and skip to terminal) { {0}, {1}, {0,1} } ∩ { Ø }", [&]() {
         /*
-                    1        T          F     ---- x0
-                   / \
-                   \ /            ==>
-                    2                         ---- x1
-                   / \
-                   F T
+        //            1        T          F     ---- x0
+        //           / \
+        //           \ /            ==>
+        //            2                         ---- x1
+        //           / \
+        //           F T
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -732,18 +732,18 @@ go_bandit([]() {
 
       it("computes (and skip to terminal) { {0,2}, {0}, {2} } \\ { {1}, {2}, Ø }", [&]() {
         /*
-                        1                             F       ---- x0
-                       / \
-                      /   \         _1_                         ---- x1
-                      |   |        /   \       =>
-                      2   3        2   3                        ---- x2
-                     / \ / \      / \ / \
-                     F T T T      T F F T
-
-                     Where (2) and (3) are swapped in order on the right. Notice,
-                     that (2) on the right technically is illegal, but it makes
-                     for a much simpler counter-example that catches
-                     prod_pq_1.peek() throwing an error on being empty.
+        //                1                             F       ---- x0
+        //               / \
+        //              /   \         _1_                         ---- x1
+        //              |   |        /   \       =>
+        //              2   3        2   3                        ---- x2
+        //             / \ / \      / \ / \
+        //             F T T T      T F F T
+        //
+        //             Where (2) and (3) are swapped in order on the right. Notice,
+        //             that (2) on the right technically is illegal, but it makes
+        //             for a much simpler counter-example that catches
+        //             prod_pq_1.peek() throwing an error on being empty.
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -788,19 +788,19 @@ go_bandit([]() {
 
       it("computes (and skips in) { {0,1,2}, {0,2}, {0}, {2} } } ∩ { {0,2}, {0}, {1}, {2} }", [&]() {
         /*
-                        1             1                 (1,1)      ---- x0
-                       / \           / \                /   \
-                       | _2_        2   \              /     \
-                       \/   \      / \  |     ==>      |     |
-                        3   4      3 T  4            (3,3) (3,4)
-                       / \ / \    / \  / \            / \   / \
-                       T T F T    F T  T T            F T   T T
-
-                       where (3) and (4) are swapped in order on the left one.
-
-                       (3,3) : ((2,1), (2,0))   ,   (3,4) : ((2,1), (2,1))
-
-                       so (3,3) is forwarded while (3,4) is not and hence (3,3) is output first.
+        //                1             1                 (1,1)      ---- x0
+        //               / \           / \                /   \
+        //               | _2_        2   \              /     \
+        //               \/   \      / \  |     ==>      |     |
+        //                3   4      3 T  4            (3,3) (3,4)
+        //               / \ / \    / \  / \            / \   / \
+        //               T T F T    F T  T T            F T   T T
+        //
+        //               where (3) and (4) are swapped in order on the left one.
+        //
+        //               (3,3) : ((2,1), (2,0))   ,   (3,4) : ((2,1), (2,1))
+        //
+        //               so (3,3) is forwarded while (3,4) is not and hence (3,3) is output first.
         */
         shared_levelized_file<zdd::node_t> zdd_a;
 
@@ -829,22 +829,22 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
 
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -866,11 +866,11 @@ go_bandit([]() {
 
       it("computes (and skip) { {0}, {1} } ∩ { {0,1} }", [&]() {
         /*
-                    1          1                  (1,1)         ---- x0
-                   / \        / \                 /   \
-                   2 T        F 2                 F   F         ---- x1
-                  / \          / \       ==>
-                  F T          F T
+        //            1          1                  (1,1)         ---- x0
+        //           / \        / \                 /   \
+        //           2 T        F 2                 F   F         ---- x1
+        //          / \          / \       ==>
+        //          F T          F T
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -895,9 +895,9 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -916,15 +916,15 @@ go_bandit([]() {
 
       it("computes (and skip) { {0}, {1}, {2}, {1,2}, {0,2} } ∩ { {0}, {2}, {0,2}, {0,1,2} }", [&]() {
         /*
-                      1          1                 (1,1)         ---- x0
-                     / \        / \                /   \
-                     2 |        | 2               /     \        ---- x1
-                    / \|        |/ \       ==>    |     |
-                    3  4        3  4            (3,3) (4,3)      ---- x2
-                   / \/ \      / \/ \            / \   / \
-                   F T  T      F T  T            F T   F T
-
-                   Notice, how (2,3) and (4,2) was skipped on the low and high of (1,1)
+        //              1          1                 (1,1)         ---- x0
+        //             / \        / \                /   \
+        //             2 |        | 2               /     \        ---- x1
+        //            / \|        |/ \       ==>    |     |
+        //            3  4        3  4            (3,3) (4,3)      ---- x2
+        //           / \/ \      / \/ \            / \   / \
+        //           F T  T      F T  T            F T   F T
+        //
+        //           Notice, how (2,3) and (4,2) was skipped on the low and high of (1,1)
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -951,22 +951,22 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -988,13 +988,13 @@ go_bandit([]() {
 
       it("computes (and skip) { {0}, {1} } ∩ { {1}, {0,2} }", [&]() {
         /*
-                     1         1                (1,1)      ---- x0
-                    / \       / \               /   \
-                    2 T       2  \            (2,2) F      ---- x1
-                   / \       / \ |     =>      / \
-                   F T       F T 3             F T         ---- x2
-                                / \
-                                F T
+        //             1         1                (1,1)      ---- x0
+        //            / \       / \               /   \
+        //            2 T       2  \            (2,2) F      ---- x1
+        //           / \       / \ |     =>      / \
+        //           F T       F T 3             F T         ---- x2
+        //                        / \
+        //                        F T
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -1018,18 +1018,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1051,15 +1051,15 @@ go_bandit([]() {
 
       it("computes (and skip) { {0,2}, {1,2}, Ø } ∩ { {0,1}, {0}, {1} }", [&]() {
         /*
-                     1         1                    (1,1)    ---- x0
-                    / \       / \                   /   \
-                    2  \      2 T                 (2,2) |    ---- x1
-                   / \ /     / \       =>         /   \ |
-                   T  3      T T                  T   F F    ---- x2
-                     / \
-                     F T
-
-                   This shortcuts the (3,T) tuple twice.
+        //             1         1                    (1,1)    ---- x0
+        //            / \       / \                   /   \
+        //            2  \      2 T                 (2,2) |    ---- x1
+        //           / \ /     / \       =>         /   \ |
+        //           T  3      T T                  T   F F    ---- x2
+        //             / \
+        //             F T
+        //
+        //           This shortcuts the (3,T) tuple twice.
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -1083,18 +1083,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_T }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1116,15 +1116,15 @@ go_bandit([]() {
 
       it("computes (and shortcut) { {0,2}, {1,2}, Ø } ∩ { {0,2}, {0} }", [&]() {
         /*
-                     1            1               (1,1)     ---- x0
-                    / \          / \               / \
-                    2  \         F |               F |      ---- x1
-                   / \ /           |     ==>         |
-                   T  3            2               (2,3)    ---- x2
-                     / \          / \               / \
-                     F T          T T               F T
-
-                   This shortcuts the (3,T) tuple twice.
+        //             1            1               (1,1)     ---- x0
+        //            / \          / \               / \
+        //            2  \         F |               F |      ---- x1
+        //           / \ /           |     ==>         |
+        //           T  3            2               (2,3)    ---- x2
+        //             / \          / \               / \
+        //             F T          T T               F T
+        //
+        //           This shortcuts the (3,T) tuple twice.
         */
 
         shared_levelized_file<zdd::node_t> zdd_a;
@@ -1148,17 +1148,17 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1314,9 +1314,9 @@ go_bandit([]() {
 
       it("computes { {0} } \\ { Ø }", [&]() {
         /*
-                   1      T            1       ---- x0
-                  / \          ==>    / \
-                  F T                 F T
+        //           1      T            1       ---- x0
+        //          / \          ==>    / \
+        //          F T                 F T
         */
         __zdd out = zdd_diff(zdd_x0, zdd_T);
 
@@ -1325,9 +1325,9 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1346,9 +1346,9 @@ go_bandit([]() {
 
       it("computes { {0}, Ø } \\ { Ø }", [&]() {
         /*
-                   1      T            1       ---- x0
-                  / \          ==>    / \
-                  T T                 F T
+        //           1      T            1       ---- x0
+        //          / \          ==>    / \
+        //          T T                 F T
         */
         shared_levelized_file<zdd::node_t> zdd_a;
 
@@ -1364,9 +1364,9 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1385,11 +1385,11 @@ go_bandit([]() {
 
       it("computes (and skip) { {0,1}, {1} } \\ { {1}, Ø }", [&]() {
         /*
-                     1                      (1,1)       ---- x0
-                     ||                     /   \
-                     2      1     ==>    (2,1)  F       ---- x1
-                    / \    / \            / \
-                    F T    T T            F F
+        //             1                      (1,1)       ---- x0
+        //             ||                     /   \
+        //             2      1     ==>    (2,1)  F       ---- x1
+        //            / \    / \            / \
+        //            F T    T T            F F
         */
         shared_levelized_file<zdd::node_t> zdd_a;
         shared_levelized_file<zdd::node_t> zdd_b;
@@ -1409,17 +1409,17 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1441,13 +1441,13 @@ go_bandit([]() {
 
       it("computes { {0,1}, {1,2}, {1} } \\ { {1}, Ø }", [&]() {
         /*
-                     _1_                        (1,1)       ---- x0
-                    /   \                       /   \
-                    3   2      1     ==>    (3,1)   (2,F)    ---- x1
-                   / \ / \    / \           /   \    / \
-                   F 4 F T    T T           F (3,T)  F T    ---- x2
-                    / \                        / \
-                    T T                        F T
+        //             _1_                        (1,1)       ---- x0
+        //            /   \                       /   \
+        //            3   2      1     ==>    (3,1)   (2,F)    ---- x1
+        //           / \ / \    / \           /   \    / \
+        //           F 4 F T    T T           F (3,T)  F T    ---- x2
+        //            / \                        / \
+        //            T T                        F T
         */
         shared_levelized_file<zdd::node_t> zdd_a;
         shared_levelized_file<zdd::node_t> zdd_b;
@@ -1469,28 +1469,28 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/zdd/test_change.cpp
+++ b/test/adiar/zdd/test_change.cpp
@@ -28,16 +28,16 @@ go_bandit([]() {
     }
 
     /*
-                1      ---- x0
-               / \
-               2  \    ---- x1
-              / \ /
-              3  4     ---- x2
-             / \/ \
-             5 T  T    ---- x3
-            / \
-            F T
-     */
+    //            1      ---- x0
+    //           / \
+    //           2  \    ---- x1
+    //          / \ /
+    //          3  4     ---- x2
+    //         / \/ \
+    //         5 T  T    ---- x3
+    //        / \
+    //        F T
+    */
     shared_levelized_file<zdd::node_t> zdd_1;
 
     const node n1_5 = node(3, node::MAX_ID,   terminal_F,   terminal_T);
@@ -136,18 +136,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -187,24 +187,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -240,24 +240,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -293,24 +293,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -346,30 +346,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -417,30 +417,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -546,10 +546,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -587,18 +587,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -642,10 +642,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -684,10 +684,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -725,18 +725,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -769,36 +769,36 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -846,30 +846,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -905,42 +905,42 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,1), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1027,18 +1027,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1081,18 +1081,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1134,24 +1134,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1176,17 +1176,17 @@ go_bandit([]() {
 
     it("bridges node before the last label and a terminal for { {0}, {1} } on (0,1)", [&]() {
       /*
-              1     ---- x0
-             / \
-             2 T    ---- x1
-            / \
-            F T
-
-         When resoving for (2) the label is at x1, but as it is pruned then the
-         source is still at x0 from (1). Hence, if one looks at source.label()
-         rather than the current level then this edge is by mistake placed into
-         the "cut edge with a new node" queue.
-       */
+      //        1     ---- x0
+      //       / \
+      //       2 T    ---- x1
+      //      / \
+      //      F T
+      //
+      //   When resoving for (2) the label is at x1, but as it is pruned then the
+      //   source is still at x0 from (1). Hence, if one looks at source.label()
+      //   rather than the current level then this edge is by mistake placed into
+      //   the "cut edge with a new node" queue.
+      */
       shared_levelized_file<zdd::node_t> in;
 
       { // Garbage collect writer to free write-lock
@@ -1208,18 +1208,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1241,18 +1241,18 @@ go_bandit([]() {
 
     it("flips, adds and bridges nodes for [1] on (2,3)", [&]() {
       /*
-               1      ---- x0
-              / \
-              2  \    ---- x1
-             / \ /
-             3  4     ---- x2
-            / \ ||
-            | F ||            (The F is the shortcutting on 5)
-            \_ _//
-              *       ---- x3 (From the T terminal)
-             / \
-             F T
-       */
+      //         1      ---- x0
+      //        / \
+      //        2  \    ---- x1
+      //       / \ /
+      //       3  4     ---- x2
+      //      / \ ||
+      //      | F ||            (The F is the shortcutting on 5)
+      //      \_ _//
+      //        *       ---- x3 (From the T terminal)
+      //       / \
+      //       F T
+      */
 
       adiar::shared_file<zdd::label_t> labels;
 
@@ -1266,36 +1266,36 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1324,13 +1324,12 @@ go_bandit([]() {
     it("correctly connects pre-root chain with skipped root for { { 1 }, { 1,2 } } on (0,1)", [&]() {
       shared_levelized_file<zdd::node_t> in;
       /*
-                1     ---- x1
-               / \
-               F 2    ---- x2
-                / \
-                T T
-
-       */
+      //          1     ---- x1
+      //         / \
+      //         F 2    ---- x2
+      //          / \
+      //          T T
+      */
 
       const node n2 = node(2, node::MAX_ID, terminal_T, terminal_T);
       const node n1 = node(1, node::MAX_ID, terminal_F, n2.uid());
@@ -1352,18 +1351,18 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1386,9 +1385,9 @@ go_bandit([]() {
     it("cuts collapse of root to a terminal for { { 0 } } on (0,1)", [&]() {
       shared_levelized_file<zdd::node_t> in;
       /*
-                1     ---- x0
-               / \
-               F T
+      //          1     ---- x0
+      //         / \
+      //         F T
       */
       { // Garbage collect writer to free write-lock
         node_writer nw(in);
@@ -1408,10 +1407,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1431,11 +1430,11 @@ go_bandit([]() {
     it("cuts collapse to a terminal for { { 0,1 } } on (0,1,2)", [&]() {
       shared_levelized_file<zdd::node_t> in;
       /*
-                1     ---- x0
-               / \
-               F 2    ---- x1
-                / \
-                F T
+      //          1     ---- x0
+      //         / \
+      //         F 2    ---- x1
+      //          / \
+      //          F T
       */
       { // Garbage collect writer to free write-lock
         node_writer nw(in);
@@ -1456,10 +1455,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1479,9 +1478,9 @@ go_bandit([]() {
     it("keeps pre-root chain despite collapse to a terminal of the root for { { 1 } } on (0,1)", [&]() {
       shared_levelized_file<zdd::node_t> in;
       /*
-                1     ---- x1
-               / \
-               F T
+      //          1     ---- x1
+      //         / \
+      //         F T
       */
       { // Garbage collect writer to free write-lock
         node_writer nw(in);
@@ -1501,10 +1500,10 @@ go_bandit([]() {
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/zdd/test_complement.cpp
+++ b/test/adiar/zdd/test_complement.cpp
@@ -19,13 +19,13 @@ go_bandit([]() {
     shared_levelized_file<zdd::node_t> zdd_pow_24;
     // { Ø, { 2 }, { 4 }, { 2,4 } }
     /*
-            1      ---- x2
-            / \
-            | |
-            \ /
-            2      ---- x4
-            / \
-            T T
+    //         1      ---- x2
+    //        / \
+    //        | |
+    //        \ /
+    //         2      ---- x4
+    //        / \
+    //        T T
     */
     { // Garbage collect writer early
       const node n2 = node(4, node::MAX_ID,   terminal_T, terminal_T);
@@ -71,23 +71,23 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                      terminal_T,
-                                                      terminal_T)));
+                                                terminal_T,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                ptr_uint64(3, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                      ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(1, ptr_uint64::MAX_ID),
+                                                ptr_uint64(1, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -123,23 +123,23 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                      terminal_T,
-                                                      terminal_T)));
+                                                terminal_T,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                      ptr_uint64(4, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(4, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(4, ptr_uint64::MAX_ID),
+                                                ptr_uint64(4, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                ptr_uint64(3, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -182,13 +182,13 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                      terminal_F,
-                                                      terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -218,23 +218,23 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                      terminal_F,
-                                                      terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                      ptr_uint64(4, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(4, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(4, ptr_uint64::MAX_ID),
+                                                ptr_uint64(4, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                ptr_uint64(3, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -268,71 +268,71 @@ go_bandit([]() {
         {
           node_writer nw(zdd_x3);
           /*
-                1        ---- x3
-               / \
-               F T
+          //      1        ---- x3
+          //     / \
+          //     F T
           */
           nw << node(3, node::MAX_ID, terminal_F, terminal_T);
         }
 
         __zdd out = zdd_complement(zdd_x3, dom_0123);
         /*
-                     *    ---- x0
-                    / \
-                   *   *  ---- x1
-                  / \ //
-                  *   *   ---- x2
-                 / \ //
-                1   *     ---- x3
-               / \  ||
-               T F  T
-         */
+        //             *    ---- x0
+        //            / \
+        //           *   *  ---- x1
+        //          / \ //
+        //          *   *   ---- x2
+        //         / \ //
+        //        1   *     ---- x3
+        //       / \  ||
+        //       T F  T
+        */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // root chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // root chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // root chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // input node (flipped)
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // T chain
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -370,48 +370,48 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // root chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // root chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // original node
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // F chain
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // T chain
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -440,9 +440,9 @@ go_bandit([]() {
       it("adds out-of-set chain above and below root on { Ø, { 1 } } and U = { 1, 2, 3, 4 }", [&]() {
         shared_levelized_file<zdd::node_t> zdd_x1_null;
         /*
-                1        ---- x1
-              / \
-              T T
+        //       1        ---- x1
+        //      / \
+        //      T T
         */
         {
           node_writer nw(zdd_x1_null);
@@ -451,63 +451,63 @@ go_bandit([]() {
 
         __zdd out = zdd_complement(zdd_x1_null, dom_0123);
         /*
-                1        ---- x0
-                / \
-                2 3       ---- x1
-              || ||
-                4_ 5      ---- x2
-              |  \||
-                6_ 7      ---- x3
-              |  \||
-              F   T
+        //         1        ---- x0
+        //        / \
+        //        2 3       ---- x1
+        //       || ||
+        //        4_ 5      ---- x2
+        //       |  \||
+        //        6_ 7      ---- x3
+        //       |  \||
+        //       F   T
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 6
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 7
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 6
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 7
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -537,13 +537,13 @@ go_bandit([]() {
         shared_levelized_file<zdd::node_t> in;
         // { { 2 }, { 3 }, { 4 }, { 2,4 }, { 3,4 } }
         /*
-                1       ---- x2
-              / \
-              2 |      ---- x3
-              / \|
-              3  4      ---- x4
-            / \/ \
-            F T  T
+        //       1       ---- x2
+        //      / \
+        //      2 |      ---- x3
+        //     / \|
+        //     3  4      ---- x4
+        //    / \/ \
+        //    F T  T
         */
         { // Garbage collect writer early
           const node n4 = node(4, node::MAX_ID,   terminal_T, terminal_T);
@@ -557,72 +557,72 @@ go_bandit([]() {
 
         __zdd out = zdd_complement(in, dom_1234);
         /*
-                  _1_      ---- x1
-                  /   \
-                  2   3     ---- x2
-                / \  ||
-                4 5_ 6     ---- x3
-                / \| \||
-                7  8  9     ---- x4
-              / \/ \ ||
-              T F  F T
+        //          _1_      ---- x1
+        //         /   \
+        //         2   3     ---- x2
+        //        / \  ||
+        //        4 5_ 6     ---- x3
+        //        / \| \||
+        //        7  8  9    ---- x4
+        //       / \/ \ ||
+        //       T F  F T
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 6
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 7
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 8
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 9
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), ptr_uint64(4,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(4,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,2), ptr_uint64(4,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,2), false, ptr_uint64(4,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), ptr_uint64(4,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  ptr_uint64(4,2) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 7
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 8
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 9
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,2), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,2), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -651,15 +651,15 @@ go_bandit([]() {
       it("computes pow(U) \\ { Ø, { 1,2 }, { 2,3 }, { 2,4 }, { 1,2,3 }, { 1,2,4 } } with U = { 1, 2, 3, 4 }", [&]() {
         shared_levelized_file<zdd::node_t> in;
         /*
-                _1_      ---- x1
-              /   \
-              2   3     ---- x2
-              / \ / \
-              T 4 F 5    ---- x3
-              / \ / \
-              6 T 7 T   ---- x4
-              / \ / \
-              F T T T
+        //        _1_      ---- x1
+        //       /   \
+        //       2   3     ---- x2
+        //      / \ / \
+        //      T 4 F 5    ---- x3
+        //      / \ / \
+        //      6 T 7 T    ---- x4
+        //     / \ / \
+        //     F T T T
         */
         { // Garbage collect writer early
           const node n7 = node(4, node::MAX_ID,   terminal_T, terminal_T);
@@ -676,90 +676,90 @@ go_bandit([]() {
 
         __zdd out = zdd_complement(in, dom_1234);
         /*
-                  _1_                ---- x1
-                  /   \
-                  2   3               ---- x2
-                  X__ X_______
-                /   X____    \
-                /   /     \    \
-                4   5     6    7      ---- x3
-              / \ / \___ |\__ ||
-              /   X______\\   \||
-            /   /       \\\  |||
-            8  9         10   11     ---- x4
-            / \/ \       /  \  ||
-            T F  F       F  T  T
+        //           _1_                ---- x1
+        //          /   \
+        //          2   3               ---- x2
+        //          X__ X_______
+        //         /   X____    \
+        //        /   /     \    \
+        //        4   5     6    7      ---- x3
+        //       / \ / \___ |\__ ||
+        //      /   X______\\   \||
+        //     /   /       \\\  |||
+        //     8  9         10   11     ---- x4
+        //    / \/ \       /  \  ||
+        //    T F  F       F  T  T
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 6
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 7
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 8
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 9
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 10
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), ptr_uint64(4,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(4,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,2), ptr_uint64(4,2) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,2), false, ptr_uint64(4,2) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 11
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,2)), ptr_uint64(4,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,2), true,  ptr_uint64(4,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,3), ptr_uint64(4,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,3), false, ptr_uint64(4,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,3)), ptr_uint64(4,3) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,3), true,  ptr_uint64(4,3) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 8
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 9
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,1)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 10
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,2), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,2), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,2)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,2), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 11
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,3), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,3), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,3)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,3), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -785,7 +785,7 @@ go_bandit([]() {
         AssertThat(out.get<__zdd::shared_arcs_t>()->number_of_terminals[true],  Is().EqualTo(4u));
       });
 
-    it("computes pow(U) \\ pow(U) with U = { 2, 4 }", [&]() {
+      it("computes pow(U) \\ pow(U) with U = { 2, 4 }", [&]() {
 
         adiar::shared_file<zdd::label_t> U;
         {
@@ -795,30 +795,30 @@ go_bandit([]() {
 
         __zdd out = zdd_complement(zdd_pow_24, U);
         /*
-            1      ---- x2
-            / \
-            | |
-            \ /
-            2      ---- x4
-            / \
-            F F
+        //     1      ---- x2
+        //    / \
+        //    | |
+        //    \ /
+        //     2      ---- x4
+        //    / \
+        //    F F
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 2
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -838,65 +838,65 @@ go_bandit([]() {
         AssertThat(out.get<__zdd::shared_arcs_t>()->number_of_terminals[true],  Is().EqualTo(0u));
       });
 
-    it("computes pow(U) \\ pow({ 2, 4 }) with U = { 1, 2, 3, 4 }", [&]() {
+      it("computes pow(U) \\ pow({ 2, 4 }) with U = { 1, 2, 3, 4 }", [&]() {
         __zdd out = zdd_complement(zdd_pow_24, dom_1234);
         /*
-              _1_       ---- x1
-            /   \
-            2   3      ---- x2
-            ||  ||
-            4   5      ---- x3
-            / \__||
-            6    7      ---- x4
-          / \  / \
-          F F  T T
+        //      _1_       ---- x1
+        //     /   \
+        //     2   3      ---- x2
+        //    ||   ||
+        //     4   5      ---- x3
+        //    / \__||
+        //    6    7      ---- x4
+        //   / \  / \
+        //   F F  T T
         */
 
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 2
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 3
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 4
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 5
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), ptr_uint64(3,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(3,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 6
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(4,0) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(4,0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // 7
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), ptr_uint64(4,1) }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(4,1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 6
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // 7
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,1)), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,1), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -933,23 +933,23 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                      terminal_T,
-                                                      terminal_T)));
+                                                terminal_T,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                ptr_uint64(3, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                      ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(1, ptr_uint64::MAX_ID),
+                                                ptr_uint64(1, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -987,23 +987,23 @@ go_bandit([]() {
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                      terminal_F,
-                                                      terminal_T)));
+                                                terminal_F,
+                                                terminal_T)));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                      ptr_uint64(4, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(4, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(4, ptr_uint64::MAX_ID),
+                                                ptr_uint64(4, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                ptr_uint64(3, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().True());
         AssertThat(ns.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                      ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                ptr_uint64(2, ptr_uint64::MAX_ID))));
 
         AssertThat(ns.can_pull(), Is().False());
 
@@ -1033,4 +1033,4 @@ go_bandit([]() {
       });
     });
   });
-});
+ });

--- a/test/adiar/zdd/test_expand.cpp
+++ b/test/adiar/zdd/test_expand.cpp
@@ -18,9 +18,9 @@ go_bandit([]() {
 
     shared_levelized_file<zdd::node_t> zdd_x1;
     /*
-             1              ---- x1
-            / \
-            F T
+    //         1              ---- x1
+    //        / \
+    //        F T
     */
 
     { // Garbage collect writers to free write-lock
@@ -30,18 +30,18 @@ go_bandit([]() {
 
     shared_levelized_file<zdd::node_t> zdd_1;
     /*
-             _1_            ---- x2
-            /   \
-            2   3           ---- x4
-           / \ / \
-           F _4_ T          ---- x6
-            /   \
-            5   6           ---- x8
-           / \ / \
-           7 T T T          ---- x10
-          / \
-          F T
-     */
+    //         _1_            ---- x2
+    //        /   \
+    //        2   3           ---- x4
+    //       / \ / \
+    //       F _4_ T          ---- x6
+    //        /   \
+    //        5   6           ---- x8
+    //       / \ / \
+    //       7 T T T          ---- x10
+    //      / \
+    //      F T
+    */
 
     const node n1_7 = node(10, zdd::MAX_ID,   terminal_F,   terminal_T);
     const node n1_6 = node(8,  zdd::MAX_ID,   terminal_T,   terminal_T);
@@ -191,7 +191,7 @@ go_bandit([]() {
       AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
@@ -199,7 +199,7 @@ go_bandit([]() {
       AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -241,30 +241,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -310,30 +310,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -383,42 +383,42 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,0), ptr_uint64(5,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,0), false, ptr_uint64(5,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), ptr_uint64(5,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  ptr_uint64(5,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,0), ptr_uint64(6,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,0), false, ptr_uint64(6,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(5,0)), ptr_uint64(6,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,0), true,  ptr_uint64(6,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(1,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(6,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(6,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(6,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(6,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -471,24 +471,24 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -532,30 +532,30 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(0,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -603,36 +603,36 @@ go_bandit([]() {
       arc_test_stream arcs(out);
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,1)), ptr_uint64(2,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(2,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(2,1)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(2,1), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -669,125 +669,125 @@ go_bandit([]() {
 
       // Pre-chain
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(0,0)), ptr_uint64(1,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
 
       // (1) and its x3 cut
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(1,0)), ptr_uint64(2,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), ptr_uint64(3,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(2,0)), ptr_uint64(3,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
 
       // (2) and (3) and their x5 cut
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,0)), ptr_uint64(4,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(4,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), ptr_uint64(4,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(4,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(3,1)), ptr_uint64(4,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(4,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(4,0)), ptr_uint64(5,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,0), true,  ptr_uint64(5,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,1), ptr_uint64(5,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,1), false, ptr_uint64(5,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(4,1)), ptr_uint64(5,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(4,1), true,  ptr_uint64(5,1) }));
 
       // (4) and the x7 cuts
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,0), ptr_uint64(6,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,0), false, ptr_uint64(6,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(5,0)), ptr_uint64(6,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,0), true,  ptr_uint64(6,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(6,0), ptr_uint64(7,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(6,0), false, ptr_uint64(7,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(6,0)), ptr_uint64(7,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(6,0), true,  ptr_uint64(7,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,1), ptr_uint64(7,2) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,1), false, ptr_uint64(7,2) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(5,1)), ptr_uint64(7,2) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(5,1), true,  ptr_uint64(7,2) }));
 
       // (5) and (6) and their x9 cuts
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,0), ptr_uint64(8,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,0),  false, ptr_uint64(8,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(7,0)), ptr_uint64(8,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,0),  true,  ptr_uint64(8,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,1), ptr_uint64(8,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,1),  false, ptr_uint64(8,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(7,1)), ptr_uint64(8,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,1),  true,  ptr_uint64(8,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(8,0), ptr_uint64(9,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(8,0),  false, ptr_uint64(9,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,2), ptr_uint64(9,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,2),  false, ptr_uint64(9,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(7,2)), ptr_uint64(9,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(7,2),  true,  ptr_uint64(9,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(8,0)), ptr_uint64(9,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(8,0),  true,  ptr_uint64(9,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(8,1), ptr_uint64(9,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(8,1),  false, ptr_uint64(9,1) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(8,1)), ptr_uint64(9,1) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(8,1),  true,  ptr_uint64(9,1) }));
 
       // (7) and the x11 cuts
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(9,0), ptr_uint64(10,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(9,0),  false, ptr_uint64(10,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True());
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(9,0)), ptr_uint64(10,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(9,0),  true,  ptr_uint64(10,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(9,1), ptr_uint64(11,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(9,1),  false, ptr_uint64(11,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(9,1)), ptr_uint64(11,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(9,1),  true,  ptr_uint64(11,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().True()); // T chain
-      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(ptr_uint64(10,0)), ptr_uint64(11,0) }));
+      AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(10,0), true,  ptr_uint64(11,0) }));
 
       AssertThat(arcs.can_pull_internal(), Is().False());
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(4,0),  false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(10,0), terminal_F }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(10,0), false, terminal_F }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(11,0), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(11,0), false, terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().True());
-      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(ptr_uint64(11,0)), terminal_T }));
+      AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { ptr_uint64(11,0), true,  terminal_T }));
 
       AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/zdd/test_subset.cpp
+++ b/test/adiar/zdd/test_subset.cpp
@@ -144,10 +144,10 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1.uid()), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -188,10 +188,10 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -232,10 +232,10 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -266,36 +266,36 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_2.uid()), n1_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), true,  n1_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_3.uid()), n1_5.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), true,  n1_5.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_4.uid()), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_4.uid(), true,  n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_5.uid(), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_5.uid(), false, n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_5.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_5.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_6.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -335,24 +335,24 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_1.uid()), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), true,  n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_4.uid()), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_4.uid(), true,  n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_6.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -506,24 +506,24 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), n2_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), false, n2_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_1.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_2.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_2.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_2.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_2.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2_3.uid()), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -681,10 +681,10 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -752,24 +752,24 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_1.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_3.uid()), n2_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_3.uid(), true,  n2_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_1.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_1.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2_4.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -813,18 +813,18 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_1.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_1.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_1.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2_3.uid()), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), true,  terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -858,42 +858,42 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_1.uid()), n1_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), true,  n1_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_2.uid()), n1_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), true,  n1_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_3.uid()), n1_5.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), true,  n1_5.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_4.uid()), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_4.uid(), true,  n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_5.uid(), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_5.uid(), false, n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_1.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_1.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_5.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_5.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_6.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -936,36 +936,36 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), n1_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), false, n1_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_1.uid()), n1_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), true,  n1_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_2.uid()), n1_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), true,  n1_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_3.uid()), n1_5.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), true,  n1_5.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_5.uid(), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_5.uid(), false, n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_2.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_2.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_3.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_3.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_5.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_5.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_6.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1073,24 +1073,24 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2.uid()), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2.uid(), true,  n3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n3.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1146,18 +1146,18 @@ go_bandit([]() {
         arc_test_stream arcs(out);
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1191,30 +1191,30 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), n2_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), false, n2_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_1.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_1.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_2.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_2.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_3.uid()), n2_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_3.uid(), true,  n2_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_2.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_2.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2_4.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1254,24 +1254,24 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_2.uid()), n2_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_2.uid(), true,  n2_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n2_3.uid()), n2_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n2_3.uid(), true,  n2_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_2.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_2.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_3.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n2_4.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n2_4.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1308,36 +1308,36 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), n1_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), false, n1_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_1.uid()), n1_2.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_1.uid(), true,  n1_2.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_2.uid()), n1_3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), true,  n1_3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_2.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), n1_4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), false, n1_4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_3.uid()), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_3.uid(), true,  n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1_4.uid()), n1_6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1_4.uid(), true,  n1_6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n1_6.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1_6.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
@@ -1405,30 +1405,30 @@ go_bandit([]() {
         AssertThat(arcs.can_pull_internal(), Is().True());
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n1.uid()), n3.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n1.uid(), true,  n3.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n3.uid()), n4.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n3.uid(), true,  n4.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { flag(n4.uid()), n6.uid() }));
+        AssertThat(arcs.pull_internal(), Is().EqualTo(arc { n4.uid(), true,  n6.uid() }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n1.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n3.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), terminal_F }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n4.uid(), false, terminal_F }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n6.uid(), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n6.uid(), false, terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { flag(n6.uid()), terminal_T }));
+        AssertThat(arcs.pull_terminal(), Is().EqualTo(arc { n6.uid(), true,  terminal_T }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 

--- a/test/adiar/zdd/test_zdd.cpp
+++ b/test/adiar/zdd/test_zdd.cpp
@@ -80,11 +80,11 @@ go_bandit([]() {
 
       {
         arc_writer aw(af);
-        aw.push_internal(arc {ptr_uint64(0,0), ptr_uint64(1,0)});
+        aw.push_internal(arc {ptr_uint64(0,0), false, ptr_uint64(1,0)});
 
-        aw.push_terminal(arc {flag(ptr_uint64(0,0)), ptr_uint64(true)});
-        aw.push_terminal(arc {ptr_uint64(1,0), ptr_uint64(false)});
-        aw.push_terminal(arc {flag(ptr_uint64(1,0)), ptr_uint64(true)});
+        aw.push_terminal(arc {ptr_uint64(0,0), true,  ptr_uint64(true)});
+        aw.push_terminal(arc {ptr_uint64(1,0), false, ptr_uint64(false)});
+        aw.push_terminal(arc {ptr_uint64(1,0), true,  ptr_uint64(true)});
 
         aw.push(level_info(0,1u));
         aw.push(level_info(1,1u));

--- a/test/test.h
+++ b/test/test.h
@@ -103,7 +103,7 @@ namespace snowhouse
       std::stringstream stream;
       stream << "arc: "
              << string_of_adiar_uid(a.source())
-             << " " << (a.is_high() ? "--->" : "- ->") << " "
+             << " " << (a.out_idx() ? "--->" : "- ->") << " "
              << string_of_adiar_uid(a.target())
         ;
       return stream.str();


### PR DESCRIPTION
Multiple fixes (primarily for the Reduce algorithm) that are part of the foundation for implementing the Nested Sweeping algorithm.

**Fixes**

- Fix Reduce for small widths is not computed with a priority queue with a look ahead of 0.
- Fix `make test` crashes due to typo

**Preparation for Nested Sweeping**

- Make the `__reduce` function return the node file rather than the `bdd` wrapping it.
- Make the data structures expose their respective types. This allows Nested Sweeping to obtain the type of the elements
- Add support in the sorters for single ownership of some memory. This will be used as part of Nested Sweeping.
- Move the *is_high* value from the *flag* on the source to a separate *out_idx* value (closes #475).