### PR TITLE
Add IPO (if possible) to Adiar's compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,13 +42,13 @@ message(STATUS "  | Statistics:              ${ADIAR_STATS}")
 
 message(STATUS "  Optional targets:")
 
-option(ADIAR_DOCS "Build Documentation for Adiar" ON)
+option(ADIAR_DOCS "Create target for Adiar's documentation" ${PROJECT_IS_TOP_LEVEL})
 message(STATUS "  | Documentation (Doxygen): ${ADIAR_DOCS}")
 
-option(ADIAR_TEST "Build unit tests for adiar" ${PROJECT_IS_TOP_LEVEL})
+option(ADIAR_TEST "Create target for Adiar's unit tests" ${PROJECT_IS_TOP_LEVEL})
 message(STATUS "  | Unit Tests:              ${ADIAR_TEST}")
 
-option(ADIAR_EXAMPLES "Build examples for usage of adiar" ${PROJECT_IS_TOP_LEVEL})
+option(ADIAR_EXAMPLES "Create targets for Adiar's examples" ${PROJECT_IS_TOP_LEVEL})
 message(STATUS "  | Examples:                ${ADIAR_EXAMPLES}")
 
 message(STATUS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ message(VERBOSE "    EXE Linker Flags:       ${CMAKE_EXE_LINKER_FLAGS}")
 
 message(STATUS "  Library Options:")
 
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+	option(ADIAR_IPO "Enable Interprocedural Optimisations (IPO)" ON)
+else ()
+	option(ADIAR_IPO "Enable Interprocedural Optimisations (IPO)" OFF)
+endif()
+message(STATUS "  | IPO:                     ${ADIAR_IPO}")
+
 option(ADIAR_SHARED "Build adiar as a shared library" OFF)
 message(STATUS "  | Shared:                  ${ADIAR_SHARED}")
 

--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -176,4 +176,15 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   VERSION ${PROJECT_VERSION}
 )
 
+# Include Interprocedural Optimisations, if requested and possible
+if (ADIAR_IPO)
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT ipo_result OUTPUT ipo_output)
+	if(ipo_result)
+	  set_property(TARGET adiar PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+	else()
+	  message(WARNING "IPO is not supported: ${ipo_output}")
+	endif()
+endif(ADIAR_IPO)
+ 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)


### PR DESCRIPTION
Adds the new `ADIAR_IPO` option which allows you to compile Adiar with Interprocedural Optimisations. This may decrease the binary size (currently about 7 MiB) slightly and hopefully improve performance as an offshot.

I do not know, whether this truly has any relevance to this library.