### PR TITLE
Deprecation/file based quantify

### DIFF
--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -387,24 +387,6 @@ namespace adiar
   ///
   /// \param f    BDD to be quantified.
   ///
-  /// \param vars Variables to quantify in f (in order of their quantification)
-  ///
-  /// \returns    \f$ \exists x_{i_1}, \dots, x_{i_k} : f \f$
-  //////////////////////////////////////////////////////////////////////////////
-  __bdd bdd_exists(const bdd &f, const shared_file<bdd::label_t> &vars);
-
-  /// \cond
-  __bdd bdd_exists(bdd &&f, const shared_file<bdd::label_t> &vars);
-  /// \endcond
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief      Existential quantification of multiple variables.
-  ///
-  /// \details    Repeatedly calls `bdd_exists` for the given variables
-  ///             while optimising garbage collecting intermediate results.
-  ///
-  /// \param f    BDD to be quantified.
-  ///
   /// \param vars Predicate to identify the variables to quantify in f. You may
   ///             abuse the fact, that this predicate will only be invoked in
   ///             ascending/descending order of the levels in `f` (but, with
@@ -487,24 +469,6 @@ namespace adiar
   /// \cond
   inline __bdd bdd_forall(bdd &&f, bdd::label_t var)
   { return bdd_forall(f, var); }
-  /// \endcond
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief      Forall quantification of multiple variables.
-  ///
-  /// \details    Repeatedly calls `bdd_forall` for the given variables
-  ///             while optimising garbage collecting intermediate results.
-  ///
-  /// \param f    BDD to be quantified.
-  ///
-  /// \param vars Variables to quantify in f (in order of their quantification)
-  ///
-  /// \returns    \f$ \forall x_{i_1}, \dots, x_{i_k} : f \f$
-  //////////////////////////////////////////////////////////////////////////////
-  __bdd bdd_forall(const bdd &f, const shared_file<bdd::label_t> &vars);
-
-  /// \cond
-  __bdd bdd_forall(bdd &&f, const shared_file<bdd::label_t> &vars);
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -60,7 +60,7 @@ namespace adiar
     }
 
   public:
-    static constexpr bool pred_value = true;
+    static constexpr bool quantify_onset = true;
   };
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -69,20 +69,6 @@ namespace adiar
     return internal::quantify<bdd_quantify_policy>(f, var, or_op);
   }
 
-  // LCOV_EXCL_START
-  // TODO (deprecated): remove
-  __bdd bdd_exists(const bdd &f, const shared_file<bdd::label_t> &vars)
-  {
-    return internal::quantify<bdd_quantify_policy>(f, vars, or_op);
-  }
-
-  // TODO (deprecated): remove
-  __bdd bdd_exists(bdd &&f, const shared_file<bdd::label_t> &vars)
-  {
-    return internal::quantify<bdd_quantify_policy>(std::forward<bdd>(f), vars, or_op);
-  }
-  // LCOV_EXCL_STOP
-
   __bdd bdd_exists(const bdd &f, const std::function<bool(bdd::label_t)> &vars)
   {
     return internal::quantify<bdd_quantify_policy>(f, vars, or_op);
@@ -108,20 +94,6 @@ namespace adiar
   {
     return internal::quantify<bdd_quantify_policy>(f, var, and_op);
   }
-
-  // LCOV_EXCL_START
-  // TODO (deprecated): remove
-  __bdd bdd_forall(const bdd &f, const shared_file<bdd::label_t> &vars)
-  {
-    return internal::quantify<bdd_quantify_policy>(f, vars, and_op);
-  }
-
-  // TODO (deprecated): remove
-  __bdd bdd_forall(bdd &&f, const shared_file<bdd::label_t> &vars)
-  {
-    return internal::quantify<bdd_quantify_policy>(std::forward<bdd>(f), vars, and_op);
-  }
-  // LCOV_EXCL_STOP
 
   __bdd bdd_forall(const bdd &f, const std::function<bool(bdd::label_t)> &vars)
   {

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -69,15 +69,19 @@ namespace adiar
     return internal::quantify<bdd_quantify_policy>(f, var, or_op);
   }
 
+  // LCOV_EXCL_START
+  // TODO (deprecated): remove
   __bdd bdd_exists(const bdd &f, const shared_file<bdd::label_t> &vars)
   {
     return internal::quantify<bdd_quantify_policy>(f, vars, or_op);
   }
 
+  // TODO (deprecated): remove
   __bdd bdd_exists(bdd &&f, const shared_file<bdd::label_t> &vars)
   {
     return internal::quantify<bdd_quantify_policy>(std::forward<bdd>(f), vars, or_op);
   }
+  // LCOV_EXCL_STOP
 
   __bdd bdd_exists(const bdd &f, const std::function<bool(bdd::label_t)> &vars)
   {
@@ -94,26 +98,30 @@ namespace adiar
     return internal::quantify<bdd_quantify_policy>(f, gen, or_op);
   }
 
-  //////////////////////////////////////////////////////////////////////////////
   __bdd bdd_exists(bdd &&f, const std::function<bdd::label_t()> &gen)
   {
     return internal::quantify<bdd_quantify_policy>(std::forward<bdd>(f), gen, or_op);
   }
+  //////////////////////////////////////////////////////////////////////////////
 
   __bdd bdd_forall(const bdd &f, bdd::label_t var)
   {
     return internal::quantify<bdd_quantify_policy>(f, var, and_op);
   }
 
+  // LCOV_EXCL_START
+  // TODO (deprecated): remove
   __bdd bdd_forall(const bdd &f, const shared_file<bdd::label_t> &vars)
   {
     return internal::quantify<bdd_quantify_policy>(f, vars, and_op);
   }
 
+  // TODO (deprecated): remove
   __bdd bdd_forall(bdd &&f, const shared_file<bdd::label_t> &vars)
   {
     return internal::quantify<bdd_quantify_policy>(std::forward<bdd>(f), vars, and_op);
   }
+  // LCOV_EXCL_STOP
 
   __bdd bdd_forall(const bdd &f, const std::function<bool(bdd::label_t)> &vars)
   {

--- a/src/adiar/deprecated.h
+++ b/src/adiar/deprecated.h
@@ -5,6 +5,47 @@ namespace adiar
 {
   // LCOV_EXCL_START
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief      Existential quantification of multiple variables.
+  ///
+  /// \details    Repeatedly calls `bdd_exists` for the given variables
+  ///             while optimising garbage collecting intermediate results.
+  ///
+  /// \param f    BDD to be quantified.
+  ///
+  /// \param vars Variables to quantify in f (in order of their quantification)
+  ///
+  /// \returns    \f$ \exists x_{i_1}, \dots, x_{i_k} : f \f$
+  //////////////////////////////////////////////////////////////////////////////
+  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
+    __bdd bdd_exists(const bdd &f, const shared_file<bdd::label_t> &vars);
+
+  /// \cond
+  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
+    __bdd bdd_exists(bdd &&f, const shared_file<bdd::label_t> &vars);
+  /// \endcond
+
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief      Forall quantification of multiple variables.
+  ///
+  /// \details    Repeatedly calls `bdd_forall` for the given variables
+  ///             while optimising garbage collecting intermediate results.
+  ///
+  /// \param f    BDD to be quantified.
+  ///
+  /// \param vars Variables to quantify in f (in order of their quantification)
+  ///
+  /// \returns    \f$ \forall x_{i_1}, \dots, x_{i_k} : f \f$
+  //////////////////////////////////////////////////////////////////////////////
+  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
+  __bdd bdd_forall(const bdd &f, const shared_file<bdd::label_t> &vars);
+
+  /// \cond
+  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
+  __bdd bdd_forall(bdd &&f, const shared_file<bdd::label_t> &vars);
+  /// \endcond
+
   // LCOV_EXCL_STOP
 }
 

--- a/src/adiar/deprecated.h
+++ b/src/adiar/deprecated.h
@@ -5,66 +5,6 @@ namespace adiar
 {
   // LCOV_EXCL_START
 
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief      Existential quantification of multiple variables.
-  ///
-  /// \details    Repeatedly calls `bdd_exists` for the given variables
-  ///             while optimising garbage collecting intermediate results.
-  ///
-  /// \param f    BDD to be quantified.
-  ///
-  /// \param vars Variables to quantify in f (in order of their quantification)
-  ///
-  /// \returns    \f$ \exists x_{i_1}, \dots, x_{i_k} : f \f$
-  //////////////////////////////////////////////////////////////////////////////
-  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
-    __bdd bdd_exists(const bdd &f, const shared_file<bdd::label_t> &vars);
-
-  /// \cond
-  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
-    __bdd bdd_exists(bdd &&f, const shared_file<bdd::label_t> &vars);
-  /// \endcond
-
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief      Forall quantification of multiple variables.
-  ///
-  /// \details    Repeatedly calls `bdd_forall` for the given variables
-  ///             while optimising garbage collecting intermediate results.
-  ///
-  /// \param f    BDD to be quantified.
-  ///
-  /// \param vars Variables to quantify in f (in order of their quantification)
-  ///
-  /// \returns    \f$ \forall x_{i_1}, \dots, x_{i_k} : f \f$
-  //////////////////////////////////////////////////////////////////////////////
-  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
-  __bdd bdd_forall(const bdd &f, const shared_file<bdd::label_t> &vars);
-
-  /// \cond
-  [[deprecated("Replaced with using 'predicates', 'generators' etc. for multiple variables")]]
-  __bdd bdd_forall(bdd &&f, const shared_file<bdd::label_t> &vars);
-  /// \endcond
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief     Project family of sets onto a domain, i.e. remove from every
-  ///            set all variables not mentioned.
-  ///
-  /// \param A   Family of sets to project
-  ///
-  /// \param dom The domain to project onto (in ascending order)
-  ///
-  /// \returns
-  /// \f$ \prod_{\mathit{dom}}(A) = \{ a \setminus \mathit{dom}^c \mid a \in A \} \f$
-  //////////////////////////////////////////////////////////////////////////////
-  [[deprecated("Replaced with using 'predicates' for multiple variables")]]
-  __zdd zdd_project(const zdd &A, const shared_file<zdd::label_t> &dom);
-
-  /// \cond
-  [[deprecated("Replaced with using 'predicates' for multiple variables")]]
-  __zdd zdd_project(zdd &&A, const shared_file<zdd::label_t> &dom);
-  /// \endcond
-
   // LCOV_EXCL_STOP
 }
 

--- a/src/adiar/deprecated.h
+++ b/src/adiar/deprecated.h
@@ -46,6 +46,25 @@ namespace adiar
   __bdd bdd_forall(bdd &&f, const shared_file<bdd::label_t> &vars);
   /// \endcond
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief     Project family of sets onto a domain, i.e. remove from every
+  ///            set all variables not mentioned.
+  ///
+  /// \param A   Family of sets to project
+  ///
+  /// \param dom The domain to project onto (in ascending order)
+  ///
+  /// \returns
+  /// \f$ \prod_{\mathit{dom}}(A) = \{ a \setminus \mathit{dom}^c \mid a \in A \} \f$
+  //////////////////////////////////////////////////////////////////////////////
+  [[deprecated("Replaced with using 'predicates' for multiple variables")]]
+  __zdd zdd_project(const zdd &A, const shared_file<zdd::label_t> &dom);
+
+  /// \cond
+  [[deprecated("Replaced with using 'predicates' for multiple variables")]]
+  __zdd zdd_project(zdd &&A, const shared_file<zdd::label_t> &dom);
+  /// \endcond
+
   // LCOV_EXCL_STOP
 }
 

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -509,36 +509,6 @@ namespace adiar::internal
   };
 
   //////////////////////////////////////////////////////////////////////////////
-  // Multi-variable (file)
-  // TODO (deprecated): Remove
-
-  // LCOV_EXCL_START
-  template<typename quantify_policy>
-  typename quantify_policy::unreduced_t
-  quantify(typename quantify_policy::reduced_t dd,
-           const shared_file<typename quantify_policy::label_t> labels,
-           const bool_op &op)
-  {
-    const size_t labels_size = labels->size();
-    if (labels_size == 0) { return dd; }
-
-    file_stream<typename quantify_policy::label_t> label_stream(labels);
-
-    for (size_t label_idx = 0u; label_idx < labels_size - 1; label_idx++) {
-      if (is_terminal(dd)) { return dd; }
-
-      adiar_debug(label_stream.can_pull(), "Should not exceed 'labels' size");
-      dd = quantify<quantify_policy>(dd, label_stream.pull(), op);
-    }
-
-    adiar_debug(label_stream.can_pull(), "Should not exceed 'labels' size");
-    const typename quantify_policy::label_t label = label_stream.pull();
-    adiar_debug(!label_stream.can_pull(), "Should pull final label");
-    return quantify<quantify_policy>(dd, label, op);
-  }
-  // LCOV_EXCL_STOP
-
-  //////////////////////////////////////////////////////////////////////////////
   // Multi-variable (predicate)
   template<typename quantify_policy>
   class multi_quantify_policy__pred

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -510,6 +510,9 @@ namespace adiar::internal
 
   //////////////////////////////////////////////////////////////////////////////
   // Multi-variable (file)
+  // TODO (deprecated): Remove
+
+  // LCOV_EXCL_START
   template<typename quantify_policy>
   typename quantify_policy::unreduced_t
   quantify(typename quantify_policy::reduced_t dd,
@@ -533,6 +536,7 @@ namespace adiar::internal
     adiar_debug(!label_stream.can_pull(), "Should pull final label");
     return quantify<quantify_policy>(dd, label, op);
   }
+  // LCOV_EXCL_STOP
 
   //////////////////////////////////////////////////////////////////////////////
   // Multi-variable (predicate)

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -333,23 +333,6 @@ namespace adiar
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief     Project family of sets onto a domain, i.e. remove from every
-  ///            set all variables not mentioned.
-  ///
-  /// \param A   Family of sets to project
-  ///
-  /// \param dom The domain to project onto (in ascending order)
-  ///
-  /// \returns
-  /// \f$ \prod_{\mathit{dom}}(A) = \{ a \setminus \mathit{dom}^c \mid a \in A \} \f$
-  //////////////////////////////////////////////////////////////////////////////
-  __zdd zdd_project(const zdd &A, const shared_file<zdd::label_t> &dom);
-
-  /// \cond
-  __zdd zdd_project(zdd &&A, const shared_file<zdd::label_t> &dom);
-  /// \endcond
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief     Project family of sets onto a domain, i.e. remove from every
   ///            set all variables not within the domain.
   ///
   /// \param A   Family of sets to project
@@ -363,6 +346,52 @@ namespace adiar
 
   /// \cond
   __zdd zdd_project(zdd &&A, const std::function<bool(zdd::label_t)> &dom);
+  /// \endcond
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief     Project family of sets onto a domain, i.e. remove from every
+  ///            set all variables not within the domain.
+  ///
+  /// \param A   Family of sets to project
+  ///
+  /// \param gen Generator function, that produces the variables of the domain in
+  ///            *descending* order. When none are left to-be quantified, it
+  ///            returns a value larger than `bdd::MAX_LABEL`, e.g. -1.
+  ///
+  /// \returns
+  /// \f$ \prod_{\mathit{dom}}(A) = \{ a \setminus \mathit{dom}^c \mid a \in A \} \f$
+  //////////////////////////////////////////////////////////////////////////////
+  __zdd zdd_project(const zdd &A, const std::function<zdd::label_t()> &dom);
+
+  /// \cond
+  __zdd zdd_project(zdd &&A, const std::function<zdd::label_t()> &dom);
+  /// \endcond
+
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief     Project family of sets onto a domain, i.e. remove from every
+  ///            set all variables not within the domain.
+  ///
+  /// \param A   Family of sets to project
+  ///
+  /// \param begin Iterator that provides the domain in *descending* order.
+  ///
+  /// \returns
+  /// \f$ \prod_{\mathit{dom}}(A) = \{ a \setminus \mathit{dom}^c \mid a \in A \} \f$
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename IT>
+  __zdd zdd_project(const zdd &A, IT begin, IT end)
+  {
+    return zdd_project(A, internal::iterator_gen<bdd::label_t>(begin, end));
+  }
+
+  /// \cond
+  template<typename IT>
+  __zdd zdd_project(zdd &&A, IT begin, IT end)
+  {
+    return zdd_project(std::forward<zdd>(A),
+                       internal::iterator_gen<bdd::label_t>(begin, end));
+  }
   /// \endcond
 
   /// \}

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -59,60 +59,6 @@ namespace adiar
   };
 
   //////////////////////////////////////////////////////////////////////////////
-  // LCOV_EXCL_START
-  // TODO (deprecated): remove
-
-  shared_file<zdd::label_t>
-  extract_non_dom(const zdd &dd, const shared_file<zdd::label_t> &dom)
-  {
-    shared_file<zdd::label_t> dom_inv;
-    internal::label_writer diw(dom_inv);
-
-    internal::file_stream<zdd::label_t> ls(dom);
-    internal::level_info_stream<> dd_meta(dd);
-
-    while (dd_meta.can_pull()) {
-      zdd::label_t dd_label = dd_meta.pull().label();
-      bool found_dd_label = false;
-
-      while (ls.can_pull()) {
-        zdd::label_t dom_label = ls.pull();
-
-        if (dd_label == dom_label) {
-          found_dd_label = true;
-          break;
-        }
-      }
-      if (!found_dd_label) { diw << dd_label; }
-      ls.reset();
-    }
-
-    return dom_inv;
-  }
-
-  inline __zdd zdd_project_multi(zdd &&A, const shared_file<zdd::label_t> &dom)
-  {
-    if (is_terminal(A))   { return A; }
-    if (dom->size() == 0) { return zdd_null(); }
-
-    const shared_file<zdd::label_t> dom_inv = extract_non_dom(A, dom);
-    if (dom_inv->size() == zdd_varcount(A)) { return zdd_null(); }
-
-    return internal::quantify<zdd_project_policy>(std::forward<zdd>(A), dom_inv, or_op);
-  }
-
-  __zdd zdd_project(const zdd &A, const shared_file<zdd::label_t> &dom)
-  {
-    return zdd_project_multi(zdd(A), dom);
-  }
-
-  __zdd zdd_project(zdd &&A, const shared_file<zdd::label_t> &dom)
-  {
-    return zdd_project_multi(std::forward<zdd>(A), dom);
-  }
-
-  // LCOV_EXCL_STOP
-  //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_project(const zdd &A, const std::function<bool(zdd::label_t)> &dom)
   {
     return internal::quantify<zdd_project_policy>(A, dom, or_op);

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -55,7 +55,7 @@ namespace adiar
     }
 
   public:
-    static constexpr bool pred_value = false;
+    static constexpr bool quantify_onset = false;
   };
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -59,6 +59,9 @@ namespace adiar
   };
 
   //////////////////////////////////////////////////////////////////////////////
+  // LCOV_EXCL_START
+  // TODO (deprecated): remove
+
   shared_file<zdd::label_t>
   extract_non_dom(const zdd &dd, const shared_file<zdd::label_t> &dom)
   {
@@ -98,12 +101,6 @@ namespace adiar
     return internal::quantify<zdd_project_policy>(std::forward<zdd>(A), dom_inv, or_op);
   }
 
-  inline __zdd zdd_project_multi(zdd &&A, const std::function<bool(zdd::label_t)> &dom)
-  {
-    return internal::quantify<zdd_project_policy>(std::forward<zdd>(A), dom, or_op);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_project(const zdd &A, const shared_file<zdd::label_t> &dom)
   {
     return zdd_project_multi(zdd(A), dom);
@@ -114,13 +111,25 @@ namespace adiar
     return zdd_project_multi(std::forward<zdd>(A), dom);
   }
 
+  // LCOV_EXCL_STOP
+  //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_project(const zdd &A, const std::function<bool(zdd::label_t)> &dom)
   {
-    return zdd_project_multi(zdd(A), dom);
+    return internal::quantify<zdd_project_policy>(A, dom, or_op);
   }
 
   __zdd zdd_project(zdd &&A, const std::function<bool(zdd::label_t)> &dom)
   {
-    return zdd_project_multi(std::forward<zdd>(A), dom);
+    return internal::quantify<zdd_project_policy>(std::forward<zdd>(A), dom, or_op);
+  }
+
+  __zdd zdd_project(const zdd &A, const std::function<zdd::label_t()> &dom)
+  {
+    return internal::quantify<zdd_project_policy>(A, dom, or_op);
+  }
+
+  __zdd zdd_project(zdd &&A, const std::function<zdd::label_t()> &dom)
+  {
+    return internal::quantify<zdd_project_policy>(A, dom, or_op);
   }
 }

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -1312,6 +1312,40 @@ go_bandit([]() {
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
+        it("quantifies 7, 5, 3, 1, -1 in BDD 6 [&&]", [&]() {
+          bdd::label_t var = 7;
+
+          /* expected
+          //
+          //         _1_
+          //        /   \
+          //        *   *
+          //         \ /
+          //          |
+          //          /
+          //         /
+          //        *
+          //        |
+          //        T
+           */
+          bdd out = bdd_exists(bdd_6, [&var]() {
+            const bdd::label_t ret = var;
+            var -= 2;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
         it("quantifies 1, -1 variables in BDD 1 [&&]", [&]() {
           bdd::label_t var = 1;
 

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -869,312 +869,6 @@ go_bandit([]() {
       });
     });
 
-    describe("bdd_exists(const bdd&, const shared_file<bdd::label_t>&)", [&]() {
-      it("quantifies [x1, x2] in terminal-only BDD [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 1 << 2;
-        }
-
-        __bdd out = bdd_exists(terminal_T, labels);
-
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>(), Is().EqualTo(terminal_T));
-        AssertThat(out.negate, Is().False());
-      });
-
-      it("quantifies [x1, x2] in terminal-only BDD [const &]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 1 << 2;
-        }
-
-        const bdd in_bdd = terminal_T;
-        __bdd out = bdd_exists(in_bdd, labels);
-
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>(), Is().EqualTo(terminal_T));
-        AssertThat(out.negate, Is().False());
-      });
-
-      it("quantifies [x1, x2] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 1 << 2;
-        }
-
-        bdd out = bdd_exists(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream out_meta(out);
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().False());
-      });
-
-      it("quantifies [x2, x1] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 2 << 1;
-        }
-
-        bdd out = bdd_exists(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream out_meta(out);
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().False());
-      });
-
-      it("quantifies [x2] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 2;
-        }
-
-        bdd out = bdd_exists(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream out_meta(out);
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().False());
-      });
-
-      it("quantifies [x1, x3] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 1 << 3;
-        }
-
-        bdd out = bdd_exists(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream out_meta(out);
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().False());
-      });
-
-      it("quantifies [x0, x2] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 0 << 2;
-        }
-
-        bdd out = bdd_exists(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream out_meta(out);
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().False());
-      });
-
-      it("quantifies [x0, x2] in BDD 4 [const &]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 0 << 2;
-        }
-
-        bdd in_bdd = bdd_4;
-        bdd out = bdd_exists(in_bdd, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream out_meta(out);
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
-
-        AssertThat(out_meta.can_pull(), Is().False());
-      });
-
-      it("quantifies [x3, x1, x0, x2] where it is terminal-only already before x2 BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 3 << 1 << 0 << 2;
-        }
-
-        bdd out = bdd_exists(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-      });
-
-      it("quantifies [x2, x1] into T terminal x2 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 2 << 1;
-        }
-
-        bdd out = bdd_exists(bdd_x2, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-      });
-
-      it("quantifies [] into the original file of BDD 3 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        // __bdd is used to access the shared_levelized_file<bdd::node_t>
-        __bdd out = bdd_exists(bdd_3, labels);
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>(), Is().EqualTo(bdd_3));
-      });
-
-      it("quantifies [] into the original file of BDD 3 [const &]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        bdd in_bdd = bdd_3;
-        __bdd out = bdd_exists(in_bdd, labels);
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>(), Is().EqualTo(bdd_3));
-      });
-    });
-
     describe("bdd_exists(const bdd&, const std::function<bool(bdd::label_t)>&)", [&]() {
       it("returns input on always-false predicate BDD 1 [&&]", [&]() {
         __bdd out = bdd_exists(bdd_1, [](const bdd::label_t) { return false; });
@@ -1212,6 +906,36 @@ go_bandit([]() {
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
+        it("quantifies 1, 2 in BDD 4 [&&]", [&]() {
+          bdd out = bdd_exists(bdd_4, [](const bdd::label_t x) { return x == 1 || x == 2; });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                         ptr_uint64(false),
+                                                         ptr_uint64(true))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(true))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
+        });
+
         it("quantifies even variables in BDD 4 [const &]", [&]() {
           const bdd in = bdd_4;
           const bdd out = bdd_exists(in, [](const bdd::label_t x) { return !(x % 2); });
@@ -1239,6 +963,8 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         it("quantifies odd variables in BDD 1 [&&]", [&]() {
@@ -1252,8 +978,9 @@ go_bandit([]() {
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
-
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         it("terminates early when quantifying to a terminal in BDD 1 [&&]", [&]() {
@@ -1275,8 +1002,24 @@ go_bandit([]() {
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
-
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
+        });
+
+        it("quantifies with always-true predicate in BDD 4 [&&]", [&]() {
+          bdd out = bdd_exists(bdd_4, [](const bdd::label_t) { return true; });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         quantify_mode = quantify_mode_t::AUTO;
@@ -1319,6 +1062,8 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         it("quantifies odd variables in BDD 1", [&]() {
@@ -1334,6 +1079,23 @@ go_bandit([]() {
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
+        });
+
+        it("quantifies with always-true predicate in BDD 4 [&&]", [&]() {
+          bdd out = bdd_exists(bdd_4, [](const bdd::label_t) { return true; });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         quantify_mode = quantify_mode_t::AUTO;
@@ -1372,6 +1134,21 @@ go_bandit([]() {
         });
 
         quantify_mode = quantify_mode_t::AUTO;
+      });
+
+      it("quantifies with always-true predicate in BDD 4 [&&]", [&]() {
+        bdd out = bdd_exists(bdd_4, [](const bdd::label_t) { return true; });
+
+        node_test_stream out_nodes(out);
+
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+        AssertThat(out_nodes.can_pull(), Is().False());
+
+        level_info_test_stream ms(out);
+        AssertThat(ms.can_pull(), Is().False());
+
+        // TODO: meta variables...
       });
     });
 
@@ -1889,152 +1666,6 @@ go_bandit([]() {
       });
     });
 
-    describe("bdd_forall(const bdd&, shared_file<bdd::label_t>&)", [&]() {
-      it("quantifies [x0, x2, x1] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 0 << 2 << 1;
-        }
-
-        __bdd out = bdd_forall(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(false)));
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>()->number_of_terminals[true],  Is().EqualTo(0u));
-      });
-
-      it("quantifies [x0, x2, x1] in BDD 4 [const &]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 0 << 2 << 1;
-        }
-
-        const bdd in_bdd = bdd_4;
-        __bdd out = bdd_forall(in_bdd, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(false)));
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>()->number_of_terminals[true],  Is().EqualTo(0u));
-      });
-
-      it("quantifies [x1] in BDD 4 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 1;
-        }
-
-        bdd out = bdd_forall(bdd_4, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True()); // (5,_) / (5,T)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True()); // (3,_) / (3,4)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
-
-        // The node (1,_) is reduced away due to its low child is (3,_)
-        // and its high child is (3,4)
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(2u,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-      });
-
-      it("quantifies [x1] in BDD 4 [const &]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        { // Garbage collect writer to free write-lock
-          label_writer lw(labels);
-          lw << 1;
-        }
-
-        const bdd in_bdd = bdd_4;
-        bdd out = bdd_forall(in_bdd, labels);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True()); // (5,_) / (5,T)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().True()); // (3,_) / (3,4)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
-
-        // The node (1,_) is reduced away due to its low child is (3,_)
-        // and its high child is (3,4)
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(3u,1u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(2u,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-      });
-
-      it("quantifies [] into the original file of BDD 3 [&&]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        // __bdd is used to access the shared_levelized_file<bdd::node_t>
-        __bdd out = bdd_forall(bdd_3, labels);
-
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>(), Is().EqualTo(bdd_3));
-        AssertThat(out.negate, Is().False());
-      });
-
-      it("quantifies [] into the original file of BDD 3 [const &]", [&]() {
-        adiar::shared_file<bdd::label_t> labels;
-
-        const bdd in_bdd = bdd_3;
-        __bdd out = bdd_forall(in_bdd, labels);
-
-        AssertThat(out.get<shared_levelized_file<bdd::node_t>>(), Is().EqualTo(bdd_3));
-        AssertThat(out.negate, Is().False());
-      });
-    });
-
     describe("bdd_forall(const bdd&, const std::function<bool(bdd::label_t)>&)", [&]() {
       it("returns input on always-false predicate BDD 1 [&&]", [&]() {
         __bdd out = bdd_forall(bdd_1, [](const bdd::label_t) { return false; });
@@ -2063,6 +1694,8 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         it("quantifies odd variables in BDD 1 [&&]", [&]() {
@@ -2083,6 +1716,24 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
+        });
+
+        it("quantifies <= 2 variables in BDD 4 [&&]", [&]() {
+          const bdd out = bdd_forall(bdd_4, [](const bdd::label_t x) { return x <= 2; });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(false)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         it("terminates early when quantifying to a terminal in BDD 1 [&&]", [&]() {
@@ -2104,8 +1755,9 @@ go_bandit([]() {
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
-
           AssertThat(out_meta.can_pull(), Is().False());
+
+          // TODO: meta variables...
         });
 
         quantify_mode = quantify_mode_t::AUTO;

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -117,602 +117,6 @@ go_bandit([]() {
     // TODO: Turn 'GreaterThanOrEqualTo' in max 1-level cuts below into an
     // 'EqualTo'.
 
-    describe("zdd_project(const zdd&, const shared_file<zdd::label_t>&)", [&]() {
-      it("computes Ø with dom = {2,4,6} [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        {
-          label_writer lw(dom);
-          lw << 2 << 4 << 6;
-        }
-
-        const zdd in = zdd_empty;
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(false)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(0u));
-      });
-
-      it("computes { Ø } with dom = {1,3,5} [&&]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        {
-          label_writer lw(dom);
-          lw << 1 << 3 << 5;
-        }
-
-        zdd out = zdd_project(zdd(zdd_null), dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("computes with dom = Ø to be Ø for Ø as input [&&]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-
-        zdd out = zdd_project(zdd(zdd_empty), dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(false)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(0u));
-      });
-
-      it("computes with dom = Ø to be { Ø } for { Ø } as input [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-
-        const zdd in = zdd_null;
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("computes with dom = Ø to be { Ø } for non-empty input [zdd_1] [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-
-        const zdd in = zdd_1;
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("computes with dom = Ø to be { Ø } for non-empty input [zdd_2] [&&]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-
-        zdd out = zdd_project(zdd(zdd_2), dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("computes with dom = Ø to be { Ø } for non-empty input [zdd_3] [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-
-        const zdd in = zdd_3;
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("computes with disjoint dom to be { Ø } [zdd_2] [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 1;
-        }
-
-        const zdd in = zdd_2;
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("computes with disjoint dom to be { Ø } [zdd_3] [&&]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 3 << 4 << 5;
-        }
-
-        zdd out = zdd_project(zdd(zdd_3), dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      // TODO: Shortcut on nothing to do
-
-      //////////////////////
-      // Single-node case
-      shared_levelized_file<zdd::node_t> zdd_x1;
-      {
-        node_writer nw(zdd_x1);
-        nw << node(1u, node::MAX_ID, ptr_uint64(false), ptr_uint64(true));
-      }
-
-      it("returns { Ø } for {1} with dom = {0} [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 0;
-        }
-
-        const zdd in = zdd_x1;
-
-        /* Expected: { Ø }
-         *
-         *        T
-         */
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      it("returns { 1 } for {1} with dom = {0,1} [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 0 << 1;
-        }
-
-        const zdd in = zdd_x1;
-
-        /* Expected: { 1 }
-         *
-         *        1       ---- x1
-         *       / \
-         *       F T
-         */
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID, zdd::ptr_t(false), zdd::ptr_t(true))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(1,1u)));
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-      });
-
-      //////////////////////
-      // Non-terminal general case
-      it("computes zdd_1 with dom = {2,3,4} [const &]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 2 << 3 << 4;
-        }
-
-        const zdd in = zdd_1;
-
-        /* Expected: { Ø, {2}, {3}, {3,4} }
-        //
-        //                           1    ---- x2
-        //                          / \
-        //                          2 T   ---- x3
-        //                         / \
-        //                         T 3    ---- x4
-        //                          / \
-        //                          T T
-        */
-
-        zdd out = zdd_project(in, dom);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       terminal_T,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       terminal_T,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
-
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(4u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(4u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
-      });
-
-      it("computes zdd_2 with dom = {2,3,4} [&&]", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 2 << 3 << 4;
-        }
-
-        /* Expected: { Ø, {2}, {3}, {2,4} }
-        //
-        //                        1      ---- x2
-        //                       / \
-        //                       2  \    ---- x3
-        //                      / \ |
-        //                      T T 3    ---- x4
-        //                         / \
-        //                         T T
-        */
-
-        zdd out = zdd_project(zdd_2, dom);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       terminal_T,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       terminal_T,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
-
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(0u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
-      });
-
-      it("computes zdd_3 with dom = {0,2,4}", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 0 << 2 << 4;
-        }
-
-        /* Expected: { {0}, {2}, {0,2} }
-        //
-        //                           1    ---- x0
-        //                          / \
-        //                          | |   ---- x1
-        //                          \ /
-        //                           2    ---- x2
-        //                          / \
-        //                          T T
-        */
-
-        zdd out = zdd_project(zdd_3, dom);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       terminal_T,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(2u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
-      });
-
-      it("computes zdd_4 with dom = {0,4}", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 0 << 4;
-        }
-
-        /* Expected: { {0}, {4}, {0,4} }
-        //
-        //                         1     ---- x0
-        //                        / \
-        //                       /   \   ---- x2
-        //                       |   |
-        //                       2   3   ---- x4
-        //                      / \ / \
-        //                      F T T T
-        */
-
-        zdd out = zdd_project(zdd_4, dom);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       terminal_T,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
-                                                       terminal_F,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
-      });
-
-      it("computes zdd_4 with dom = {2,4}", [&](){
-        adiar::shared_file<zdd::label_t> dom;
-        { label_writer lw(dom);
-          lw << 2 << 4;
-        }
-
-        /* Expected: { {2}, {4}, {2,4} }
-        //
-        //                         1     ---- x2
-        //                        / \
-        //                        2 3    ---- x4
-        //                       / \||
-        //                       F  T
-        */
-
-        zdd out = zdd_project(zdd_4, dom);
-
-        node_test_stream out_nodes(out);
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       terminal_T,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
-                                                       terminal_F,
-                                                       terminal_T)));
-
-        AssertThat(out_nodes.can_pull(), Is().True());
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
-
-        AssertThat(out_nodes.can_pull(), Is().False());
-
-        level_info_test_stream ms(out);
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
-
-        AssertThat(ms.can_pull(), Is().True());
-        AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
-
-        AssertThat(ms.can_pull(), Is().False());
-
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
-        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
-
-        AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
-      });
-    });
-
     describe("zdd_project(const zdd&, const std::function<bool(zdd::label_t)>)", [&]() {
       it("returns same file for Ø with dom = {1,3,5,...} [const &]", [&](){
         zdd out = zdd_project(zdd_empty, [](zdd::label_t x) { return x % 2; });
@@ -1010,7 +414,7 @@ go_bandit([]() {
           //                   T T
           */
 
-          zdd out = zdd_project(zdd_1, [](zdd::label_t x) { return x % 2; });
+          zdd out = zdd_project(zdd_1, [](zdd::label_t x) { return x % 2 == 1; });
 
           node_test_stream out_nodes(out);
 
@@ -1114,7 +518,7 @@ go_bandit([]() {
           //                          T T
           */
 
-          zdd out = zdd_project(zdd_3, [](zdd::label_t x) { return !(x % 2); });
+          zdd out = zdd_project(zdd_3, [](zdd::label_t x) { return x % 2 == 0; });
 
           node_test_stream out_nodes(out);
 
@@ -1147,6 +551,1198 @@ go_bandit([]() {
 
           AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+        });
+
+        quantify_mode = quantify_mode_t::AUTO;
+      });
+    });
+
+    describe("zdd_project(const zdd&, const std::function<zdd::label_t()>&)", [&]() {
+      it("returns same file for Ø with dom = {6,4,2,0} [const &]", [&](){
+        zdd::label_t var = 6;
+
+        const zdd in = zdd_empty;
+        zdd out = zdd_project(in, [&var]() {
+          const zdd::label_t ret = var;
+          var -= 2;
+          return ret;
+        });
+
+        AssertThat(out.file_ptr(), Is().EqualTo(in.file_ptr()));
+      });
+
+      it("returns same file for { Ø } with dom = {1,3,5} [&&]", [&](){
+        zdd::label_t var = 6;
+
+        zdd out = zdd_project(zdd(zdd_null), [&var]() {
+          const zdd::label_t ret = var;
+          var -= 2;
+          return ret;
+        });
+
+        AssertThat(out.file_ptr(), Is().EqualTo(zdd_null));
+      });
+
+      it("returns same file for Ø with dom = Ø [&&]", [&](){
+        zdd out = zdd_project(zdd(zdd_empty), []() { return -1; });
+        AssertThat(out.file_ptr(), Is().EqualTo(zdd_empty));
+      });
+
+      it("returns same file for { Ø } with dom = Ø [const &]", [&](){
+        const zdd in = zdd_null;
+        zdd out = zdd_project(in, []() { return -1; });
+        AssertThat(out.file_ptr(), Is().EqualTo(in.file_ptr()));
+      });
+
+      describe("quantify_mode == SINGLETON / PARTIAL", [&]() {
+        quantify_mode = quantify_mode_t::SINGLETON;
+
+        it("collapses zdd_1 with dom = Ø into { Ø } [const &]", [&](){
+          const zdd in = zdd_1;
+          zdd out = zdd_project(in, []() { return -1; });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("collapses zdd_2 with dom = Ø into { Ø } [&&]", [&](){
+          zdd out = zdd_project(zdd(zdd_2), []() { return -1; });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("collapses zdd_3 with dom = Ø into { Ø } [const &]", [&](){
+          const zdd in = zdd_3;
+          zdd out = zdd_project(in, []() { return -1; });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("collapses zdd_2 with disjoint domain into { Ø } [const &]", [&](){
+          zdd::label_t var = 1;
+
+          const zdd in = zdd_2;
+          zdd out = zdd_project(in, [&var]() {
+            const zdd::label_t ret = var;
+            var -= 2;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("computes with disjoint dom to be { Ø } [zdd_3] [&&]", [&](){
+          zdd::label_t var = 5;
+          zdd out = zdd_project(zdd(zdd_3), [&var]() {
+            return 3 <= var && var <= 5 ? var-- : -1;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        //////////////////////
+        // Single-node case
+        shared_levelized_file<zdd::node_t> zdd_x1;
+        {
+          node_writer nw(zdd_x1);
+          nw << node(1u, node::MAX_ID, ptr_uint64(false), ptr_uint64(true));
+        }
+
+        it("returns { Ø } for {1} with dom = {0} [const &]", [&](){
+          adiar::shared_file<zdd::label_t> dom;
+          { label_writer lw(dom);
+            lw << 0;
+          }
+
+          const zdd in = zdd_x1;
+
+          /* Expected: { Ø }
+           *
+           *        T
+           */
+
+          zdd::label_t var = 0;
+          zdd out = zdd_project(in, [&var]() {
+            return var == 0 ? var--: var;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns { 1 } for {1} with dom = {1,0} [const &]", [&](){
+          adiar::shared_file<zdd::label_t> dom;
+          { label_writer lw(dom);
+            lw << 0 << 1;
+          }
+
+          const zdd in = zdd_x1;
+
+          /* Expected: { 1 }
+           *
+           *        1       ---- x1
+           *       / \
+           *       F T
+           */
+          zdd::label_t var = 1;
+          zdd out = zdd_project(in, [&var]() {
+            return var <= 1 ? var--: var;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID, zdd::ptr_t(false), zdd::ptr_t(true))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(1,1u)));
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        //////////////////////
+        // Non-terminal general case
+        it("computes zdd_1 with dom = {4,3,2} [const &]", [&](){
+          const zdd in = zdd_1;
+
+          /* Expected: { Ø, {2}, {3}, {3,4} }
+          //
+          //         1    ---- x2
+          //        / \
+          //        2 T   ---- x3
+          //       / \
+          //       T 3    ---- x4
+          //        / \
+          //        T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(in, [&var]() {
+            return 2 <= var && var <= 4 ? var-- : -1;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                         terminal_T,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
+        });
+
+        it("computes zdd_2 with dom = {4,3,2} [&&]", [&](){
+          /* Expected: { Ø, {2}, {3}, {2,4} }
+          //
+          //      1      ---- x2
+          //     / \
+          //     2  \    ---- x3
+          //    / \ |
+          //    T T 3    ---- x4
+          //       / \
+          //       T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_2, [&var]() {
+            return 2 <= var && var <= 4 ? var-- : -1;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
+        });
+
+        it("computes zdd_3 with dom = {4,2,0} [&&]", [&](){
+          /* Expected: { {0}, {2}, {0,2} }
+          //
+          //         1    ---- x0
+          //        / \
+          //        | |   ---- x1
+          //        \ /
+          //         2    ---- x2
+          //        / \
+          //        T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_3, [&var]() {
+            const zdd::label_t ret = var;
+            var -= 2;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+        });
+
+        it("computes zdd_4 with dom = {4,0} [&&]", [&](){
+          /* Expected: { {0}, {4}, {0,4} }
+          //
+          //       1     ---- x0
+          //      / \
+          //     /   \   ---- x2
+          //     |   |
+          //     2   3   ---- x4
+          //    / \ / \
+          //    F T T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_4, [&var]() {
+            const zdd::label_t ret = var;
+            var -= 4;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID-1),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+        });
+
+        it("computes zdd_4 with dom = {4,2} [&&]", [&](){
+          /* Expected: { {2}, {4}, {2,4} }
+          //
+          //       1     ---- x2
+          //      / \
+          //      2 3    ---- x4
+          //     / \||
+          //     F  T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_4, [&var]() {
+            const zdd::label_t res = var;
+            if (var == 4) { var -= 2; }
+            else          { var = -1; }
+            return res;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID-1),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+        });
+
+        quantify_mode = quantify_mode_t::AUTO;
+      });
+
+      describe("quantify_mode == NESTED / AUTO", [&]() {
+        quantify_mode = quantify_mode_t::NESTED;
+
+        it("collapses zdd_1 with dom = Ø into { Ø } [const &]", [&](){
+          const zdd in = zdd_1;
+          zdd out = zdd_project(in, []() { return -1; });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("collapses zdd_2 with dom = Ø into { Ø } [&&]", [&](){
+          zdd out = zdd_project(zdd(zdd_2), []() { return -1; });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("collapses zdd_3 with dom = Ø into { Ø } [const &]", [&](){
+          const zdd in = zdd_3;
+          zdd out = zdd_project(in, []() { return -1; });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("collapses zdd_2 with disjoint domain into { Ø } [const &]", [&](){
+          zdd::label_t var = 1;
+
+          const zdd in = zdd_2;
+          zdd out = zdd_project(in, [&var]() {
+            const zdd::label_t ret = var;
+            var -= 2;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("computes with disjoint dom to be { Ø } [zdd_3] [&&]", [&](){
+          zdd::label_t var = 5;
+          zdd out = zdd_project(zdd(zdd_3), [&var]() {
+            return 3 <= var && var <= 5 ? var-- : -1;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        // TODO: Shortcut on nothing to do
+
+        //////////////////////
+        // Single-node case
+        shared_levelized_file<zdd::node_t> zdd_x1;
+        {
+          node_writer nw(zdd_x1);
+          nw << node(1u, node::MAX_ID, ptr_uint64(false), ptr_uint64(true));
+        }
+
+        it("returns { Ø } for {1} with dom = {0} [const &]", [&](){
+          adiar::shared_file<zdd::label_t> dom;
+          { label_writer lw(dom);
+            lw << 0;
+          }
+
+          const zdd in = zdd_x1;
+
+          /* Expected: { Ø }
+           *
+           *        T
+           */
+
+          zdd::label_t var = 0;
+          zdd out = zdd_project(in, [&var]() {
+            return var == 0 ? var--: var;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns { 1 } for {1} with dom = {1,0} [const &]", [&](){
+          adiar::shared_file<zdd::label_t> dom;
+          { label_writer lw(dom);
+            lw << 0 << 1;
+          }
+
+          const zdd in = zdd_x1;
+
+          /* Expected: { 1 }
+           *
+           *        1       ---- x1
+           *       / \
+           *       F T
+           */
+          zdd::label_t var = 1;
+          zdd out = zdd_project(in, [&var]() {
+            return var <= 1 ? var--: var;
+          });
+
+          node_test_stream out_nodes(out);
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID, zdd::ptr_t(false), zdd::ptr_t(true))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(1,1u)));
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        //////////////////////
+        // Non-terminal general case
+        it("computes zdd_1 with dom = {4,3,2} [const &]", [&](){
+          const zdd in = zdd_1;
+
+          /* Expected: { Ø, {2}, {3}, {3,4} }
+          //
+          //         1    ---- x2
+          //        / \
+          //        2 T   ---- x3
+          //       / \
+          //       T 3    ---- x4
+          //        / \
+          //        T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(in, [&var]() {
+            return 2 <= var && var <= 4 ? var-- : -1;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                         terminal_T,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
+        });
+
+        it("computes zdd_2 with dom = {4,3,2} [&&]", [&](){
+          /* Expected: { Ø, {2}, {3}, {2,4} }
+          //
+          //      1      ---- x2
+          //     / \
+          //     2  \    ---- x3
+          //    / \ |
+          //    T T 3    ---- x4
+          //       / \
+          //       T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_2, [&var]() {
+            return 2 <= var && var <= 4 ? var-- : -1;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
+        });
+
+        it("computes zdd_3 with dom = {4,2,0} [&&]", [&](){
+          /* Expected: { {0}, {2}, {0,2} }
+          //
+          //         1    ---- x0
+          //        / \
+          //        | |   ---- x1
+          //        \ /
+          //         2    ---- x2
+          //        / \
+          //        T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_3, [&var]() {
+            const zdd::label_t ret = var;
+            var -= 2;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+        });
+
+        it("computes zdd_4 with dom = {4,0} [&&]", [&](){
+          /* Expected: { {0}, {4}, {0,4} }
+          //
+          //       1     ---- x0
+          //      / \
+          //     /   \   ---- x2
+          //     |   |
+          //     2   3   ---- x4
+          //    / \ / \
+          //    F T T T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_4, [&var]() {
+            const zdd::label_t ret = var;
+            var -= 4;
+            return ret;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID-1),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+        });
+
+        it("computes zdd_4 with dom = {4,2} [&&]", [&](){
+          /* Expected: { {2}, {4}, {2,4} }
+          //
+          //       1     ---- x2
+          //      / \
+          //      2 3    ---- x4
+          //     / \||
+          //     F  T
+          */
+          zdd::label_t var = 4;
+          zdd out = zdd_project(zdd_4, [&var]() {
+            const zdd::label_t res = var;
+            if (var == 4) { var -= 2; }
+            else          { var = -1; }
+            return res;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID-1),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+        });
+
+        quantify_mode = quantify_mode_t::AUTO;
+      });
+    });
+
+    describe("zdd_project(const zdd&, IT, IT)", [&]() {
+      // Since this is merely a wrapper on the generator function, we will just
+      // double-check with a few tests.
+
+      describe("quantify_mode == SINGLETON / PARTIAL", [&]() {
+        quantify_mode = quantify_mode_t::NESTED;
+
+        it("computes zdd_2 with dom = {4,3,2} [&&]", [&](){
+          const std::vector<int> dom = {4,3,2};
+
+          /* Expected: { Ø, {2}, {3}, {2,4} }
+          //
+          //      1      ---- x2
+          //     / \
+          //     2  \    ---- x3
+          //    / \ |
+          //    T T 3    ---- x4
+          //       / \
+          //       T T
+          */
+          zdd out = zdd_project(zdd_2, dom.cbegin(), dom.cend());
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(1u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
+        });
+
+        quantify_mode = quantify_mode_t::AUTO;
+      });
+
+      describe("quantify_mode == NESTED / AUTO", [&]() {
+        quantify_mode = quantify_mode_t::NESTED;
+
+        it("computes zdd_3 with dom = {4,2,0} [&&]", [&](){
+          const std::vector<int> dom = {4,2,0};
+
+          /* Expected: { {0}, {2}, {0,2} }
+          //
+          //         1    ---- x0
+          //        / \
+          //        | |   ---- x1
+          //        \ /
+          //         2    ---- x2
+          //        / \
+          //        T T
+          */
+          zdd out = zdd_project(zdd_3, dom.cbegin(), dom.cend());
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+        });
+
+        it("computes zdd_4 with dom = {4,0} [const &]", [&](){
+          std::vector<int> dom = {4,0};
+          zdd in = zdd_4;
+
+          /* Expected: { {0}, {4}, {0,4} }
+          //
+          //       1     ---- x0
+          //      / \
+          //     /   \   ---- x2
+          //     |   |
+          //     2   3   ---- x4
+          //    / \ / \
+          //    F T T T
+          */
+          zdd out = zdd_project(in, dom.cbegin(), dom.cend());
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID-1),
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,2u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
         });
 
         quantify_mode = quantify_mode_t::AUTO;


### PR DESCRIPTION
**Features**

- [x] Adds *generator* and *iterator* variants of `zdd_project`. This closes #516 .

**Deprecations**

- [x] Removes `bdd_exists` and `bdd_forall` when called with a `shared_file<bdd::label_t>`. This is because (1) it is superseeded by the generator function and iterators and (2) it is incompatible with Nested Sweeping (without requiring it to be bottom-up too).
- [x] Removes `zdd_project` with a `shared_file<zdd::label_t>` domain in favour of the above mentioned *generator* and *iterator* overload. 

**Bug Fixes**

- [x] Fixes a bug where the *generator* based quantification stops too early when being provided levels outside the BDDs levels.