### PR TITLE
Internal/nested sweeping/gc bail

### DIFF
--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -21,12 +21,22 @@ namespace adiar
     static inline bdd::ptr_t
     resolve_root(const bdd::node_t &r, const bool_op &op)
     {
+      // TODO: should all but the last case not have a 'suppression taint'?
+
       // Return shortcutting terminal (including its tainting flag).
       if (r.low().is_terminal() && can_left_shortcut(op, r.low())) {
         return r.low();
       }
       if (r.high().is_terminal() && can_right_shortcut(op, r.high())) {
         return r.high();
+      }
+
+      // Return other child (including its tainting flag) for irrelevant terminals.
+      if (r.low().is_terminal() && is_left_irrelevant(op, r.low())) {
+        return r.high();
+      }
+      if (r.high().is_terminal() && is_right_irrelevant(op, r.high())) {
+        return r.low();
       }
 
       // Otherwise return 'nothing'

--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -209,6 +209,18 @@ namespace adiar::internal
         }
 
         ////////////////////////////////////////////////////////////////////////
+        /// \brief Take ownership of another root sorter's content.
+        ///
+        /// \details This leaves the other in an illegal state that requires a
+        ///          call to `reset()`.
+        ////////////////////////////////////////////////////////////////////////
+        void move(roots_sorter<memory_mode, element_t, element_comp_t> &o)
+        {
+          _sorter_ptr = std::move(o._sorter_ptr);
+          _max_source = o._max_source;
+        }
+
+        ////////////////////////////////////////////////////////////////////////
         size_t size() /*const*/
         { return _sorter_ptr->size(); }
 

--- a/src/adiar/internal/data_types/request.h
+++ b/src/adiar/internal/data_types/request.h
@@ -113,6 +113,27 @@ namespace adiar::internal
     bool empty_carry() const
     { return true; }
 
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief The number of non-nil target values.
+    ////////////////////////////////////////////////////////////////////////////
+    uint8_t targets() const
+    {
+      if constexpr (sorted_target) {
+        // Since NIL is the greatest value, we can look for the first nil entry
+        // (if any).
+        for (uint8_t i = 0u; i < cardinality; i++) {
+          if (target[i] == ptr_t::NIL()) { return i; }
+        }
+        return cardinality;
+      } else { // !sorted_target
+        uint8_t sum = 0u;
+        for (uint8_t i = 0u; i < cardinality; i++) {
+          if (target[i] != ptr_t::NIL()) { sum++; }
+        }
+        return sum;
+      }
+    }
+
     /* ============================ CONSTRUCTORS ============================ */
   public:
     // Provide 'default' constructors to ensure it being a 'POD' inside of TPIE.

--- a/src/adiar/internal/data_types/tuple.h
+++ b/src/adiar/internal/data_types/tuple.h
@@ -32,6 +32,9 @@ namespace adiar::internal
   // TODO (QMDD):
   //   Add 4-ary tuples
 
+  // TODO (Nested Sweeping Clean Up):
+  //   - Map function to create a tuple<B> from tupla<A> and f : A -> B
+
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Tuple holding two elements and providing an ordered access.
   ///

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -17,6 +17,8 @@ namespace adiar
     static inline zdd::ptr_t
     resolve_root(const zdd::node_t &r, const bool_op &/*op*/)
     {
+      // TODO: should all but the last case not have a 'suppression taint'?
+
       // Return the True terminal if any (including its tainting flags).
       if (r.low().is_terminal() && r.high().is_terminal()) {
         adiar_debug(r.low().value() || r.high().value(),
@@ -24,7 +26,14 @@ namespace adiar
 
         return r.low().value() ? r.low() : r.high();
       }
-      // Otherwise return 'nothing'
+
+      // Will one of the two options "fall out"?
+      if (r.low().is_terminal() && !r.low().value()) {
+        return r.high();
+      }
+      // if (r.high().is_terminal() && !r.high().value()) { NEVER HAPPENS }
+
+      // Otherwise return as-is
       return r.uid();
     }
 

--- a/test/adiar/internal/data_types/test_request.cpp
+++ b/test/adiar/internal/data_types/test_request.cpp
@@ -73,6 +73,33 @@ go_bandit([]() {
           AssertThat(req.empty_carry(), Is().True());
         });
       });
+
+      describe(".targets()", []() {
+        it("is 0 for NIL target", []() {
+          const request<1> req(request<1>::ptr_t::NIL(), {});
+          AssertThat(req.targets(), Is().EqualTo(0));
+        });
+
+        it("is 1 for (0,0) target", []() {
+          const request<1> req(request<1>::ptr_t(0,0), {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for (MAX,MAX) target", []() {
+          const request<1> req(request<1>::ptr_t(request<1>::ptr_t::MAX_LABEL,request<1>::ptr_t::MAX_ID), {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for F target", []() {
+          const request<1> req(request<1>::ptr_t(false), {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for T target", []() {
+          const request<1> req(request<1>::ptr_t(true), {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+      });
     });
 
     describe("request<cardinality = 2>", []() {
@@ -188,6 +215,58 @@ go_bandit([]() {
           const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
                                  {{ {request<2>::ptr_t(2u,1u), request<2>::ptr_t(2u,0u)} }});
           AssertThat(req.empty_carry(), Is().False());
+        });
+      });
+
+      describe(".targets()", []() {
+        it("is 0 for {NIL, NIL} target [unsorted]", []() {
+          const request<2>req({request<2>::ptr_t::NIL(), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(0));
+        });
+
+        it("is 0 for {NIL, NIL} target [sorted]", []() {
+          const request<2,0,1> req({request<2>::ptr_t::NIL(), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(0));
+        });
+
+        it("is 1 for {(0,0), NIL} target [unsorted]", []() {
+          const request<2> req({request<2>::ptr_t(0,0), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {NIL, (0,0)} target [unsorted]", []() {
+          const request<2> req({request<2>::ptr_t(0,0), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {(0,0), NIL} target [sorted]", []() {
+          const request<2,0,1> req({request<2>::ptr_t(0,0), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {F, NIL} target [unsorted]", []() {
+          const request<2> req({request<2>::ptr_t(false), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {T, NIL} target [sorted]", []() {
+          const request<2,0,1> req({request<2>::ptr_t(true), request<2>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 2 for {(0,0), T} target [unsorted]", []() {
+          const request<2> req({request<2>::ptr_t(0,0), request<2>::ptr_t(true)}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
+        });
+
+        it("is 2 for {F, (1,0)} target [unsorted]", []() {
+          const request<2> req({request<2>::ptr_t(false), request<2>::ptr_t(1,0)}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
+        });
+
+        it("is 2 for {(0,0), T} target [sorted]", []() {
+          const request<2,0,1> req({request<2>::ptr_t(0,0), request<2>::ptr_t(true)}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
         });
       });
     });
@@ -366,6 +445,68 @@ go_bandit([]() {
                                  {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
                                     {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
           AssertThat(req.empty_carry(), Is().False());
+        });
+      });
+
+      describe(".targets()", []() {
+        it("is 0 for {NIL, NIL, NIL} target [unsorted]", []() {
+          const request<3>req({request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(0));
+        });
+
+        it("is 0 for {NIL, NIL, NIL} target [sorted]", []() {
+          const request<3,0,1> req({request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(0));
+        });
+
+        it("is 1 for {NIL, T, NIL} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t::NIL(), request<3>::ptr_t(true), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {(1,0), NIL, NIL} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t(1,0), request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {NIL, NIL, (0,0)} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL(), request<3>::ptr_t(0,0)}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 1 for {T, NIL, NIL} target [sorted]", []() {
+          const request<3,0,1> req({request<3>::ptr_t(true), request<3>::ptr_t::NIL(), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(1));
+        });
+
+        it("is 2 for {T, NIL, (0,0)} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t(true), request<3>::ptr_t::NIL(), request<3>::ptr_t(0,0)}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
+        });
+
+        it("is 2 for {NIL, (42,0), (0,0)} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t::NIL(), request<3>::ptr_t(42,0), request<3>::ptr_t(0,0)}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
+        });
+
+        it("is 2 for {(42,0), (0,0), NIL} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t(42,0), request<3>::ptr_t(0,0), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
+        });
+
+        it("is 2 for {(2,8), F, NIL} target [sorted]", []() {
+          const request<3,0,1> req({request<3>::ptr_t(2,8), request<3>::ptr_t(false), request<3>::ptr_t::NIL()}, {});
+          AssertThat(req.targets(), Is().EqualTo(2));
+        });
+
+        it("is 3 for {(2,8), F, (3,0)} target [unsorted]", []() {
+          const request<3> req({request<3>::ptr_t(2,8), request<3>::ptr_t(false), request<3>::ptr_t(3,0)}, {});
+          AssertThat(req.targets(), Is().EqualTo(3));
+        });
+
+        it("is 3 for {(2,8), (3,0), T} target [sorted]", []() {
+          const request<3,0,1> req({request<3>::ptr_t(2,8), request<3>::ptr_t(3,0), request<3>::ptr_t(true)}, {});
+          AssertThat(req.targets(), Is().EqualTo(3));
         });
       });
     });

--- a/test/adiar/internal/data_types/test_request.cpp
+++ b/test/adiar/internal/data_types/test_request.cpp
@@ -29,47 +29,47 @@ go_bandit([]() {
         const auto node_carry_size = request<1>::node_carry_size;
         AssertThat(node_carry_size, Is().EqualTo(0u));
 
-        const auto rec = request<1>({ request<1>::ptr_t(0,0) }, {});
+        const request<1> rec({ request<1>::ptr_t(0,0) }, {});
         AssertThat(sizeof(rec), Is().EqualTo(1u * 8u));
       });
 
       describe(".level()", []() {
         it("returns the level of the target [1]", []() {
-          const auto req = request<1>({request<1>::ptr_t(0u,0u)}, {});
+          const request<1> req({request<1>::ptr_t(0u,0u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
         it("returns the level of the target [2]", []() {
-          const auto req = request<1>({request<1>::ptr_t(0u,1u)}, {});
+          const request<1> req({request<1>::ptr_t(0u,1u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
         it("returns the level of the target [3]", []() {
-          const auto req = request<1>({request<1>::ptr_t(1u,0u)}, {});
+          const request<1> req({request<1>::ptr_t(1u,0u)}, {});
           AssertThat(req.level(), Is().EqualTo(1u));
         });
 
         it("returns the level of the target [4]", []() {
-          const auto req = request<1>({request<1>::ptr_t(42u,21u)}, {});
+          const request<1> req({request<1>::ptr_t(42u,21u)}, {});
           AssertThat(req.level(), Is().EqualTo(42u));
         });
       });
 
       describe(".nodes_carried()", []() {
         it("does not carry any nodes [1]", []() {
-          const auto req = request<1>({request<1>::ptr_t(0u,0u)}, {});
+          const request<1> req({request<1>::ptr_t(0u,0u)}, {});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("does not carry any nodes [2]", []() {
-          const auto req = request<1>({request<1>::ptr_t(42u,21u)}, {});
+          const request<1> req({request<1>::ptr_t(42u,21u)}, {});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
       });
 
       describe(".empty_carry()", []() {
         it("is true", []() {
-          const auto req = request<1>(request<1>::ptr_t(0u,0u), {});
+          const request<1> req(request<1>::ptr_t(0u,0u), {});
           AssertThat(req.empty_carry(), Is().True());
         });
       });
@@ -95,10 +95,10 @@ go_bandit([]() {
       });
 
       it("has the target sorted if number of inputs is 1", []() {
-        const auto sorted_target = request<2,0,true>::sorted_target;
+        const auto sorted_target = request<2,0,1>::sorted_target;
         AssertThat(sorted_target, Is().True());
 
-        const auto target__is_sorted = request<2,0,true>::target_t::is_sorted;
+        const auto target__is_sorted = request<2,0,1>::target_t::is_sorted;
         AssertThat(target__is_sorted, Is().True());
       });
 
@@ -106,7 +106,7 @@ go_bandit([]() {
         const auto node_carry_size = request<2>::node_carry_size;
         AssertThat(node_carry_size, Is().EqualTo(0u));
 
-        const auto rec = request<2,0>({ request<2>::ptr_t(0,0), request<2>::ptr_t(0,0) }, { });
+        const request<2,0> rec({ request<2>::ptr_t(0,0), request<2>::ptr_t(0,0) }, { });
         AssertThat(sizeof(rec), Is().EqualTo(2u * 8u + 0u * 2u * 8u));
       });
 
@@ -114,79 +114,79 @@ go_bandit([]() {
         const auto node_carry_size = request<2,1>::node_carry_size;
         AssertThat(node_carry_size, Is().EqualTo(1u));
 
-        const auto rec = request<2,1>({ request<2>::ptr_t(0,0), request<2>::ptr_t(0,0) },
-                                      {{ {request<2>::ptr_t::NIL()} }});
+        const request<2,1> rec({ request<2>::ptr_t(0,0), request<2>::ptr_t(0,0) },
+                               {{ {request<2>::ptr_t::NIL()} }});
         AssertThat(sizeof(rec), Is().EqualTo(2u * 8u + 1u * 2u * 8u));
       });
 
       describe(".level()", []() {
         it("returns the level of the first uid in target [1]", []() {
-          const auto req = request<2>({request<2>::ptr_t(0u,1u), request<2>::ptr_t(1u,0u)}, {});
+          const request<2> req({request<2>::ptr_t(0u,1u), request<2>::ptr_t(1u,0u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
         it("returns the level of the first uid in target [2]", []() {
-          const auto req = request<2>({request<2>::ptr_t(1u,0u), request<2>::ptr_t(0u,1u)}, {});
+          const request<2> req({request<2>::ptr_t(1u,0u), request<2>::ptr_t(0u,1u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
         it("returns the level of the first uid in target [3]", []() {
-          const auto req = request<2>({request<2>::ptr_t(21u,11u), request<2>::ptr_t(42u,8u)}, {});
+          const request<2> req({request<2>::ptr_t(21u,11u), request<2>::ptr_t(42u,8u)}, {});
           AssertThat(req.level(), Is().EqualTo(21u));
         });
 
         it("returns the level of the first uid in target [4]", []() {
-          const auto req = request<2>({request<2>::ptr_t(42u,11u), request<2>::ptr_t(21u,42u)}, {});
+          const request<2> req({request<2>::ptr_t(42u,11u), request<2>::ptr_t(21u,42u)}, {});
           AssertThat(req.level(), Is().EqualTo(21u));
         });
       });
 
       describe(".nodes_carried()", []() {
         it("has no nodes when node_carry_size is 0", []() {
-          const auto req = request<2,0>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)}, {});
+          const request<2,0> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)}, {});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has no nodes when node_carry_size is 1 with manually added NIL()", []() {
-          const auto req = request<2,1>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
-                                        {{ request<2>::ptr_t::NIL() }});
+          const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
+                                 {{ request<2>::ptr_t::NIL() }});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has no nodes when node_carry_size is 1 with NO_CHILDREN()", []() {
-          const auto req = request<2,1>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
-                                        {{ request<2>::NO_CHILDREN() }});
+          const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
+                                 {{ request<2>::NO_CHILDREN() }});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has one nodes when node_carry_size is 1 with non-NIL content", []() {
-          const auto req = request<2,1>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
-                                        {{ {request<2>::ptr_t(2u,1u), request<2>::ptr_t(2u,0u)} }});
+          const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
+                                 {{ {request<2>::ptr_t(2u,1u), request<2>::ptr_t(2u,0u)} }});
           AssertThat(req.nodes_carried(), Is().EqualTo(1u));
         });
       });
 
       describe(".empty_carry()", []() {
         it("is true when node_carry_size is 0", []() {
-          const auto req = request<2,0>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)}, {});
+          const request<2,0> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)}, {});
           AssertThat(req.empty_carry(), Is().True());
         });
 
         it("is true when node_carry_size is 1 with manually added NIL()", []() {
-          const auto req = request<2,1>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
-                                        {{ request<2>::ptr_t::NIL() }});
+          const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
+                                 {{ request<2>::ptr_t::NIL() }});
           AssertThat(req.empty_carry(), Is().True());
         });
 
         it("is true when node_carry_size is 1 with NO_CHILDREN()", []() {
-          const auto req = request<2,1>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
-                                        {{ request<2>::NO_CHILDREN() }});
+          const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
+                                 {{ request<2>::NO_CHILDREN() }});
           AssertThat(req.empty_carry(), Is().True());
         });
 
         it("is false when node_carry_size is 1 with non-NIL content", []() {
-          const auto req = request<2,1>({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
-                                        {{ {request<2>::ptr_t(2u,1u), request<2>::ptr_t(2u,0u)} }});
+          const request<2,1> req({request<2>::ptr_t(1u,1u), request<2>::ptr_t(1u,0u)},
+                                 {{ {request<2>::ptr_t(2u,1u), request<2>::ptr_t(2u,0u)} }});
           AssertThat(req.empty_carry(), Is().False());
         });
       });
@@ -223,8 +223,8 @@ go_bandit([]() {
         const auto node_carry_size = request<3>::node_carry_size;
         AssertThat(node_carry_size, Is().EqualTo(0u));
 
-        const auto rec = request<3,0>({ request<3>::ptr_t(0,0), request<3>::ptr_t(0,0), request<3>::ptr_t(0,0) },
-                                      { });
+        const request<3,0> rec({ request<3>::ptr_t(0,0), request<3>::ptr_t(0,0), request<3>::ptr_t(0,0) },
+                               { });
         AssertThat(sizeof(rec), Is().EqualTo(3u * 8u + 0u * 2u * 8u));
       });
 
@@ -232,8 +232,8 @@ go_bandit([]() {
         const auto node_carry_size = request<3,1>::node_carry_size;
         AssertThat(node_carry_size, Is().EqualTo(1u));
 
-        const auto rec = request<3,1>({ request<3>::ptr_t(0,0), request<3>::ptr_t(0,0), request<3>::ptr_t(0,0) },
-                                      {{ {request<3>::ptr_t::NIL()} }});
+        const request<3,1> rec({ request<3>::ptr_t(0,0), request<3>::ptr_t(0,0), request<3>::ptr_t(0,0) },
+                               {{ {request<3>::ptr_t::NIL()} }});
         AssertThat(sizeof(rec), Is().EqualTo(3u * 8u + 1u * 2u * 8u));
       });
 
@@ -241,130 +241,130 @@ go_bandit([]() {
         const auto node_carry_size = request<3,2>::node_carry_size;
         AssertThat(node_carry_size, Is().EqualTo(2u));
 
-        const auto rec = request<3,2>({ request<3>::ptr_t(0,0), request<3>::ptr_t(0,0), request<3>::ptr_t(0,0) },
-                                      {{ {request<3>::ptr_t::NIL()},
-                                         {request<3>::ptr_t::NIL()} }});
+        const request<3,2> rec({ request<3>::ptr_t(0,0), request<3>::ptr_t(0,0), request<3>::ptr_t(0,0) },
+                               {{ {request<3>::ptr_t::NIL()},
+                                  {request<3>::ptr_t::NIL()} }});
         AssertThat(sizeof(rec), Is().EqualTo(3u * 8u + 2u * 2u * 8u));
       });
 
       describe(".level()", []() {
         it("returns the level of the first uid in target [1]", []() {
-          const auto req = request<3>({request<3>::ptr_t(0u,2u), request<3>::ptr_t(1u,1u), request<3>::ptr_t(2u,0u)}, {});
+          const request<3> req({request<3>::ptr_t(0u,2u), request<3>::ptr_t(1u,1u), request<3>::ptr_t(2u,0u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
         it("returns the level of the first uid in target [2]", []() {
-          const auto req = request<3>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(0u,2u), request<3>::ptr_t(2u,0u)}, {});
+          const request<3> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(0u,2u), request<3>::ptr_t(2u,0u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
 
         it("returns the level of the first uid in target [3]", []() {
-          const auto req = request<3>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(2u,0u), request<3>::ptr_t(0u,2u)}, {});
+          const request<3> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(2u,0u), request<3>::ptr_t(0u,2u)}, {});
           AssertThat(req.level(), Is().EqualTo(0u));
         });
 
         it("returns the level of the first uid in target [4]", []() {
-          const auto req = request<3>({request<3>::ptr_t(32u,0u), request<3>::ptr_t(21u,11u), request<3>::ptr_t(42u,8u)}, {});
+          const request<3> req({request<3>::ptr_t(32u,0u), request<3>::ptr_t(21u,11u), request<3>::ptr_t(42u,8u)}, {});
           AssertThat(req.level(), Is().EqualTo(21u));
         });
 
         it("returns the level of the first uid in target [4]", []() {
-          const auto req = request<3>({request<3>::ptr_t(32u,0u), request<3>::ptr_t(42u,11u), request<3>::ptr_t(21u,42u)}, {});
+          const request<3> req({request<3>::ptr_t(32u,0u), request<3>::ptr_t(42u,11u), request<3>::ptr_t(21u,42u)}, {});
           AssertThat(req.level(), Is().EqualTo(21u));
         });
       });
 
       describe(".nodes_carried()", []() {
         it("has no nodes when node_carry_size is 0", []() {
-          const auto req = request<3,0>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {});
+          const request<3,0> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has no nodes when node_carry_size is 1 with manually added NIL()", []() {
-          const auto req = request<3,1>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t::NIL()} }});
+          const request<3,1> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t::NIL()} }});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has no nodes when node_carry_size is 2 with manually added NIL()", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t::NIL()},
-                                           {request<3>::ptr_t::NIL()} }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t::NIL()},
+                                    {request<3>::ptr_t::NIL()} }});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has no nodes when node_carry_size is 1 with NO_CHILDREN()", []() {
-          const auto req = request<3,1>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ request<3>::NO_CHILDREN() }});
+          const request<3,1> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ request<3>::NO_CHILDREN() }});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has no nodes when node_carry_size is 2 with NO_CHILDREN()", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ request<3>::NO_CHILDREN(), request<3>::NO_CHILDREN() }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ request<3>::NO_CHILDREN(), request<3>::NO_CHILDREN() }});
           AssertThat(req.nodes_carried(), Is().EqualTo(0u));
         });
 
         it("has one nodes when node_carry_size is 1 with non-NIL content", []() {
-          const auto req = request<3,1>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
+          const request<3,1> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
           AssertThat(req.nodes_carried(), Is().EqualTo(1u));
         });
 
         it("has one nodes when node_carry_size is 2 with non-NIL and NIL content", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
-                                           request<3>::NO_CHILDREN() }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
+                                    request<3>::NO_CHILDREN() }});
           AssertThat(req.nodes_carried(), Is().EqualTo(1u));
         });
 
         it("has two nodes when node_carry_size is 2 with non-NIL content", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
-                                           {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
+                                    {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
           AssertThat(req.nodes_carried(), Is().EqualTo(2u));
         });
       });
 
       describe(".empty_carry()", []() {
         it("is true when node_carry_size is 0", []() {
-          const auto req = request<3,0>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {});
+          const request<3,0> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {});
           AssertThat(req.empty_carry(), Is().True());
         });
 
         it("is true when node_carry_size is 1 with NO_CHILDREN()", []() {
-          const auto req = request<3,1>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        { request<3>::NO_CHILDREN() });
+          const request<3,1> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 { request<3>::NO_CHILDREN() });
           AssertThat(req.empty_carry(), Is().True());
         });
 
         it("is true nodes when node_carry_size is 2 with NO_CHILDREN()", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ request<3>::NO_CHILDREN(),
-                                          request<3>::NO_CHILDREN() }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ request<3>::NO_CHILDREN(),
+                                    request<3>::NO_CHILDREN() }});
           AssertThat(req.empty_carry(), Is().True());
         });
 
         it("is false nodes when node_carry_size is 1 with non-NIL content", []() {
-          const auto req = request<3,1>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
+          const request<3,1> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
           AssertThat(req.empty_carry(), Is().False());
         });
 
         it("is false nodes when node_carry_size is 2 with non-NIL and NIL content", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
-                                           request<3>::NO_CHILDREN() }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
+                                    request<3>::NO_CHILDREN() }});
           AssertThat(req.empty_carry(), Is().False());
         });
 
         it("is false nodes when node_carry_size is 2 with non-NIL content", []() {
-          const auto req = request<3,2>({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
-                                        {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
-                                           {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
+          const request<3,2> req({request<3>::ptr_t(1u,1u), request<3>::ptr_t(1u,0u), request<3>::ptr_t(1u,2u)},
+                                 {{ {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)},
+                                    {request<3>::ptr_t(2u,1u), request<3>::ptr_t(2u,0u)} }});
           AssertThat(req.empty_carry(), Is().False());
         });
       });

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -352,6 +352,62 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
         });
 
+        it("bails out of inner sweep for zdd_4 with dom = { x | x % 2 == 0 } [const &]", [&](){
+          const zdd in = zdd_1;
+
+          /* Expected: { Ø, {0}, {2}, {4} }
+          //
+          //         1       ---- x0
+          //        / \
+          //        3 T      ---- x2
+          //       / \
+          //       5 T       ---- x4
+          //      / \
+          //      T T
+          */
+          zdd out = zdd_project(in, [](const zdd::label_t x) { return x % 2 == 0; });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
+        });
+
         quantify_mode = quantify_mode_t::AUTO;
       });
 
@@ -1567,6 +1623,67 @@ go_bandit([]() {
 
           AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+        });
+
+        it("bails out of inner sweep for zdd_4 with dom = { x | x % 2 == 0 } [const &]", [&](){
+          const zdd in = zdd_1;
+
+          /* Expected: { Ø, {0}, {2}, {4} }
+          //
+          //         1       ---- x0
+          //        / \
+          //        3 T      ---- x2
+          //       / \
+          //       5 T       ---- x4
+          //      / \
+          //      T T
+          */
+          zdd::label_t var = 8;
+          zdd out = zdd_project(in, [&var]() {
+            const zdd::label_t res = var;
+            var -= 2;
+            return res;
+          });
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         ptr_uint64(4, ptr_uint64::MAX_ID),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                         ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream ms(out);
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(4,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(ms.can_pull(), Is().True());
+          AssertThat(ms.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(ms.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
         });
 
         quantify_mode = quantify_mode_t::AUTO;

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -1695,7 +1695,7 @@ go_bandit([]() {
       // double-check with a few tests.
 
       describe("quantify_mode == SINGLETON / PARTIAL", [&]() {
-        quantify_mode = quantify_mode_t::NESTED;
+        quantify_mode = quantify_mode_t::SINGLETON;
 
         it("computes zdd_2 with dom = {4,3,2} [&&]", [&](){
           const std::vector<int> dom = {4,3,2};


### PR DESCRIPTION
Adds optimisation to bail out of running inner sweep, if there are no requests that manipulate the subgraph (thereby postponing a garbage collection).