### PR TITLE
Nested Sweeping/Fast Reduce

### DIFF
--- a/src/adiar/internal/algorithms/build.h
+++ b/src/adiar/internal/algorithms/build.h
@@ -14,10 +14,12 @@ namespace adiar::internal
   inline shared_levelized_file<node> build_terminal(bool value)
   {
     shared_levelized_file<node> nf;
-    node_writer nw(nf);
-    nw.unsafe_push(node(value));
-
-    nf->number_of_terminals[value] = 1;
+    {
+      node_writer nw(nf);
+      nw.unsafe_push(node(value));
+      nw.unsafe_set_number_of_terminals(!value, value);
+      nw.unsafe_set_canonical(true);
+    }
 
     return nf;
   }
@@ -34,6 +36,7 @@ namespace adiar::internal
                           ptr_uint64(true)));
 
       nw.unsafe_push(level_info(label,1u));
+      nw.unsafe_set_canonical(true);
     }
 
     return nf;
@@ -161,6 +164,8 @@ namespace adiar::internal
       if (nw.size() == 0u) {
         return build_terminal(chain_policy::init_terminal);
       }
+
+      nw.unsafe_set_canonical(true);
 
       // 1-level cuts
       nf->max_1level_cut[cut_type::INTERNAL] = max_internal_cut;

--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -85,8 +85,6 @@ namespace adiar::internal
                          pq_t &pq,
                          node_writer &out_writer)
     {
-      // TODO: mark non-canonical!
-
       // Count number of arcs that cross this level (including tainted ones)
       // TODO: move into helper function
       cuts_t one_level_cut   = {{ 0u, 0u, 0u, 0u }};
@@ -154,10 +152,16 @@ namespace adiar::internal
 
       out_writer.unsafe_max_1level_cut(one_level_cut);
 
-      // Add number of nodes to level information, if any nodes were pushed to the output.
+      // Add number of nodes to level information, if any nodes were pushed to
+      // the output. Furthermore, mark as non-canonical if at least two nodes
+      // were output (their order might very much have been wrong).
       if (out_id != dd_policy::MAX_ID) {
         const size_t width = dd_policy::MAX_ID - out_id;
         out_writer.unsafe_push(level_info(label, width));
+
+        if (width > 1u) {
+          out_writer.unsafe_set_canonical(false);
+        }
       }
 
       // Set up priority queue for next level (or collapse to a terminal)

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -511,9 +511,8 @@ namespace adiar::internal
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // TODO: set to AUTO and add heuristic hooks
     static constexpr internal::nested_sweeping::reduce_strategy reduce_strategy =
-      internal::nested_sweeping::ALWAYS_CANONICAL;
+      internal::nested_sweeping::AUTO;
   };
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -321,7 +321,7 @@ namespace adiar::internal
     }
 
     // Add number of nodes to level information, if any nodes were pushed to the output.
-    if (!out_node.low().is_nil() /* && !out_node.high().is_nil() */) {
+    if (out_id != dd_policy::MAX_ID) {
       const size_t width = dd_policy::MAX_ID - out_id;
       out_writer.unsafe_push(level_info(label, width));
     }

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -284,6 +284,7 @@ namespace adiar::internal
       const arc e_low  = __reduce_get_next(reduce_pq, arcs);
 
       const node n = node_of(e_low, e_high);
+      adiar_debug(n.label() == label, "Label is for desired level");
 
       // Apply Reduction rule 1
       const node::ptr_t reduction_rule_ret = dd_policy::reduction_rule(n);
@@ -369,11 +370,11 @@ namespace adiar::internal
 
       adiar_invariant(!arcs.can_pull_internal()
                       || current_map.old_uid == arcs.peek_internal().target(),
-                      "Mapping forwarded in sync with node_arcs");
+                      "Mapping forwarded in sync with internal arcs");
 
       // Find all arcs that have the target that match the current mapping's old_uid
       while (arcs.can_pull_internal() && current_map.old_uid == arcs.peek_internal().target()) {
-        // The is_high flag is included in arc.source() pulled from node_arcs.
+        // The out_idx is included in arc.source() pulled from the internal arcs.
         const ptr_uint64 s = arcs.pull_internal().source();
 
         // If Reduction Rule 1 was used, then tell the parents to add to the global cut.

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -419,7 +419,7 @@ namespace adiar::internal
             typename pq_t>
   inline void
   __reduce_level__epilogue(arc_stream_t &arcs,
-                           label_t label,
+                           [[maybe_unused]] label_t label,
                            pq_t &reduce_pq,
                            node_writer &out_writer,
                            const bool terminal_val)

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -340,9 +340,9 @@ namespace adiar::internal
     }
 
     // Add number of nodes to level information, if any nodes were pushed to the output.
-    if (out_id != dd_policy::MAX_ID) {
-      const size_t width = dd_policy::MAX_ID - out_id;
-      out_writer.unsafe_push(level_info(label, width));
+    const size_t reduced_width = dd_policy::MAX_ID - out_id;
+    if (reduced_width > 0) {
+      out_writer.unsafe_push(level_info(label, reduced_width));
     }
 
     // Sort mappings for Reduction rule 2 back in order of arcs.internal
@@ -413,6 +413,11 @@ namespace adiar::internal
 
     const bool terminal_value = next_red1.new_uid.is_terminal() && next_red1.new_uid.value();
     __reduce_level__epilogue<>(arcs, label, reduce_pq, out_writer, terminal_value);
+
+    adiar_debug(reduced_width <= unreduced_width,
+                "Reduction should only ever remove nodes");
+
+    return reduced_width;
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -303,11 +303,9 @@ namespace adiar::internal
       const node next_node = child_grouping.pull();
 
       if (out_node.low() != unflag(next_node.low()) || out_node.high() != unflag(next_node.high())) {
-        out_node = node(label, out_id, unflag(next_node.low()), unflag(next_node.high()));
+        adiar_debug(0 <= out_id, "Should still have more ids left");
+        out_node = node(label, out_id--, unflag(next_node.low()), unflag(next_node.high()));
         out_writer.unsafe_push(out_node);
-
-        adiar_debug(out_id > 0, "Has run out of ids");
-        out_id--;
 
         __reduce_cut_add(next_node.low().is_flagged()  ? tainted_1level_cut : local_1level_cut,
                          out_node.low());

--- a/src/adiar/internal/cut.h
+++ b/src/adiar/internal/cut.h
@@ -62,7 +62,7 @@ namespace adiar::internal
   {
     return terminal_val
       ? cut >= cut_type::INTERNAL_TRUE
-      : cut <= cut_type::INTERNAL_FALSE;
+      : cut == cut_type::INTERNAL_FALSE || cut == cut_type::ALL;
   }
 
   inline bool includes_terminal(const size_t cut, const bool terminal_val)

--- a/src/adiar/internal/cut.h
+++ b/src/adiar/internal/cut.h
@@ -106,8 +106,6 @@ namespace adiar::internal
       return dd.max_2level_cut(ct);
     }
   };
-
-  // TODO: Exact top-down sweep computation of 1-level and 2-level cuts.
 }
 
 #endif // ADIAR_INTERNAL_CUT_H

--- a/src/adiar/internal/io/node_writer.h
+++ b/src/adiar/internal/io/node_writer.h
@@ -127,10 +127,10 @@ namespace adiar::internal
     {
       if (!attached()) { return; }
 
-      _file_ptr -> canonical = _canonical;
-
       // Has '.push' been used?
       if (_latest_node != dummy()) {
+        _file_ptr->canonical = _canonical;
+
         // Output level information of the final level
         if (!_latest_node.is_terminal()) {
           unsafe_push(level_info(_latest_node.label(), _level_size));

--- a/src/adiar/internal/io/node_writer.h
+++ b/src/adiar/internal/io/node_writer.h
@@ -300,10 +300,19 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Overwrite the number of false and true arcs.
     ////////////////////////////////////////////////////////////////////////////
-    void unsafe_set_number_of_terminals(size_t number_of_false, size_t number_of_true)
+    void unsafe_set_number_of_terminals(const size_t number_of_false,
+                                        const size_t number_of_true)
     {
       _file_ptr->number_of_terminals[false] = number_of_false;
       _file_ptr->number_of_terminals[true]  = number_of_true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Overwrite the canonicity flag.
+    ////////////////////////////////////////////////////////////////////////////
+    void unsafe_set_canonical(const bool canonical)
+    {
+      _file_ptr->canonical = canonical;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/test/adiar/internal/algorithms/test_nested_sweeping.cpp
+++ b/test/adiar/internal/algorithms/test_nested_sweeping.cpp
@@ -2054,6 +2054,8 @@ go_bandit([]() {
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(1u));
 
+          AssertThat(out->canonical, Is().True());
+
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
@@ -2128,6 +2130,8 @@ go_bandit([]() {
 
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->canonical, Is().False());
 
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(2u));
@@ -2208,6 +2212,8 @@ go_bandit([]() {
 
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->canonical, Is().False());
 
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(2u));
@@ -2320,6 +2326,8 @@ go_bandit([]() {
 
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->canonical, Is().False());
 
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(3u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(3u));
@@ -2439,6 +2447,8 @@ go_bandit([]() {
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(1u));
 
+          AssertThat(out->canonical, Is().True());
+
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(1u)); // <-- NOTE: not '3u'
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(2u));
@@ -2541,6 +2551,8 @@ go_bandit([]() {
 
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(1u));
+
+          AssertThat(out->canonical, Is().True());
 
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(1u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(1u));
@@ -2657,6 +2669,8 @@ go_bandit([]() {
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(2u));
 
+          AssertThat(out->canonical, Is().False());
+
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(4u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(4u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(4u));
@@ -2740,6 +2754,8 @@ go_bandit([]() {
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(0u));
 
+          AssertThat(out->canonical, Is().True());
+
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(0u));
@@ -2816,7 +2832,6 @@ go_bandit([]() {
           // 1 - -> 2 (T)
           pq.push(arc(arcs.pull_internal().source(), terminal_T));
 
-          // Reduce level x0
           pq.setup_next_level(0);
 
           // Reduce level x0
@@ -2824,6 +2839,8 @@ go_bandit([]() {
 
           // Check meta variables before detach computations
           AssertThat(out->width, Is().EqualTo(0u));
+
+          AssertThat(out->canonical, Is().True());
 
           AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
           AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
@@ -2859,8 +2876,8 @@ go_bandit([]() {
                                                request_fst_lt<inner_down_sweep::request_t>>;
 
         /*
-        //       ?    ?        ---- x0
-        // -   -   -    -   -
+        //       ?   ?         ---- x0
+        // -   -   -   -   -
         //       2   3   4     ---- x1
         //      / \ / \ / \
         //      F T F  5  T    ---- x2

--- a/test/adiar/internal/algorithms/test_nested_sweeping.cpp
+++ b/test/adiar/internal/algorithms/test_nested_sweeping.cpp
@@ -1979,6 +1979,669 @@ go_bandit([]() {
       });
     });
 
+    describe("nested_sweeping::aux algorithms", []() {
+      describe("__reduce_level__fast(...)", []() {
+        using pq_t = reduce_priority_queue<1, memory_mode_t::INTERNAL>;
+
+        it("suppresses an entire level of redundant nodes", []() {
+          /*
+          //      _1_     ---- x0
+          //     /   \
+          //     2   3    ---- x1 (being reduced)
+          //     \\ //
+          //       4      ---- x2
+          //      / \
+          //      F T
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+          const arc::ptr_t n2(1,0);
+          const arc::ptr_t n3(1,1);
+          const arc::ptr_t n4(2,0);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+            aw.push_internal({ n2, false, n4 });
+            aw.push_internal({ n2, true,  n4 });
+            aw.push_internal({ n3, false, n4 });
+            aw.push_internal({ n3, true,  n4 });
+
+            aw.push_terminal({ n4, false, terminal_F });
+            aw.push_terminal({ n4, true,  terminal_T });
+
+            aw.push(level_info(0,1u));
+            aw.push(level_info(1,2u));
+            aw.push(level_info(2,1u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Simulate reduction of x2
+          arcs.pull_terminal(); // 4 ---> T
+          arcs.pull_terminal(); // 4 - -> F
+
+          out_writer.unsafe_push(node(2, node::MAX_ID, terminal_F, terminal_T));
+          out_writer.unsafe_push(level_info(2, 1));
+          out_writer.unsafe_max_1level_cut({ 0, 1, 1, 2 });
+
+          // 3 ---> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+          // 3 - -> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+          // 2 ---> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+          // 2 - -> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+
+          pq.setup_next_level(1);
+
+          // Reduce level x1
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 1, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(1u));
+
+          // Over-approximation due to assuming entire level is output as-is;
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
+        it("outputs non-redundant nodes [bottom level]", []() {
+          /*
+          //      _1_     ---- x0
+          //     /   \
+          //     2   3    ---- x1 (being reduced)
+          //    / \ / \
+          //    T F F T
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+          const arc::ptr_t n2(1,0);
+          const arc::ptr_t n3(1,1);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+
+            aw.push_terminal({ n2, false, terminal_T });
+            aw.push_terminal({ n2, true,  terminal_F });
+            aw.push_terminal({ n3, false, terminal_F });
+            aw.push_terminal({ n3, true,  terminal_T });
+
+            aw.push(level_info(0,1u));
+            aw.push(level_info(1,2u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Reduce level x1
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 1, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID-1,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,2u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
+        it("does not canonically sort output [bottom level]", []() {
+          /*
+          //      _1_     ---- x0
+          //     /   \
+          //     2   3    ---- x1 (being reduced)
+          //    / \ / \
+          //    F T T F
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+          const arc::ptr_t n2(1,0);
+          const arc::ptr_t n3(1,1);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+
+            aw.push_terminal({ n2, false, terminal_F });
+            aw.push_terminal({ n2, true,  terminal_T });
+            aw.push_terminal({ n3, false, terminal_T });
+            aw.push_terminal({ n3, true,  terminal_F });
+
+            aw.push(level_info(0,1u));
+            aw.push(level_info(1,2u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Reduce level x1
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 1, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID-1,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,2u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
+        it("does not canonically sort output [other levels]", []() {
+          /*
+          //          _1_        ---- x0
+          //         /   \
+          //         2   3       ---- x1 (being reduced)
+          //        / \ / \
+          //        | T | |
+          //         \ /  |
+          //          4   5      ---- x2
+          //         / \ / \
+          //         T F F T
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+          const arc::ptr_t n2(1,0);
+          const arc::ptr_t n3(1,1);
+          const arc::ptr_t n4(2,0);
+          const arc::ptr_t n5(2,1);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+            aw.push_internal({ n2, false, n4 });
+            aw.push_internal({ n3, false, n4 });
+            aw.push_internal({ n3, true,  n5 });
+
+            aw.push_terminal({ n2, true,  terminal_T });
+            aw.push_terminal({ n4, false, terminal_T });
+            aw.push_terminal({ n4, true,  terminal_F });
+            aw.push_terminal({ n5, false, terminal_F });
+            aw.push_terminal({ n5, true,  terminal_T });
+
+            aw.push(level_info(0,1u));
+            aw.push(level_info(1,2u));
+            aw.push(level_info(2,2u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Simulate reduction of x2
+          arcs.pull_terminal(); // 5 ---> T
+          arcs.pull_terminal(); // 5 - -> F
+          out_writer.unsafe_push(node(2, node::MAX_ID,   terminal_F, terminal_T));
+
+          arcs.pull_terminal(); // 4 ---> F
+          arcs.pull_terminal(); // 4 - -> T
+          out_writer.unsafe_push(node(2, node::MAX_ID-1, terminal_T, terminal_F));
+
+          out_writer.unsafe_push(level_info(2, 2));
+          out_writer.unsafe_max_1level_cut({ 0, 2, 3, 5 });
+
+          // 3 ---> 5
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+          // 3 - -> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID-1)));
+          // 2 - -> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID-1)));
+
+          pq.setup_next_level(1);
+
+          // Reduce level x1
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 1, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(3u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(3u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(5u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID-1,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
+                                                         node::ptr_t(2, node::MAX_ID-1),
+                                                         node::ptr_t(2, node::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID-1,
+                                                         node::ptr_t(2, node::MAX_ID-1),
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,2u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,2u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
+        it("does not merge duplicates", []() {
+          /*
+          //      _1_     ---- x0
+          //     /   \
+          //     2_ _3    ---- x1 (being reduced)
+          //     |_X_|
+          //     4   5    ---- x2
+          //    / \ / \
+          //    T F F T
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+          const arc::ptr_t n2(1,0);
+          const arc::ptr_t n3(1,1);
+          const arc::ptr_t n4(2,0);
+          const arc::ptr_t n5(2,1);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+            aw.push_internal({ n2, false, n4 });
+            aw.push_internal({ n3, false, n4 });
+            aw.push_internal({ n2, true,  n5 });
+            aw.push_internal({ n3, true,  n5 });
+
+            aw.push_terminal({ n4, false, terminal_T });
+            aw.push_terminal({ n4, true,  terminal_F });
+            aw.push_terminal({ n5, false, terminal_F });
+            aw.push_terminal({ n5, true,  terminal_T });
+
+            aw.push(level_info(0,1u));
+            aw.push(level_info(1,2u));
+            aw.push(level_info(2,2u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Simulate reduction of x2
+          arcs.pull_terminal(); // 5 ---> T
+          arcs.pull_terminal(); // 5 - -> F
+          out_writer.unsafe_push(node(2, node::MAX_ID,   terminal_F, terminal_T));
+
+          arcs.pull_terminal(); // 4 ---> F
+          arcs.pull_terminal(); // 4 - -> T
+          out_writer.unsafe_push(node(2, node::MAX_ID-1, terminal_T, terminal_F));
+
+          out_writer.unsafe_push(level_info(2, 2));
+          out_writer.unsafe_max_1level_cut({ 0, 2, 2, 4 });
+
+          // 3 ---> 5
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+          // 2 ---> 5
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID)));
+          // 3 - -> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID-1)));
+          // 2 - -> 4
+          pq.push(arc(arcs.pull_internal().source(), node::ptr_t(2, node::MAX_ID-1)));
+
+          pq.setup_next_level(1);
+
+          // Reduce level x1
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 1, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(2u));
+
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID-1,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
+                                                         node::ptr_t(2, node::MAX_ID-1),
+                                                         node::ptr_t(2, node::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID-1,
+                                                         node::ptr_t(2, node::MAX_ID-1),
+                                                         node::ptr_t(2, node::MAX_ID))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,2u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,2u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
+        it("identifies collapse to a terminal [single level]", []() {
+          /*
+          //      1     ---- x0  (being reduced)
+          //     / \
+          //     T T
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_terminal({ n1, false, terminal_T });
+            aw.push_terminal({ n1, true,  terminal_T });
+
+            aw.push(level_info(0,1u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Reduce level x0
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 0, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(0u));
+
+          // Over-approximation due to assuming entire level is output as-is;
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+
+        it("identifies collapse to a terminal [multiple levels]", []() {
+          /*
+          //      _1_      ---- x0 (being reduced)
+          //     /   \
+          //     2   3     ---- x1
+          //     ||  ||
+          //     T   T
+          */
+          const arc::ptr_t terminal_F(false);
+          const arc::ptr_t terminal_T(true);
+
+          const arc::ptr_t n1(0,0);
+          const arc::ptr_t n2(1,0);
+          const arc::ptr_t n3(1,1);
+
+          shared_levelized_file<arc> in;
+
+          { // Garbage collect writer to free write-lock
+            arc_writer aw(in);
+
+            aw.push_internal({ n1, false, n2 });
+            aw.push_internal({ n1, true,  n3 });
+
+            aw.push_terminal({ n2, false, terminal_T });
+            aw.push_terminal({ n2, true,  terminal_T });
+            aw.push_terminal({ n3, false, terminal_T });
+            aw.push_terminal({ n3, true,  terminal_T });
+
+            aw.push(level_info(0,1u));
+            aw.push(level_info(1,2u));
+          }
+
+          // Outer state
+          shared_levelized_file<node> out =  __reduce_init_output<bdd_policy>();
+
+          node_writer out_writer(out);
+
+          arc_stream arcs(in);
+
+          pq_t pq({in}, memory_available(), 16);
+
+          // Simulate reduction of x1
+          arcs.pull_terminal(); // 3 ---> T
+          arcs.pull_terminal(); // 3 - -> F
+
+          arcs.pull_terminal(); // 2 ---> F
+          arcs.pull_terminal(); // 2 - -> T
+
+          // 1 ---> 3 (T)
+          pq.push(arc(arcs.pull_internal().source(), terminal_T));
+          // 1 - -> 2 (T)
+          pq.push(arc(arcs.pull_internal().source(), terminal_T));
+
+          // Reduce level x0
+          pq.setup_next_level(0);
+
+          // Reduce level x0
+          nested_sweeping::__reduce_level__fast<bdd_policy>(arcs, 0, pq, out_writer);
+
+          // Check meta variables before detach computations
+          AssertThat(out->width, Is().EqualTo(0u));
+
+          // Over-approximation due to assuming entire level is output as-is;
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut_type::ALL], Is().EqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(0u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+
+          // Check node and meta files are correct
+          out_writer.detach();
+
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().False());
+        });
+      });
+    });
+
     describe("nested_sweeping:: _ ::sweeps", [&terminal_F, &terminal_T, &outer_dag]() {
       describe("inner::down(...)", [&]() {
         using inner_down_sweep = test_not_sweep<>;

--- a/test/adiar/internal/algorithms/test_reduce.cpp
+++ b/test/adiar/internal/algorithms/test_reduce.cpp
@@ -5,8 +5,8 @@ go_bandit([]() {
     // The reduce<dd_policy> function is used within the constructors of the BDD
     // and ZDD classes.
 
-    ptr_uint64 terminal_T = ptr_uint64(true);
-    ptr_uint64 terminal_F = ptr_uint64(false);
+    const arc::ptr_t terminal_F(false);
+    const arc::ptr_t terminal_T(true);
 
     shared_levelized_file<node> x0x1_node_file;
 
@@ -14,16 +14,16 @@ go_bandit([]() {
       node_writer nw(x0x1_node_file);
 
       nw << node(1, node::MAX_ID, terminal_F, terminal_T)
-         << node(0, node::MAX_ID, terminal_F, ptr_uint64(1, ptr_uint64::MAX_ID));
+         << node(0, node::MAX_ID, terminal_F, node::ptr_t(1, node::MAX_ID));
     }
 
     it("preserves negation flag on reduced input [1]", [&]() {
       /*
-               1                  1      ---- x0
-              / \                / \
-              F 2        =>      F 2     ---- x1
-               / \                / \
-               F T                F T
+      //         1                  1      ---- x0
+      //        / \                / \
+      //        F 2        =>      F 2     ---- x1
+      //         / \                / \
+      //         F T                F T
       */
 
       // Use a __bdd that stores the node file from a bdd.
@@ -35,11 +35,11 @@ go_bandit([]() {
 
     it("preserves negation flag on reduced input [2]", [&]() {
       /*
-               1                  1      ---- x0
-              / \                / \
-              F 2      = ~ =>    T 2     ---- x1
-               / \                / \
-               F T                T F
+      //         1                  1      ---- x0
+      //        / \                / \
+      //        F 2      = ~ =>    T 2     ---- x1
+      //         / \                / \
+      //         F T                T F
       */
 
       // Use a __bdd that stores the node file from a bdd.
@@ -52,19 +52,19 @@ go_bandit([]() {
     describe("Reduction Rule 2", [&]() {
       it("applies to terminal arcs [1]", [&]() {
         /*
-                   1                  1      ---- x0
-                  / \                / \
-                  | 2_               | 2     ---- x1
-                  | | \      =>      |/ \
-                  3 4 T              4  T    ---- x2
-                  |X|               / \
-                  F T               F T
+        //           1                  1      ---- x0
+        //          / \                / \
+        //          | 2_               | 2     ---- x1
+        //          | | \      =>      |/ \
+        //          3 4 T              4  T    ---- x2
+        //          |X|               / \
+        //          F T               F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
 
         shared_levelized_file<arc> in;
 
@@ -106,14 +106,14 @@ go_bandit([]() {
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
@@ -151,22 +151,22 @@ go_bandit([]() {
 
       it("applies to terminal arcs [2]", [&]() {
         /*
-                    1      ---- x0            1
-                   / \                       / \
-                   | |     ---- x1           | |
-                   | |                       | |
-                   2 3     ---- x2    ==>    2 3
-                  / X \                     /\ /\
-                  F/ \T                     F | T
-                   4 5     ---- x3            4
-                  /| |\                      / \
-                  FT FT                      F T
+        //            1      ---- x0            1
+        //           / \                       / \
+        //           | |     ---- x1           | |
+        //           | |                       | |
+        //           2 3     ---- x2    ==>    2 3
+        //          / X \                     /\ /\
+        //          F/ \T                     F | T
+        //           4 5     ---- x3            4
+        //          /| |\                      / \
+        //          FT FT                      F T
         */
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(2,0);
-        ptr_uint64 n3 = ptr_uint64(2,1);
-        ptr_uint64 n4 = ptr_uint64(3,0);
-        ptr_uint64 n5 = ptr_uint64(3,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(2,0);
+        const arc::ptr_t n3(2,1);
+        const arc::ptr_t n4(3,0);
+        const arc::ptr_t n5(3,1);
 
         shared_levelized_file<arc> in;
 
@@ -207,17 +207,17 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(3, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID-1,
                                                        terminal_F,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(3, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True());
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID-1),
+                                                       node::ptr_t(2, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -256,23 +256,23 @@ go_bandit([]() {
 
       it("applies to node arcs [1]", [&]() {
         /*
-                    1                  1       ---- x0
-                   / \                / \
-                   | 2_               | 2      ---- x1
-                   | | \      =>      |/ \
-                   3 4 T              4  T     ---- x2
-                   |X|               / \
-                   5 6               5  6      ---- x3
-                  / \ \\            / \/ \
-                  F T T F           F  T F
+        //            1                  1       ---- x0
+        //           / \                / \
+        //           | 2_               | 2      ---- x1
+        //           | | \      =>      |/ \
+        //           3 4 T              4  T     ---- x2
+        //           |X|               / \
+        //           5 6               5  6      ---- x3
+        //          / \ \\            / \/ \
+        //          F T T F           F  T F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
-        ptr_uint64 n5 = ptr_uint64(3,0);
-        ptr_uint64 n6 = ptr_uint64(3,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
+        const arc::ptr_t n5(3,0);
+        const arc::ptr_t n6(3,1);
 
         shared_levelized_file<arc> in;
 
@@ -321,20 +321,20 @@ go_bandit([]() {
 
         // n4
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(3, node::MAX_ID),
+                                                       node::ptr_t(3, node::MAX_ID-1))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
 
@@ -376,22 +376,22 @@ go_bandit([]() {
 
       it("applies to both node and terminal arcs", [&]() {
         /*
-                    1                  1     ---- x0
-                   / \                / \
-                   | 2_               | 2    ---- x1
-                   | | \      =>      |/ \
-                   3 4 T              4  T   ---- x2
-                   |X|               / \
-                   5 T               5 T     ---- x3
-                  / \               / \
-                  F T               F T
+        //            1                  1     ---- x0
+        //           / \                / \
+        //           | 2_               | 2    ---- x1
+        //           | | \      =>      |/ \
+        //           3 4 T              4  T   ---- x2
+        //           |X|               / \
+        //           5 T               5 T     ---- x3
+        //          / \               / \
+        //          F T               F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
-        ptr_uint64 n5 = ptr_uint64(3,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
+        const arc::ptr_t n5(3,0);
 
         shared_levelized_file<arc> in;
 
@@ -434,20 +434,20 @@ go_bandit([]() {
 
         // n4
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(3, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
@@ -493,25 +493,25 @@ go_bandit([]() {
 
       it("applies to 'disjoint' branches", [&]() {
         /*
-                       1                        1         ---- x0
-                      / \                      / \
-                     2   3                     2  3       ---- x1
-                    / \ / \                    \\/ \
-                   /   |   \                    X___\     (2.low() goes to 6)
-                   4   5   6        =>          5   6     ---- x2
-                  / \ / \ / \                  / \ / \
-                  F T 7 T F T                  7 T F T    ---- x3
-                     / \                      / \
-                     F T                      F T
+        //               1                        1         ---- x0
+        //              / \                      / \
+        //             2   3                     2  3       ---- x1
+        //            / \ / \                    \\/ \
+        //           /   |   \                    X___\     (2.low() goes to 6)
+        //           4   5   6        =>          5   6     ---- x2
+        //          / \ / \ / \                  / \ / \
+        //          F T 7 T F T                  7 T F T    ---- x3
+        //             / \                      / \
+        //             F T                      F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(1,1);
-        ptr_uint64 n4 = ptr_uint64(2,0);
-        ptr_uint64 n5 = ptr_uint64(2,1);
-        ptr_uint64 n6 = ptr_uint64(2,2);
-        ptr_uint64 n7 = ptr_uint64(3,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(2,2);
+        const arc::ptr_t n7(3,0);
 
         shared_levelized_file<arc> in;
 
@@ -566,26 +566,26 @@ go_bandit([]() {
 
         // n5
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID-1,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(3, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n3
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID-1),
+                                                       node::ptr_t(2, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID-1,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID-1))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(1, node::MAX_ID-1),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
@@ -630,21 +630,21 @@ go_bandit([]() {
 
       it("does forward the correct children [1]", [&]() {
         /*
-                       1                1        ---- x0
-                      / \              / \
-                     2   3             | 3       ---- x1
-                    / \ / \      =>    |/ \
-                   4   5   6           5   6     ---- x2
-                  / \ / \ / \         / \ / \
-                  F T F T T F         F T T F
+        //               1                1        ---- x0
+        //              / \              / \
+        //             2   3             | 3       ---- x1
+        //            / \ / \      =>    |/ \
+        //           4   5   6           5   6     ---- x2
+        //          / \ / \ / \         / \ / \
+        //          F T F T T F         F T T F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(1,1);
-        ptr_uint64 n4 = ptr_uint64(2,0);
-        ptr_uint64 n5 = ptr_uint64(2,1);
-        ptr_uint64 n6 = ptr_uint64(2,2);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(2,2);
 
         shared_levelized_file<arc> in;
 
@@ -692,13 +692,13 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True()); // 3
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // 1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -740,21 +740,21 @@ go_bandit([]() {
 
       it("does forward the correct children [2]", [&]() {
         /*
-                       1                1        ---- x0
-                      / \              / \
-                     2   3             | 3       ---- x1
-                    / \ / \      =>    |/ \
-                   4   5   6           5   6     ---- x2
-                  / \ / \ / \         / \ / \
-                  T F T F F T         T F F T
+        //               1                1        ---- x0
+        //              / \              / \
+        //             2   3             | 3       ---- x1
+        //            / \ / \      =>    |/ \
+        //           4   5   6           5   6     ---- x2
+        //          / \ / \ / \         / \ / \
+        //          T F T F F T         T F F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(1,1);
-        ptr_uint64 n4 = ptr_uint64(2,0);
-        ptr_uint64 n5 = ptr_uint64(2,1);
-        ptr_uint64 n6 = ptr_uint64(2,2);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(2,2);
 
         shared_levelized_file<arc> in;
 
@@ -802,13 +802,13 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True()); // 3
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID-1),
+                                                       node::ptr_t(2, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // 1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID-1),
+                                                       node::ptr_t(1, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -851,19 +851,19 @@ go_bandit([]() {
     describe("Reduction Rule 1: BDD", [&]() {
       it("applies to terminal arcs", [&]() {
         /*
-                    1                  1     ---- x0
-                   / \                / \
-                   | 2                | 2    ---- x1
-                   |/ \      =>       |/ \
-                   3  4               3  |   ---- x2
-                  / \//               |\ /
-                  F  T                F T
+        //            1                  1     ---- x0
+        //           / \                / \
+        //           | 2                | 2    ---- x1
+        //           |/ \      =>       |/ \
+        //           3  4               3  |   ---- x2
+        //          / \//               |\ /
+        //          F  T                F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
 
         shared_levelized_file<arc> in;
 
@@ -905,14 +905,14 @@ go_bandit([]() {
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
 
@@ -951,22 +951,22 @@ go_bandit([]() {
 
       it("applies to node arcs", [&]() {
         /*
-                    1                  1        ---- x0
-                   / \                / \
-                   | 2                | 2       ---- x1
-                   |/ \      =>       |/ \
-                   3  4               3   \     ---- x2
-                  / \ \\             / \  |
-                  F T  5             F T  5     ---- x3
-                      / \                / \
-                      F T                F T
+        //            1                  1        ---- x0
+        //           / \                / \
+        //           | 2                | 2       ---- x1
+        //           |/ \      =>       |/ \
+        //           3  4               3   \     ---- x2
+        //          / \ \\             / \  |
+        //          F T  5             F T  5     ---- x3
+        //              / \                / \
+        //              F T                F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
-        ptr_uint64 n5 = ptr_uint64(3,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
+        const arc::ptr_t n5(3,0);
 
         shared_levelized_file<arc> in;
 
@@ -1013,14 +1013,14 @@ go_bandit([]() {
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(3, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
 
@@ -1065,21 +1065,20 @@ go_bandit([]() {
 
       it("works with two reductions on the same level", [&]() {
         /*
-                    1                  1        ---- x0
-                   / \                / \
-                  2   3              |   |      ---- x1
-                  ||  ||     =>      |   |
-                  4   5              4   5      ---- x2
-                 / \ / \            / \ / \
-                 F T T F            F T T F
-
+        //            1                  1        ---- x0
+        //           / \                / \
+        //          2   3              |   |      ---- x1
+        //          ||  ||     =>      |   |
+        //          4   5              4   5      ---- x2
+        //         / \ / \            / \ / \
+        //         F T T F            F T T F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(1,1);
-        ptr_uint64 n4 = ptr_uint64(2,0);
-        ptr_uint64 n5 = ptr_uint64(2,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
 
         shared_levelized_file<arc> in;
 
@@ -1125,8 +1124,8 @@ go_bandit([]() {
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID-1))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
 
@@ -1166,19 +1165,19 @@ go_bandit([]() {
 
       it("can be applied together with reduction rule 2 [1]", [&]() {
         /*
-                    1                  1     ---- x0
-                   / \                / \
-                   2 T                | T    ---- x1
-                  / \        =>       |
-                  3 4                 4      ---- x2
-                  |X|                / \
-                  F T                F T
+        //            1                  1     ---- x0
+        //           / \                / \
+        //           2 T                | T    ---- x1
+        //          / \        =>       |
+        //          3 4                 4      ---- x2
+        //          |X|                / \
+        //          F T                F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
 
         shared_levelized_file<arc> in;
 
@@ -1220,7 +1219,7 @@ go_bandit([]() {
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1259,147 +1258,147 @@ go_bandit([]() {
       });
 
       it("can be applied together with reduction rule 2 [2]", [&]() {
-          /*
-                   1                   1       ---- 0
-                  / \                 / \
-                 2   3               2  |      ---- 1
-                / \ / \     =>      / \ /
-               /   4   5           /   4       ---- 2
-              /   / \ / \         /   / \
-              6   F T F T         6   F T      ---- 3
-             / \                 / \
-             F T                 F T
-          */
+        /*
+        //           1                   1       ---- 0
+        //          / \                 / \
+        //         2   3               2  |      ---- 1
+        //        / \ / \     =>      / \ /
+        //       /   4   5           /   4       ---- 2
+        //      /   / \ / \         /   / \
+        //      6   F T F T         6   F T      ---- 3
+        //     / \                 / \
+        //     F T                 F T
+        */
 
-          ptr_uint64 n1 = ptr_uint64(0,0);
-          ptr_uint64 n2 = ptr_uint64(1,0);
-          ptr_uint64 n3 = ptr_uint64(1,1);
-          ptr_uint64 n4 = ptr_uint64(2,0);
-          ptr_uint64 n5 = ptr_uint64(2,1);
-          ptr_uint64 n6 = ptr_uint64(3,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(3,0);
 
-          shared_levelized_file<arc> in;
+        shared_levelized_file<arc> in;
 
-          { // Garbage collect writer to free write-lock
-            arc_writer aw(in);
+        { // Garbage collect writer to free write-lock
+          arc_writer aw(in);
 
-            aw.push_internal({ n1, false, n2 });
-            aw.push_internal({ n1, true,  n3 });
-            aw.push_internal({ n2, true,  n4 });
-            aw.push_internal({ n3, false, n4 });
-            aw.push_internal({ n3, true,  n5 });
-            aw.push_internal({ n2, false, n6 });
+          aw.push_internal({ n1, false, n2 });
+          aw.push_internal({ n1, true,  n3 });
+          aw.push_internal({ n2, true,  n4 });
+          aw.push_internal({ n3, false, n4 });
+          aw.push_internal({ n3, true,  n5 });
+          aw.push_internal({ n2, false, n6 });
 
-            aw.push_terminal({ n4, false, terminal_F });
-            aw.push_terminal({ n4, true,  terminal_T });
-            aw.push_terminal({ n5, false, terminal_F });
-            aw.push_terminal({ n5, true,  terminal_T });
-            aw.push_terminal({ n6, false, terminal_F });
-            aw.push_terminal({ n6, true,  terminal_T });
+          aw.push_terminal({ n4, false, terminal_F });
+          aw.push_terminal({ n4, true,  terminal_T });
+          aw.push_terminal({ n5, false, terminal_F });
+          aw.push_terminal({ n5, true,  terminal_T });
+          aw.push_terminal({ n6, false, terminal_F });
+          aw.push_terminal({ n6, true,  terminal_T });
 
-            aw.push(level_info(0,1u));
-            aw.push(level_info(1,2u));
-            aw.push(level_info(2,2u));
-            aw.push(level_info(3,1u));
-          }
+          aw.push(level_info(0,1u));
+          aw.push(level_info(1,2u));
+          aw.push(level_info(2,2u));
+          aw.push(level_info(3,1u));
+        }
 
-          in->max_1level_cut = 4;
+        in->max_1level_cut = 4;
 
-          // Reduce it
-          bdd out(in);
+        // Reduce it
+        bdd out(in);
 
-          AssertThat(adiar::is_canonical(out), Is().True());
+        AssertThat(adiar::is_canonical(out), Is().True());
 
-          // Check it looks all right
-          node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-          // n6
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                         terminal_F,
-                                                         terminal_T)));
+        // n6
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                       terminal_F,
+                                                       terminal_T)));
 
-          // n4
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                         terminal_F,
-                                                         terminal_T)));
+        // n4
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                       terminal_F,
+                                                       terminal_T)));
 
-          // n2
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                         ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                         ptr_uint64(2, ptr_uint64::MAX_ID))));
+        // n2
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
+                                                       node::ptr_t(3, node::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID))));
 
-          // n1
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                         ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                         ptr_uint64(2, ptr_uint64::MAX_ID))));
-          AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                       node::ptr_t(1, node::MAX_ID),
+                                                       node::ptr_t(2, node::MAX_ID))));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
-          level_info_test_stream out_meta(out);
+        level_info_test_stream out_meta(out);
 
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
 
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
 
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
+        AssertThat(out_meta.can_pull(), Is().True());
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
 
-          AssertThat(out_meta.can_pull(), Is().False());
+        AssertThat(out_meta.can_pull(), Is().False());
 
-          AssertThat(out->width, Is().EqualTo(1u));
+        AssertThat(out->width, Is().EqualTo(1u));
 
-          AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(3u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(3u));
 
-          // Over-approximation: globally counted arc from (1) to (4)
-          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().LessThanOrEqualTo(5u));
+        // Over-approximation: globally counted arc from (1) to (4)
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_FALSE], Is().LessThanOrEqualTo(5u));
 
-          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().LessThanOrEqualTo(5u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_1level_cut[cut_type::INTERNAL_TRUE], Is().LessThanOrEqualTo(5u));
 
-          // Over-approximation: at the lowest level we don't know yet, that
-          //                     nodes (4) and (5) will be merged.
-          //
-          //                     Currently, returns 5, i.e. maximum DiCut of '.size() + 1'.
-          AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_1level_cut[cut_type::ALL], Is().LessThanOrEqualTo(5u));
+        // Over-approximation: at the lowest level we don't know yet, that
+        //                     nodes (4) and (5) will be merged.
+        //
+        //                     Currently, returns 5, i.e. maximum DiCut of '.size() + 1'.
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_1level_cut[cut_type::ALL], Is().LessThanOrEqualTo(5u));
 
-          AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().LessThanOrEqualTo(5u));
-          AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().LessThanOrEqualTo(5u));
-          AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().LessThanOrEqualTo(5u));
-          AssertThat(out->max_2level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut_type::ALL], Is().LessThanOrEqualTo(5u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL], Is().LessThanOrEqualTo(5u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_FALSE], Is().LessThanOrEqualTo(5u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_2level_cut[cut_type::INTERNAL_TRUE], Is().LessThanOrEqualTo(5u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().GreaterThanOrEqualTo(3u));
+        AssertThat(out->max_2level_cut[cut_type::ALL], Is().LessThanOrEqualTo(5u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
-          AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
-        });
+        AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+        AssertThat(out->number_of_terminals[true],  Is().EqualTo(2u));
+      });
 
       it("can reduce the root [1]", [&]() {
         /*
-                   1                         ---- x0
-                  / \
-                  | 2                        ---- x1
-                  |/|         =>
-                  3 4                 4      ---- x2
-                  |X|                / \
-                  F T                F T
+        //           1                         ---- x0
+        //          / \
+        //          | 2                        ---- x1
+        //          |/|         =>
+        //          3 4                 4      ---- x2
+        //          |X|                / \
+        //          F T                F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
 
         shared_levelized_file<arc> in;
 
@@ -1475,15 +1474,15 @@ go_bandit([]() {
         //        F T               F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(1,1);
-        ptr_uint64 n4 = ptr_uint64(2,0);
-        ptr_uint64 n5 = ptr_uint64(2,1);
-        ptr_uint64 n6 = ptr_uint64(3,0);
-        ptr_uint64 n7 = ptr_uint64(3,1);
-        ptr_uint64 n8 = ptr_uint64(3,2);
-        ptr_uint64 n9 = ptr_uint64(4,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(3,0);
+        const arc::ptr_t n7(3,1);
+        const arc::ptr_t n8(3,2);
+        const arc::ptr_t n9(4,0);
 
         shared_levelized_file<arc> in;
 
@@ -1541,31 +1540,31 @@ go_bandit([]() {
 
         // n7
         AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID-1,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID),
+                                                       node::ptr_t(4, node::MAX_ID),
                                                        terminal_T)));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n6
         AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID-2,
                                                        terminal_F,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(4, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n5
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(3, node::MAX_ID-1),
+                                                       node::ptr_t(3, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n4
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID-1,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID-2),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(3, node::MAX_ID-2),
+                                                       node::ptr_t(3, node::MAX_ID-1))));
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID-1),
+                                                       node::ptr_t(2, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1605,23 +1604,23 @@ go_bandit([]() {
 
       it("accounts for multiple ingoing arcs to reduction rule 1 node", [&]() {
         /*
-                   1                   1       ---- x0
-                  / \                 / \
-                 2   \                2 T      ---- x1
-                / \  |               / \
-              _3_  \ |       =>    _3_ T       ---- x2
-             /   \  \|            /   \
-             4   5   6            4   5        ---- x3
-            / \ / \ / \          / \ / \
-            T F F T T T          T F F T
+        //           1                   1       ---- x0
+        //          / \                 / \
+        //         2   \                2 T      ---- x1
+        //        / \  |               / \
+        //      _3_  \ |       =>    _3_ T       ---- x2
+        //     /   \  \|            /   \
+        //     4   5   6            4   5        ---- x3
+        //    / \ / \ / \          / \ / \
+        //    T F F T T T          T F F T
         */
 
-        const ptr_uint64 n1 = ptr_uint64(0,0);
-        const ptr_uint64 n2 = ptr_uint64(1,0);
-        const ptr_uint64 n3 = ptr_uint64(2,0);
-        const ptr_uint64 n4 = ptr_uint64(3,0);
-        const ptr_uint64 n5 = ptr_uint64(3,1);
-        const ptr_uint64 n6 = ptr_uint64(3,2);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(3,0);
+        const arc::ptr_t n5(3,1);
+        const arc::ptr_t n6(3,2);
 
         shared_levelized_file<arc> in;
 
@@ -1655,38 +1654,38 @@ go_bandit([]() {
 
         AssertThat(adiar::is_canonical(out), Is().True());
 
-          // Check it looks all right
-          node_test_stream out_nodes(out);
+        // Check it looks all right
+        node_test_stream out_nodes(out);
 
-          // n4
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                         terminal_F,
-                                                         terminal_T)));
+        // n4
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
+                                                       terminal_F,
+                                                       terminal_T)));
 
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID-1,
-                                                         terminal_T,
-                                                         terminal_F)));
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID-1,
+                                                       terminal_T,
+                                                       terminal_F)));
 
-          // n4
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                         ptr_uint64(3, ptr_uint64::MAX_ID-1),
-                                                         ptr_uint64(3, ptr_uint64::MAX_ID))));
+        // n4
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
+                                                       node::ptr_t(3, node::MAX_ID-1),
+                                                       node::ptr_t(3, node::MAX_ID))));
 
-          // n2
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                         ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                         terminal_T)));
+        // n2
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       terminal_T)));
 
-          // n1
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                         ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                         terminal_T)));
-          AssertThat(out_nodes.can_pull(), Is().False());
+        // n1
+        AssertThat(out_nodes.can_pull(), Is().True());
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                       node::ptr_t(1, node::MAX_ID),
+                                                       terminal_T)));
+        AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
 
@@ -1732,12 +1731,12 @@ go_bandit([]() {
 
       it("can apply reduction rule 1 to a single node", [&]() {
         /*
-                   1                 F       ---- x0
-                  / \      =>
-                  F F
+        //           1                 F       ---- x0
+        //          / \      =>
+        //          F F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
+        const arc::ptr_t n1(0,0);
 
         shared_levelized_file<arc> in;
 
@@ -1787,15 +1786,15 @@ go_bandit([]() {
 
       it("can propagate reduction rule 1 up to a terminal", [&]() {
         /*
-                   1                  T
-                  / \
-                  | 2         =>
-                  |/ \
-                  T  T
+        //           1                  T
+        //          / \
+        //          | 2         =>
+        //          |/ \
+        //          T  T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
 
         shared_levelized_file<arc> in;
 
@@ -1847,12 +1846,12 @@ go_bandit([]() {
 
       it("can return non-reducible single-node variable with MAX_ID", [&]() {
         /*
-                   1                 1       ---- x0
-                  / \      =>       / \
-                  F T               F T
+        //           1                 1       ---- x0
+        //          / \      =>       / \
+        //          F T               F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
+        const arc::ptr_t n1(0,0);
 
         shared_levelized_file<arc> in;
 
@@ -1903,32 +1902,32 @@ go_bandit([]() {
 
       it("can account for a chain of don't cares contributing to the maximum cut [1]", [&]() {
         /*
-             _1_                 1             ---- x0
-            /   \               / \
-            2   3              /  3            ---- x1
-            \\ / \             | / \
-              4  5             |/  5           ---- x2
-              \\/ \            || / \
-               6  7      =>    || | 7          ---- x3
-               \\/ \           || |/ \
-                8  9           \\ || 9         ---- x4
-                \\/ \           \\|// \
-                10  11           10   11       ---- x5
-               /  \/  \         /  \ /  \
-               T  F   T         T  F F  T
-         */
+        //       _1_                 1             ---- x0
+        //      /   \               / \
+        //      2   3              /  3            ---- x1
+        //      \\ / \             | / \
+        //        4  5             |/  5           ---- x2
+        //        \\/ \            || / \
+        //         6  7      =>    || | 7          ---- x3
+        //         \\/ \           || |/ \
+        //          8  9           \\ || 9         ---- x4
+        //          \\/ \           \\|// \
+        //          10  11           10   11       ---- x5
+        //         /  \/  \         /  \ /  \
+        //         T  F   T         T  F F  T
+        */
 
-        const ptr_uint64 n1  = ptr_uint64(0,0);
-        const ptr_uint64 n2  = ptr_uint64(1,0);
-        const ptr_uint64 n3  = ptr_uint64(1,1);
-        const ptr_uint64 n4  = ptr_uint64(2,0);
-        const ptr_uint64 n5  = ptr_uint64(2,1);
-        const ptr_uint64 n6  = ptr_uint64(3,0);
-        const ptr_uint64 n7  = ptr_uint64(3,1);
-        const ptr_uint64 n8  = ptr_uint64(4,0);
-        const ptr_uint64 n9  = ptr_uint64(4,1);
-        const ptr_uint64 n10 = ptr_uint64(5,0);
-        const ptr_uint64 n11 = ptr_uint64(5,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(3,0);
+        const arc::ptr_t n7(3,1);
+        const arc::ptr_t n8(4,0);
+        const arc::ptr_t n9(4,1);
+        const arc::ptr_t n10(5,0);
+        const arc::ptr_t n11(5,1);
 
         shared_levelized_file<arc> in;
 
@@ -1989,29 +1988,29 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n9
         AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n7
         AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(4, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n5
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(3, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n3
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(2, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(1, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -2063,35 +2062,35 @@ go_bandit([]() {
 
       it("can account for a chain of don't cares contributing to the maximum cut [2]", [&]() {
         /*
-                    __1__                      __1__           ---- x0
-                   /     \                    /     \
-                   2_   _3                    2_   _3          ---- x1
-                  /  \ /  \                  /  \ /  \
-                  4_  5  _6                  4  | |  6         ---- x2
-                  | \| |/ |                 / \ | | / \
-                  7_  8  _9                 7 | | | | 9        ---- x3
-                  | \| |/ |                /\ | | | // \
-                  10  11 _12              10_\\ | ///__12      ---- x4
-                  | \| |/ |              /   \\\|////    \
-                  *   13  14*            *      13      14*    ---- x5
-                     /  \/  \                  /  \    /  \
-                     T  F   T                  T  F    F  T
-         */
+        //            __1__                      __1__           ---- x0
+        //           /     \                    /     \
+        //           2_   _3                    2_   _3          ---- x1
+        //          /  \ /  \                  /  \ /  \
+        //          4_  5  _6                  4  | |  6         ---- x2
+        //          | \| |/ |                 / \ | | / \
+        //          7_  8  _9                 7 | | | | 9        ---- x3
+        //          | \| |/ |                /\ | | | // \
+        //          10  11 _12              10_\\ | ///__12      ---- x4
+        //          | \| |/ |              /   \\\|////    \
+        //          *   13  14*            *      13      14*    ---- x5
+        //             /  \/  \                  /  \    /  \
+        //             T  F   T                  T  F    F  T
+        */
 
-        const ptr_uint64 n1  = ptr_uint64(0,0);
-        const ptr_uint64 n2  = ptr_uint64(1,0);
-        const ptr_uint64 n3  = ptr_uint64(1,1);
-        const ptr_uint64 n4  = ptr_uint64(2,0);
-        const ptr_uint64 n5  = ptr_uint64(2,1);
-        const ptr_uint64 n6  = ptr_uint64(2,2);
-        const ptr_uint64 n7  = ptr_uint64(3,0);
-        const ptr_uint64 n8  = ptr_uint64(3,1);
-        const ptr_uint64 n9  = ptr_uint64(3,2);
-        const ptr_uint64 n10 = ptr_uint64(4,0);
-        const ptr_uint64 n11 = ptr_uint64(4,1);
-        const ptr_uint64 n12 = ptr_uint64(4,2);
-        const ptr_uint64 n13 = ptr_uint64(5,0);
-        const ptr_uint64 n14 = ptr_uint64(5,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(2,2);
+        const arc::ptr_t n7(3,0);
+        const arc::ptr_t n8(3,1);
+        const arc::ptr_t n9(3,2);
+        const arc::ptr_t n10(4,0);
+        const arc::ptr_t n11(4,1);
+        const arc::ptr_t n12(4,2);
+        const arc::ptr_t n13(5,0);
+        const arc::ptr_t n14(5,1);
 
         shared_levelized_file<arc> in;
 
@@ -2158,48 +2157,48 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n12
         AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n10
         AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID-1,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(5, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n7
         AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(4, node::MAX_ID-1),
+                                                       node::ptr_t(5, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n9
         AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID-1,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(4, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n4
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(3, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n6
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID-1,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(3, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n3
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID-1,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(2, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID-1))));
+                                                       node::ptr_t(1, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID-1))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -2264,14 +2263,14 @@ go_bandit([]() {
         //            F T                  F T
         */
 
-        const ptr_uint64 n1  = ptr_uint64(0,0);
-        const ptr_uint64 n2  = ptr_uint64(1,0);
-        const ptr_uint64 n3  = ptr_uint64(1,1);
-        const ptr_uint64 n4  = ptr_uint64(2,0);
-        const ptr_uint64 n5  = ptr_uint64(2,1);
-        const ptr_uint64 n6  = ptr_uint64(2,2);
-        const ptr_uint64 n7  = ptr_uint64(3,0);
-        const ptr_uint64 n8  = ptr_uint64(4,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(2,2);
+        const arc::ptr_t n7(3,0);
+        const arc::ptr_t n8(4,0);
 
         shared_levelized_file<arc> in;
 
@@ -2396,10 +2395,10 @@ go_bandit([]() {
         //     T T
         */
 
-        const ptr_uint64 n1  = ptr_uint64(0,0);
-        const ptr_uint64 n2  = ptr_uint64(1,0);
-        const ptr_uint64 n3  = ptr_uint64(1,1);
-        const ptr_uint64 n4  = ptr_uint64(2,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
 
         shared_levelized_file<arc> in;
 
@@ -2463,15 +2462,15 @@ go_bandit([]() {
     describe("Reduction Rule 1: ZDD", [&]() {
       it("applies to terminal arcs", [&]() {
         /*
-                   1                  1     ---- x0
-                  / \                / \
-                  | 2         =>     T T    ---- x1
-                  |/ \
-                  T  F
+        //           1                  1     ---- x0
+        //          / \                / \
+        //          | 2         =>     T T    ---- x1
+        //          |/ \
+        //          T  F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
 
         shared_levelized_file<arc> in;
 
@@ -2528,22 +2527,22 @@ go_bandit([]() {
 
       it("applies to node arcs", [&]() {
         /*
-                    1                  1        ---- x0
-                   / \                / \
-                   | 2                | 2       ---- x1
-                   |/ \      =>       |/ \
-                   3   4              3   \     ---- x2
-                  / \ / \            / \  |
-                  F T 5 F            F T  5     ---- x3
-                     / \                 / \
-                     F T                 F T
+        //            1                  1        ---- x0
+        //           / \                / \
+        //           | 2                | 2       ---- x1
+        //           |/ \      =>       |/ \
+        //           3   4              3   \     ---- x2
+        //          / \ / \            / \  |
+        //          F T 5 F            F T  5     ---- x3
+        //             / \                 / \
+        //             F T                 F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(2,0);
-        ptr_uint64 n4 = ptr_uint64(2,1);
-        ptr_uint64 n5 = ptr_uint64(3,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(2,0);
+        const arc::ptr_t n4(2,1);
+        const arc::ptr_t n5(3,0);
 
         shared_levelized_file<arc> in;
 
@@ -2590,14 +2589,14 @@ go_bandit([]() {
 
         // n2
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(3, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().True());
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
 
@@ -2647,19 +2646,19 @@ go_bandit([]() {
 
       it("can be applied together with reduction rule 2", [&]() {
         /*
-                      1                  1     ---- x0
-                     / \                ||
-                    2   3                3     ---- x1
-                   / \ / \              / \
-                   F T F 4              F T
-                        / \
-                        T F
+        //              1                  1     ---- x0
+        //             / \                ||
+        //            2   3                3     ---- x1
+        //           / \ / \              / \
+        //           F T F 4              F T
+        //                / \
+        //                T F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
-        ptr_uint64 n3 = ptr_uint64(1,1);
-        ptr_uint64 n4 = ptr_uint64(2,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
 
         shared_levelized_file<arc> in;
 
@@ -2701,8 +2700,8 @@ go_bandit([]() {
 
         // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(1, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
@@ -2743,12 +2742,12 @@ go_bandit([]() {
 
       it("applies to a single node", [&]() {
         /*
-                   1                 T       ---- x0
-                  / \      =>
-                  T F
+        //           1                 T       ---- x0
+        //          / \      =>
+        //          T F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
+        const arc::ptr_t n1(0,0);
 
         shared_levelized_file<arc> in;
 
@@ -2798,15 +2797,15 @@ go_bandit([]() {
 
       it("can reduce the root", [&]() {
         /*
-                    1                        ---- x0
-                   / \
-                   2 F        =>      2      ---- x1
-                  / \                / \
-                  F T                F T
+        //            1                        ---- x0
+        //           / \
+        //           2 F        =>      2      ---- x1
+        //          / \                / \
+        //          F T                F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
 
         shared_levelized_file<arc> in;
 
@@ -2864,15 +2863,15 @@ go_bandit([]() {
 
       it("can propagate reduction rule 1 up to a terminal", [&]() {
         /*
-                   1                  F
-                  / \
-                  | 2         =>
-                  |/ \
-                  F  F
+        //           1                  F
+        //          / \
+        //          | 2         =>
+        //          |/ \
+        //          F  F
         */
 
-        ptr_uint64 n1 = ptr_uint64(0,0);
-        ptr_uint64 n2 = ptr_uint64(1,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
 
         shared_levelized_file<arc> in;
 
@@ -2924,12 +2923,12 @@ go_bandit([]() {
 
       it("can return non-reducible single-node variable with MAX_ID [1]", [&]() {
         /*
-                   1                 1       ---- x42
-                  / \      =>       / \
-                  F T               F T
+        //           1                 1       ---- x42
+        //          / \      =>       / \
+        //          F T               F T
         */
 
-        ptr_uint64 n1 = ptr_uint64(42,0);
+        const arc::ptr_t n1(42,0);
 
         shared_levelized_file<arc> in;
 
@@ -2981,12 +2980,12 @@ go_bandit([]() {
 
       it("can return non-reducible single-node variable with MAX_ID [2]", [&]() {
         /*
-                   1                 1       ---- x12
-                  / \      =>       / \
-                  T T               T T
+        //           1                 1       ---- x12
+        //          / \      =>       / \
+        //          T T               T T
         */
 
-        ptr_uint64 n1 = ptr_uint64(12,0);
+        const arc::ptr_t n1(12,0);
 
         shared_levelized_file<arc> in;
 
@@ -3039,32 +3038,32 @@ go_bandit([]() {
 
       it("can account for a chain of don't cares contributing to the maximum cut [1]", [&]() {
         /*
-                      _1_                 1             ---- x0
-                     /   \               / \
-                     2   3              2  |            ---- x1
-                    / \ / \            / \ |
-                    4  5  F            4 | |            ---- x2
-                   / \/ \             / \| |
-                   6  7 F             6 || |            ---- x3
-                  / \/ \             / \|| |
-                  8  9 F             8 ||| /            ---- x4
-                 / \/ \             / \||//
-                10 11 F             10 11               ---- x5
-               / | | \             / | | \
-               F T T T             F T T T
-         */
+        //              _1_                 1             ---- x0
+        //             /   \               / \
+        //             2   3              2  |            ---- x1
+        //            / \ / \            / \ |
+        //            4  5  F            4 | |            ---- x2
+        //           / \/ \             / \| |
+        //           6  7 F             6 || |            ---- x3
+        //          / \/ \             / \|| |
+        //          8  9 F             8 ||| /            ---- x4
+        //         / \/ \             / \||//
+        //        10 11 F             10 11               ---- x5
+        //       / | | \             / | | \
+        //       F T T T             F T T T
+        */
 
-        const ptr_uint64 n1  = ptr_uint64(0,0);
-        const ptr_uint64 n2  = ptr_uint64(1,0);
-        const ptr_uint64 n3  = ptr_uint64(1,1);
-        const ptr_uint64 n4  = ptr_uint64(2,0);
-        const ptr_uint64 n5  = ptr_uint64(2,1);
-        const ptr_uint64 n6  = ptr_uint64(3,0);
-        const ptr_uint64 n7  = ptr_uint64(3,1);
-        const ptr_uint64 n8  = ptr_uint64(4,0);
-        const ptr_uint64 n9  = ptr_uint64(4,1);
-        const ptr_uint64 n10 = ptr_uint64(5,0);
-        const ptr_uint64 n11 = ptr_uint64(5,1);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
+        const arc::ptr_t n5(2,1);
+        const arc::ptr_t n6(3,0);
+        const arc::ptr_t n7(3,1);
+        const arc::ptr_t n8(4,0);
+        const arc::ptr_t n9(4,1);
+        const arc::ptr_t n10(5,0);
+        const arc::ptr_t n11(5,1);
 
         shared_levelized_file<arc> in;
 
@@ -3125,29 +3124,29 @@ go_bandit([]() {
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n9
         AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::MAX_ID,
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID-1),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(5, node::MAX_ID-1),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n7
         AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::MAX_ID,
-                                                       ptr_uint64(4, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(4, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n5
         AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::MAX_ID,
-                                                       ptr_uint64(3, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(3, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n3
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID,
-                                                       ptr_uint64(2, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(2, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n1
         AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
-                                                       ptr_uint64(1, ptr_uint64::MAX_ID),
-                                                       ptr_uint64(5, ptr_uint64::MAX_ID))));
+                                                       node::ptr_t(1, node::MAX_ID),
+                                                       node::ptr_t(5, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -3199,19 +3198,19 @@ go_bandit([]() {
 
       it("Merges nodes, despite of reduction rule 1 flag on child", [&]() {
         /*
-                _1_                1      ---- x0
-               /   \               ||
-               2   3     =>        2      ---- x1
-              / \ / \             / \
-              F 4 F T             F T     ---- x2
-               / \
-               T F
-         */
+        //        _1_                1      ---- x0
+        //       /   \               ||
+        //       2   3     =>        2      ---- x1
+        //      / \ / \             / \
+        //      F 4 F T             F T     ---- x2
+        //       / \
+        //       T F
+        */
 
-        const ptr_uint64 n1  = ptr_uint64(0,0);
-        const ptr_uint64 n2  = ptr_uint64(1,0);
-        const ptr_uint64 n3  = ptr_uint64(1,1);
-        const ptr_uint64 n4  = ptr_uint64(2,0);
+        const arc::ptr_t n1(0,0);
+        const arc::ptr_t n2(1,0);
+        const arc::ptr_t n3(1,1);
+        const arc::ptr_t n4(2,0);
 
         shared_levelized_file<arc> in;
 
@@ -3247,7 +3246,9 @@ go_bandit([]() {
         AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::MAX_ID, terminal_F, terminal_T)));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // n1
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID, ptr_uint64(1, ptr_uint64::MAX_ID), ptr_uint64(1, ptr_uint64::MAX_ID))));
+        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::MAX_ID,
+                                                       node::ptr_t(1, node::MAX_ID),
+                                                       node::ptr_t(1, node::MAX_ID))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 


### PR DESCRIPTION
Adds an alternative to `__reduce_level` that skips merging duplicate nodes in the hopes to obtain a higher performance. This seems to potentially give a speed-up of a few percent.