### PR TITLE
Internal/assertions

### DIFF
--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -41,6 +41,7 @@ set(HEADERS
   internal/dd_func.h
   internal/dot.h
   internal/memory.h
+  internal/unreachable.h
   internal/util.h
 
   # internal/algorithms

--- a/src/adiar/CMakeLists.txt
+++ b/src/adiar/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADERS
   data.h
   deprecated.h
   domain.h
+  exception.h
   file.h
   map.h
   memory_mode.h

--- a/src/adiar/adiar.cpp
+++ b/src/adiar/adiar.cpp
@@ -25,12 +25,12 @@ namespace adiar
       return;
     }
     if (!_adiar_initialized && _tpie_initialized) {
-      throw std::runtime_error("Adiar cannot be initialized after call to 'adiar_deinit()'");
+      throw runtime_error("Adiar cannot be initialized after call to 'adiar_deinit()'");
     }
     if (memory_limit_bytes < MINIMUM_MEMORY) {
-      throw std::invalid_argument("Adiar requires at least "
-                                  + std::to_string(MINIMUM_MEMORY / 1024 / 1024)
-                                  + " MiB of memory");
+      throw invalid_argument("Adiar requires at least "
+                             + std::to_string(MINIMUM_MEMORY / 1024 / 1024)
+                             + " MiB of memory");
     }
 
     try {

--- a/src/adiar/adiar.h
+++ b/src/adiar/adiar.h
@@ -15,6 +15,7 @@
 #include <adiar/assignment.h>
 #include <adiar/builder.h>
 #include <adiar/domain.h>
+#include <adiar/exception.h>
 #include <adiar/file.h>
 #include <adiar/memory_mode.h>
 #include <adiar/quantify_mode.h>
@@ -65,11 +66,11 @@ namespace adiar
   ///   The directory in which to place all temporary files. Default on Linux is
   ///   the */tmp* library.
   ///
-  /// \throws std::invalid_argument If `memory_limit_bytes` is set to a value
-  ///                               less than the `MINIMUM_MEMORY` required.
+  /// \throws invalid_argument If `memory_limit_bytes` is set to a value less
+  ///                          than the `MINIMUM_MEMORY` required.
   ///
-  /// \throws std::runtime_error    If `adiar_init()` and then `adiar_deinit()`
-  ///                               have been called previously.
+  /// \throws runtime_error    If `adiar_init()` and then `adiar_deinit()` have
+  ///                          been called previously.
   //////////////////////////////////////////////////////////////////////////////
   void adiar_init(size_t memory_limit_bytes, std::string temp_dir = "");
 
@@ -86,8 +87,8 @@ namespace adiar
   ///          zdd \ref zdd_builder or any \ref shared_file objects you may be
   ///          using.
   ///
-  /// \throws std::runtime_error If compiled with *debug flag* and one of
-  ///                            Adiar's objects have *not* been destructed.
+  /// \throws runtime_error If compiled with *debug* and one of Adiar's objects
+  ///                       have *not* been destructed.
   //////////////////////////////////////////////////////////////////////////////
   void adiar_deinit();
 

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -831,10 +831,6 @@ namespace adiar
   ///            the given domain.
   ///
   /// \pre       Labels in `dom` are provided in ascending order.
-  ///
-  /// \throws invalid_argument If a label in `dom` is too large.
-  ///
-  /// \throws invalid_argument If labels in `dom` are not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   __bdd bdd_from(const zdd &A, const shared_file<bdd::label_t> &dom);
 

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -71,6 +71,8 @@ namespace adiar
   /// \param var The label of the desired variable
   ///
   /// \returns   \f$ x_{var} \f$
+  ///
+  /// \throws invalid_argument If `var` is a too large value.
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_ithvar(bdd::label_t var);
 
@@ -84,6 +86,8 @@ namespace adiar
   /// \param var Label of the desired variable
   ///
   /// \returns   \f$ \neg x_{var} \f$
+  ///
+  /// \throws invalid_argument If `var` is a too large value.
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_nithvar(bdd::label_t var);
 
@@ -100,6 +104,8 @@ namespace adiar
   /// \returns    \f$ \bigwedge_{x \in \mathit{vars}} x \f$
   ///
   /// \pre        Labels in `vars` are provided in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` are not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_and(const shared_file<bdd::label_t> &vars);
 
@@ -116,6 +122,8 @@ namespace adiar
   /// \returns    \f$ \bigvee_{x \in \mathit{vars}} x \f$
   ///
   /// \pre        Labels in `vars` are provided in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` are not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_or(const shared_file<bdd::label_t> &vars);
 
@@ -126,6 +134,8 @@ namespace adiar
   /// \param min_var   The minimum label (inclusive) to start counting from
   /// \param max_var   The maximum label (inclusive) to end counting at
   /// \param threshold The threshold number of variables set to true
+  ///
+  /// \throws invalid_arugment If `min_var <= max_var` is not satisfied.
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_counter(bdd::label_t min_var,
                   bdd::label_t max_var,
@@ -644,6 +654,9 @@ namespace adiar
   ///                 of levels in the BDD (\see bdd_varcount())
   ///
   /// \returns        The number of unique assignments.
+  ///
+  /// \throws invalid_argument If varcount is not larger than the number of
+  ///                          levels in the BDD.
   //////////////////////////////////////////////////////////////////////////////
   uint64_t bdd_satcount(const bdd &f, bdd::label_t varcount);
 
@@ -775,6 +788,11 @@ namespace adiar
   /// \param xs A list of tuples `(i,v)` in ascending order of `i`.
   ///
   /// \pre      Assignment tuples in `xs` is in ascending order
+  ///
+  /// \throws out_of_range If traversal of the BDD leads to going beyond the end
+  ///                      of the content of `xs`.
+  ///
+  /// \throws invalid_argument If a level in the BDD does not exist in `xs`.
   //////////////////////////////////////////////////////////////////////////////
   bool bdd_eval(const bdd &f,
                 const shared_file<map_pair<bdd::label_t, boolean>> &xs);
@@ -815,6 +833,10 @@ namespace adiar
   ///            the given domain.
   ///
   /// \pre       Labels in `dom` are provided in ascending order.
+  ///
+  /// \throws invalid_argument If a label in `dom` is too large.
+  ///
+  /// \throws invalid_argument If labels in `dom` are not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   __bdd bdd_from(const zdd &A, const shared_file<bdd::label_t> &dom);
 

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -134,8 +134,6 @@ namespace adiar
   /// \param min_var   The minimum label (inclusive) to start counting from
   /// \param max_var   The maximum label (inclusive) to end counting at
   /// \param threshold The threshold number of variables set to true
-  ///
-  /// \throws invalid_arugment If `min_var <= max_var` is not satisfied.
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_counter(bdd::label_t min_var,
                   bdd::label_t max_var,

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -36,7 +36,7 @@ namespace adiar
                                        const bdd& bdd_2,
                                        const bool_op &op)
     {
-      adiar_debug(is_terminal(bdd_1) || is_terminal(bdd_2));
+      adiar_assert(is_terminal(bdd_1) || is_terminal(bdd_2));
 
       if (is_terminal(bdd_1) && is_terminal(bdd_2)) {
         const bdd::ptr_t p1 = bdd::ptr_t(value_of(bdd_1));

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -36,7 +36,7 @@ namespace adiar
                                        const bdd& bdd_2,
                                        const bool_op &op)
     {
-      adiar_precondition(is_terminal(bdd_1) || is_terminal(bdd_2));
+      adiar_debug(is_terminal(bdd_1) || is_terminal(bdd_2));
 
       if (is_terminal(bdd_1) && is_terminal(bdd_2)) {
         const bdd::ptr_t p1 = bdd::ptr_t(value_of(bdd_1));

--- a/src/adiar/bdd/apply.cpp
+++ b/src/adiar/bdd/apply.cpp
@@ -3,6 +3,7 @@
 
 #include <adiar/internal/assert.h>
 #include <adiar/internal/cut.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/algorithms/prod2.h>
 #include <adiar/internal/data_types/tuple.h>
 

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -78,8 +78,8 @@ namespace adiar
     }
 
     if (vars == 1) {
-      adiar_debug(min_var == max_var,
-                  "If 'vars == 1' then we ought to have 'max_var - min_var == 0'");
+      adiar_assert(min_var == max_var,
+                   "If 'vars == 1' then we ought to have 'max_var - min_var == 0'");
       return threshold == 1 ? bdd_ithvar(min_var) : bdd_nithvar(max_var);
     }
 

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -64,8 +64,9 @@ namespace adiar
 
   bdd bdd_counter(bdd::label_t min_var, bdd::label_t max_var, bdd::label_t threshold)
   {
+    // Empty set of variables is trivially true.
     if (max_var < min_var) {
-      throw invalid_argument("'min_var' ought to be smaller than 'max_var'");
+      return bdd_terminal(true);
     }
 
     const bdd::ptr_t gt_terminal = bdd::ptr_t(false);

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -15,29 +15,29 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_terminal(bool value)
   {
-    return internal::build_terminal(value);
+    return internal::build_terminal<bdd_policy>(value);
   }
 
   bdd bdd_true()
   {
-    return internal::build_terminal(true);
+    return internal::build_terminal<bdd_policy>(true);
   }
 
   bdd bdd_false()
   {
-    return internal::build_terminal(false);
+    return internal::build_terminal<bdd_policy>(false);
   }
 
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_ithvar(bdd::label_t label)
   {
-    return internal::build_ithvar(label);
+    return internal::build_ithvar<bdd_policy>(label);
   }
 
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_nithvar(bdd::label_t label)
   {
-    return bdd_not(internal::build_ithvar(label));
+    return bdd_not(internal::build_ithvar<bdd_policy>(label));
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -64,8 +64,9 @@ namespace adiar
 
   bdd bdd_counter(bdd::label_t min_var, bdd::label_t max_var, bdd::label_t threshold)
   {
-    adiar_assert(min_var <= max_var,
-                 "The given min_var should be smaller than the given max_var");
+    if (max_var < min_var) {
+      throw invalid_argument("'min_var' ought to be smaller than 'max_var'");
+    }
 
     const bdd::ptr_t gt_terminal = bdd::ptr_t(false);
     const bdd::ptr_t eq_terminal = bdd::ptr_t(true);

--- a/src/adiar/bdd/count.cpp
+++ b/src/adiar/bdd/count.cpp
@@ -4,6 +4,7 @@
 #include <adiar/bdd/bdd_policy.h>
 
 #include <adiar/domain.h>
+#include <adiar/exception.h>
 #include <adiar/internal/assert.h>
 #include <adiar/internal/algorithms/count.h>
 
@@ -93,12 +94,13 @@ namespace adiar
 
   uint64_t bdd_satcount(const bdd& bdd, bdd::label_t varcount)
   {
+    if (varcount < bdd_varcount(bdd)) {
+      throw invalid_argument("'varcount' ought to be at least the number of levels in the BDD");
+    }
+
     if (is_terminal(bdd)) {
       return value_of(bdd) ? std::min(1u, varcount) << varcount : 0u;
     }
-
-    adiar_assert(bdd_varcount(bdd) <= varcount,
-                 "number of variables in domain should be greater than the ones present in the BDD.");
 
     return internal::count<sat_count_policy>(bdd, varcount);
   }

--- a/src/adiar/bdd/count.cpp
+++ b/src/adiar/bdd/count.cpp
@@ -41,10 +41,10 @@ namespace adiar
                                            const bdd::ptr_t child_to_resolve,
                                            const queue_t &request)
     {
-      adiar_debug(request.sum > 0, "No 'empty' request should be created");
+      adiar_assert(request.sum > 0, "No 'empty' request should be created");
 
-      adiar_debug(request.levels_visited < varcount,
-                  "Cannot have already visited more levels than are expected");
+      adiar_assert(request.levels_visited < varcount,
+                   "Cannot have already visited more levels than are expected");
 
       bdd::label_t levels_visited = request.levels_visited + 1u;
 
@@ -60,11 +60,11 @@ namespace adiar
 
     inline static queue_t combine_requests(const queue_t &acc, const queue_t &next)
     {
-      adiar_debug(acc.target == next.target,
-                  "Requests should be for the same node");
+      adiar_assert(acc.target == next.target,
+                   "Requests should be for the same node");
 
-      adiar_debug(acc.levels_visited <= next.levels_visited,
-                  "Requests should be ordered on the number of levels visited");
+      adiar_assert(acc.levels_visited <= next.levels_visited,
+                   "Requests should be ordered on the number of levels visited");
 
       return {
         acc.target,

--- a/src/adiar/bdd/evaluate.cpp
+++ b/src/adiar/bdd/evaluate.cpp
@@ -63,7 +63,10 @@ namespace adiar
       const bdd::label_t level = n.label();
       while (mp.level() < level) {
         if (!mps.can_pull()) {
-          throw out_of_range("'msf' is insufficient to traverse BDD");
+          throw out_of_range("Labels are insufficient to traverse BDD");
+        }
+        if (mps.peek().level() <= mp.level()) {
+          throw invalid_argument("Labels are not in ascending order");
         }
 
         mp = mps.pull();

--- a/src/adiar/bdd/evaluate.cpp
+++ b/src/adiar/bdd/evaluate.cpp
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include <adiar/domain.h>
+#include <adiar/exception.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/assert.h>
 #include <adiar/internal/algorithms/traverse.h>
@@ -61,12 +62,16 @@ namespace adiar
     {
       const bdd::label_t level = n.label();
       while (mp.level() < level) {
-        adiar_assert(mps.can_pull(),
-                     "Assignment file is insufficient to traverse BDD");
+        if (!mps.can_pull()) {
+          throw out_of_range("'msf' is insufficient to traverse BDD");
+        }
+
         mp = mps.pull();
       }
-      adiar_assert(mp.level() == level,
-                   "Missing assignment for node visited in BDD");
+
+      if (mp.level() != level) {
+        throw invalid_argument("Missing assignment for node visited in BDD");
+      }
 
       return mp.value() ? n.high() : n.low();
     }

--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -91,8 +91,8 @@ namespace adiar
     }
 
     // push all nodes from 'if' conditional and remap its terminals
-    adiar_debug(!root_then.is_nil(), "Did not obtain root from then stream");
-    adiar_debug(!root_else.is_nil(), "Did not obtain root from else stream");
+    adiar_assert(!root_then.is_nil(), "Did not obtain root from then stream");
+    adiar_assert(!root_else.is_nil(), "Did not obtain root from else stream");
 
     internal::node_stream<true> in_nodes_if(bdd_if);
 
@@ -328,10 +328,10 @@ namespace adiar
                                           + ((int) forward_else);
 
         if (with_data_1 || number_of_elements_to_forward == 2) {
-          adiar_debug(!with_data_1 || t_seek != t_first,
-                      "cannot have data and still seek the first element");
-          adiar_debug(!(with_data_1 && (number_of_elements_to_forward == 2)),
-                      "cannot have forwarded an element, hold two unforwarded items, and still need to forward for something");
+          adiar_assert(!with_data_1 || t_seek != t_first,
+                       "cannot have data and still seek the first element");
+          adiar_assert(!(with_data_1 && (number_of_elements_to_forward == 2)),
+                       "cannot have forwarded an element, hold two unforwarded items, and still need to forward for something");
 
           internal::node::children_t children_1;
           internal::node::children_t children_2;
@@ -415,7 +415,7 @@ namespace adiar
       }
 
       // Resolve request
-      adiar_debug(out_id < bdd::MAX_ID, "Has run out of ids");
+      adiar_assert(out_id < bdd::MAX_ID, "Has run out of ids");
       const internal::node::uid_t out_uid(out_label, out_id++);
 
       __ite_resolve_request(ite_pq_1, aw, out_uid.with(false), low_if, low_then, low_else);

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -417,8 +417,8 @@ namespace adiar
     inline void attach_if_needed() noexcept
     {
       if (!nf) {
-        adiar_debug(!nw.attached(),
-                    "`nw`'s attachment should be consistent with existence of `nf`");
+        adiar_assert(!nw.attached(),
+                     "`nw`'s attachment should be consistent with existence of `nf`");
 
         // Initialise file
         nf = internal::make_shared_levelized_file<node_t>();

--- a/src/adiar/builder.h
+++ b/src/adiar/builder.h
@@ -1,6 +1,7 @@
 #ifndef ADIAR_BUILDER_H
 #define ADIAR_BUILDER_H
 
+#include <adiar/exception.h>
 #include <adiar/bdd/bdd_policy.h>
 #include <adiar/zdd/zdd_policy.h>
 #include <adiar/internal/memory.h>
@@ -192,9 +193,10 @@ namespace adiar
     ///         builder cannot apply the second reduction rule, i.e. merging of
     ///         duplicate nodes, so that is still left up to you to do.
     ///
-    /// \throws std::invalid_argument If a node is malformed or not added in
-    ///                               bottom-up order and if pointers from
-    ///                               another builder is used.
+    /// \throws invalid_argument If a node is malformed or not added in
+    ///                          bottom-up order.
+    ///
+    /// \throws invalid_argument If pointers stem from another builder.
     /////////////////////////////////////////////////////////////////////////////
     builder_ptr<dd_policy> add_node(typename dd_policy::label_t label,
                                     const builder_ptr<dd_policy> &low,
@@ -204,19 +206,19 @@ namespace adiar
 
       // Check validity of input
       if(low.builder_ref != builder_ref || high.builder_ref != builder_ref) {
-        throw std::invalid_argument("Cannot use pointers from a different builder");
+        throw invalid_argument("Cannot use pointers from a different builder");
       }
       if(label > dd_policy::MAX_LABEL) {
-        throw std::invalid_argument("Nodes must have a valid label");
+        throw invalid_argument("Nodes must have a valid label");
       }
       if(label > current_label) {
-        throw std::invalid_argument("Nodes must be added bottom-up");
+        throw invalid_argument("Nodes must be added bottom-up");
       }
       if(low.uid.is_node() && low.uid.label() <= label) {
-        throw std::invalid_argument("Low child must point to a node with higher label");
+        throw invalid_argument("Low child must point to a node with higher label");
       }
       if(high.uid.is_node() && high.uid.label() <= label) {
-        throw std::invalid_argument("High child must point to a node with higher label");
+        throw invalid_argument("High child must point to a node with higher label");
       }
 
       // Update label and ID if necessary
@@ -274,8 +276,8 @@ namespace adiar
     /// \returns     Pointer to the (possibly new) node for the desired
     ///              function.
     ///
-    /// \throws std::invalid_argument If `label` and `high` are illegal (see
-    ///                               \ref add_node).
+    /// \throws invalid_argument If `label` and `high` are illegal (see \ref
+    ///                          add_node).
     /////////////////////////////////////////////////////////////////////////////
     builder_ptr<dd_policy> add_node(const typename dd_policy::label_t label,
                                     const bool low,
@@ -301,8 +303,8 @@ namespace adiar
     /// \returns     Pointer to the (possibly new) node for the desired
     ///              function.
     ///
-    /// \throws std::invalid_argument If `label` and `low` are illegal (see
-    ///                               \ref add_node).
+    /// \throws invalid_argument If `label` and `low` are illegal (see \ref
+    ///                          add_node).
     /////////////////////////////////////////////////////////////////////////////
     builder_ptr<dd_policy> add_node(const typename dd_policy::label_t label,
                                     const builder_ptr<dd_policy> &low,
@@ -327,8 +329,8 @@ namespace adiar
     ///
     /// \returns     Pointer to the node for the desired function.
     ///
-    /// \throws std::invalid_argument If `label` violates the bottom-up ordering
-    ///                               (see \ref add_node).
+    /// \throws invalid_argument If `label` violates the bottom-up ordering (see
+    ///                          \ref add_node).
     /////////////////////////////////////////////////////////////////////////////
     builder_ptr<dd_policy> add_node(const typename dd_policy::label_t label,
                                     const bool low,
@@ -366,8 +368,8 @@ namespace adiar
     ///
     /// \see clear
     ///
-    /// \throws std::domain_error If (a) add_node has not been called or (b) if
-    ///                           there are more than one root in the diagram.
+    /// \throws domain_error If add_node has not been called
+    /// \throws domain_error If there are more than one root in the diagram.
     ///
     /// \pre     One has used `add_node` to create a non-empty and singly-rooted
     ///          decision diagram.
@@ -384,13 +386,13 @@ namespace adiar
         if(created_terminal) {
           nw.push(node_t(terminal_val));
         } else {
-          throw std::domain_error("There must be at least one node or terminal in the decision diagram");
+          throw domain_error("There must be at least one node or terminal in the decision diagram");
         }
       }
       nw.detach();
 
       if(unref_nodes > 1) {
-        throw std::domain_error("Decision diagram has more than one root");
+        throw domain_error("Decision diagram has more than one root");
       }
 
       const typename dd_policy::reduced_t res(nf);

--- a/src/adiar/domain.cpp
+++ b/src/adiar/domain.cpp
@@ -46,7 +46,7 @@ namespace adiar
 
   shared_file<domain_var_t> adiar_get_domain() {
     if(!adiar_has_domain()) {
-      throw std::domain_error("Domain must be set before it can be used");
+      throw domain_error("Domain must be set before it can be used");
     }
 
     return domain_ptr;

--- a/src/adiar/domain.h
+++ b/src/adiar/domain.h
@@ -11,9 +11,12 @@
 /// using it when needed.
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <adiar/exception.h>
 #include <adiar/file.h>
-#include <adiar/internal/data_types/node.h> // <-- remove after TODO below.
 #include <adiar/internal/util.h>
+
+// TODO: Make 'domain_var_t' independent of node type. Then remove this include.
+#include <adiar/internal/data_types/node.h>
 
 namespace adiar
 {
@@ -83,7 +86,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   /// \brief  Returns the global domain if `adiar_has_domain() == true`.
   ///
-  /// \throws std::domain_error If no domain is yet set, i.e.
+  /// \throws domain_error If no domain is yet set, i.e.
   ///         `adiar_has_domain() == false`.
   //////////////////////////////////////////////////////////////////////////////
   shared_file<domain_var_t> adiar_get_domain();

--- a/src/adiar/exception.h
+++ b/src/adiar/exception.h
@@ -1,0 +1,56 @@
+#ifndef ADIAR_EXCEPTION_H
+#define ADIAR_EXCEPTION_H
+
+// Include exceptions from STD for aliasing
+#include <exception>
+#include <stdexcept>
+#include <system_error>
+
+namespace adiar
+{
+  // TODO: Design custom exceptions for Adiar.
+  //
+  // Notice that common use-cases are:
+  //
+  // - User has provided a list that does not contain a needed element/too
+  //   short. This is quite similar to an `out_of_range` error.
+  //
+  // - User has provided a list that does not satisfy the required ordering.
+  //   Right now, here we throw an `invalid_argument`.
+  //
+  // - User has provided a label-value that does not fit into the number of
+  //   bits. Currently, we here use an `invalid_argument`
+  //
+  // - User has called a function that is not 'available' in the current state.
+  //   Right now, we here use `domain_error`.
+  //
+  // - I/O errors from Adiar's files or from TPIE.
+  //   Here we currently use `runtime_error` / `system_error`.
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Inputs that are invalid.
+  ////////////////////////////////////////////////////////////////////////////
+  using invalid_argument = std::invalid_argument;
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Inputs for which an operation is undefined.
+  ////////////////////////////////////////////////////////////////////////////
+  using domain_error = std::domain_error;
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Attempt to access elements outside of the given range.
+  ////////////////////////////////////////////////////////////////////////////
+  using out_of_range = std::out_of_range;
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Errors beyond the scope of the program.
+  ////////////////////////////////////////////////////////////////////////////
+  using runtime_error = std::runtime_error;
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief System runtime errors with an associated error code.
+  ////////////////////////////////////////////////////////////////////////////
+  using system_error = std::system_error;
+}
+
+#endif // ADIAR_EXCEPTION_H

--- a/src/adiar/internal/algorithms/build.h
+++ b/src/adiar/internal/algorithms/build.h
@@ -2,7 +2,6 @@
 #define ADIAR_INTERNAL_ALGORITHMS_BUILD_H
 
 #include <adiar/exception.h>
-#include <adiar/internal/assert.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/data_types/uid.h>
 #include <adiar/internal/data_types/node.h>
@@ -136,6 +135,9 @@ namespace adiar::internal
       while(ls.can_pull()) {
         const node::ptr_t::label_t next_label = ls.pull();
 
+        if (node::MAX_LABEL < next_label) {
+          throw invalid_argument("Cannot represent that large a label");
+        }
         if (!root.is_terminal() && root.label() <= next_label) {
           throw invalid_argument("Labels not given in increasing order");
         }

--- a/src/adiar/internal/algorithms/convert.h
+++ b/src/adiar/internal/algorithms/convert.h
@@ -3,7 +3,9 @@
 
 #include <adiar/exception.h>
 
+#include <adiar/internal/assert.h>
 #include <adiar/internal/dd.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/algorithms/intercut.h>
 #include <adiar/internal/data_types/node.h>
 #include <adiar/internal/data_types/tuple.h>

--- a/src/adiar/internal/algorithms/convert.h
+++ b/src/adiar/internal/algorithms/convert.h
@@ -46,9 +46,6 @@ namespace adiar::internal
     static typename to_policy::reduced_t
     on_empty_labels(const typename from_policy::reduced_t& dd)
     {
-      if (!is_terminal(dd)) {
-        throw invalid_argument("Only a pure terminal can be part of an empty domain");
-      }
       return typename to_policy::reduced_t(dd.file, dd.negate);
     }
 
@@ -70,13 +67,6 @@ namespace adiar::internal
 
       while(ls.can_pull()) {
         const typename to_policy::label_t next_label = ls.pull();
-
-        if (to_policy::MAX_LABEL < next_label) {
-          throw invalid_argument("Domain contains unrepresentable labels");
-        }
-        if (!prior_node.is_terminal() && prior_node.label() <= next_label) {
-          throw invalid_argument("Labels are not provided in increasing order");
-        }
 
         const tuple children = from_policy::reduction_rule_inv(prior_node);
         const node next_node = node(next_label, to_policy::MAX_ID, children[0], children[1]);

--- a/src/adiar/internal/algorithms/convert.h
+++ b/src/adiar/internal/algorithms/convert.h
@@ -55,7 +55,7 @@ namespace adiar::internal
                       const typename from_policy::reduced_t& /*dd*/,
                       const shared_file<typename from_policy::label_t> &dom)
     {
-      adiar_debug(dom->size() > 0, "Emptiness check is before terminal check");
+      adiar_assert(dom->size() > 0, "Emptiness check is before terminal check");
 
       node::uid_t prior_node = node::uid_t(terminal_value);
 
@@ -120,8 +120,8 @@ namespace adiar::internal
       const tuple children = from_policy::reduction_rule_inv(target);
 
       // Debug mode: double-check we don't create irrelevant nodes
-      adiar_debug(to_policy::reduction_rule(node(0,0, children[0], children[1])) != target,
-                  "Should not cut an arc where the one created will be killed anyways.");
+      adiar_assert(to_policy::reduction_rule(node(0,0, children[0], children[1])) != target,
+                   "Should not cut an arc where the one created will be killed anyways.");
 
       return intercut_rec_output { children[0], children[1] };
     }

--- a/src/adiar/internal/algorithms/count.h
+++ b/src/adiar/internal/algorithms/count.h
@@ -60,7 +60,7 @@ namespace adiar::internal
                                            const ptr_uint64 child_to_resolve,
                                            const queue_t &request)
     {
-      adiar_debug(request.sum > 0, "No 'empty' request should be created");
+      adiar_assert(request.sum > 0, "No 'empty' request should be created");
 
       if (child_to_resolve.is_terminal()) {
         return child_to_resolve.value() ? request.sum : 0u;
@@ -72,8 +72,8 @@ namespace adiar::internal
 
     inline static queue_t combine_requests(const queue_t &acc, const queue_t &next)
     {
-      adiar_debug(acc.target == next.target,
-                  "Requests should be for the same node");
+      adiar_assert(acc.target == next.target,
+                   "Requests should be for the same node");
 
       return { acc.target, acc.sum + next.sum };
     }
@@ -107,10 +107,10 @@ namespace adiar::internal
       if (!count_pq.has_current_level() || count_pq.current_level() != n.label()) {
         count_pq.setup_next_level();
       }
-      adiar_debug(count_pq.current_level() == n.label(),
-                  "Priority queue is out-of-sync with node stream");
-      adiar_debug(count_pq.can_pull() && count_pq.top().target == n.uid(),
-                  "Priority queue is out-of-sync with node stream");
+      adiar_assert(count_pq.current_level() == n.label(),
+                   "Priority queue is out-of-sync with node stream");
+      adiar_assert(count_pq.can_pull() && count_pq.top().target == n.uid(),
+                   "Priority queue is out-of-sync with node stream");
 
       // Resolve requests
       typename count_policy::queue_t request = count_pq.pull();
@@ -130,8 +130,8 @@ namespace adiar::internal
   uint64_t count(const typename count_policy::reduced_t &dd,
                  const typename count_policy::label_t varcount)
   {
-    adiar_debug(!is_terminal(dd),
-                "Count algorithm does not work on terminal-only edge case");
+    adiar_assert(!is_terminal(dd),
+                 "Count algorithm does not work on terminal-only edge case");
 
     // Compute amount of memory available for auxiliary data structures after
     // having opened all streams.

--- a/src/adiar/internal/algorithms/intercut.h
+++ b/src/adiar/internal/algorithms/intercut.h
@@ -251,8 +251,8 @@ namespace adiar::internal
 
       // Resolve requests that end after the cut for this level
       while(intercut_pq.can_pull()) {
-        adiar_invariant(out_label <= l,
-                        "the last iteration in this case is for the very last label to cut on");
+        adiar_debug(out_label <= l,
+                    "the last iteration in this case is for the very last label to cut on");
 
         const intercut_req request = intercut_pq.top();
         const intercut_rec_output ro = intercut_policy::hit_cut(request.target());

--- a/src/adiar/internal/algorithms/intercut.h
+++ b/src/adiar/internal/algorithms/intercut.h
@@ -144,8 +144,8 @@ namespace adiar::internal
                               const typename intercut_policy::ptr_t out_target,
                               const typename intercut_policy::label_t l)
   {
-    adiar_debug(out_label <= out_target.label(),
-                "should forward/output a node on this level or ahead.");
+    adiar_assert(out_label <= out_target.label(),
+                 "should forward/output a node on this level or ahead.");
 
     while (pq.can_pull()
            && pq.top().level() == out_label
@@ -214,7 +214,7 @@ namespace adiar::internal
           n = in_nodes.pull();
         }
 
-        adiar_debug(n.uid() == intercut_pq.top().target(), "should always find desired node");
+        adiar_assert(n.uid() == intercut_pq.top().target(), "should always find desired node");
 
         const intercut_rec r = hit_level
           ? intercut_policy::hit_existing(n)
@@ -251,8 +251,8 @@ namespace adiar::internal
 
       // Resolve requests that end after the cut for this level
       while(intercut_pq.can_pull()) {
-        adiar_debug(out_label <= l,
-                    "the last iteration in this case is for the very last label to cut on");
+        adiar_assert(out_label <= l,
+                     "the last iteration in this case is for the very last label to cut on");
 
         const intercut_req request = intercut_pq.top();
         const intercut_rec_output ro = intercut_policy::hit_cut(request.target());

--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -258,8 +258,8 @@ namespace adiar::internal
         ////////////////////////////////////////////////////////////////////////
         void push(const elem_t& e)
         {
-          adiar_invariant(e.target.first().is_node(),
-                          "Requests should have at least one internal node");
+          adiar_debug(e.target.first().is_node(),
+                      "Requests should have at least one internal node");
 
           _max_source = _max_source.is_nil()
             ? e.data.source
@@ -274,8 +274,8 @@ namespace adiar::internal
         ////////////////////////////////////////////////////////////////////////
         void push(const reduce_arc& a)
         {
-          adiar_invariant(!a.target().is_terminal(),
-                          "Arcs to terminals always reside in the outer PQ");
+          adiar_debug(!a.target().is_terminal(),
+                      "Arcs to terminals always reside in the outer PQ");
 
           // TODO: support requests with more than just the source
 
@@ -500,8 +500,7 @@ namespace adiar::internal
         ////////////////////////////////////////////////////////////////////////
         void push(const typename outer_roots_t::elem_t &e)
         {
-          adiar_precondition(e.data.source.is_nil()
-                             || e.data.source.label() < _next_inner);
+          adiar_debug(e.data.source.is_nil() || e.data.source.label() < _next_inner);
           if (e.target.first().is_terminal()) {
             _outer_pq.push({ e.data.source, e.target.first() });
           } else {
@@ -1242,8 +1241,8 @@ namespace adiar::internal
 
           const typename nesting_policy::label_t level = inner_level_info.level();
 
-          adiar_invariant(!decorated_pq.has_current_level() || level == decorated_pq.current_level(),
-                          "level and priority queue should be in sync");
+          adiar_debug(!decorated_pq.has_current_level() || level == decorated_pq.current_level(),
+                      "level and priority queue should be in sync");
 
           if (nesting_policy::reduce_strategy == nested_sweeping::NEVER_CANONICAL ||
               (nesting_policy::reduce_strategy == nested_sweeping::FINAL_CANONICAL && !is_last_inner)) {
@@ -1448,11 +1447,11 @@ namespace adiar::internal
 
       const level_info outer_level = outer_levels.pull();
 
-      adiar_invariant(!outer_pq.has_current_level()
-                      || outer_level.level() == outer_pq.current_level(),
-                      "level and priority queue should be in sync");
-      adiar_invariant(next_inner == inner_iter_t::NONE || next_inner <= outer_level.level(),
-                      "next_inner level should (if it exists) be above current level (inclusive).");
+      adiar_debug(!outer_pq.has_current_level()
+                  || outer_level.level() == outer_pq.current_level(),
+                  "level and priority queue should be in sync");
+      adiar_debug(next_inner == inner_iter_t::NONE || next_inner <= outer_level.level(),
+                  "next_inner level should (if it exists) be above current level (inclusive).");
 
       // -----------------------------------------------------------------------
       // CASE Unnested Level with no nested sweep above:

--- a/src/adiar/internal/algorithms/pred.cpp
+++ b/src/adiar/internal/algorithms/pred.cpp
@@ -87,7 +87,7 @@ namespace adiar::internal
     static inline void compute_cofactor([[maybe_unused]] const bool on_curr_level,
                                         dd::ptr_t &/*low*/,
                                         dd::ptr_t &/*high*/)
-    { adiar_invariant(on_curr_level, "No request have mixed levels"); }
+    { adiar_debug(on_curr_level, "No request have mixed levels"); }
 
     // Since we guarantee to be on the same level, then we merely provide a noop
     // (similar to the bdd_policy) for the cofactor.
@@ -95,7 +95,7 @@ namespace adiar::internal
     compute_cofactor([[maybe_unused]] const bool on_curr_level,
                      const dd::node_t::children_t &children)
     {
-      adiar_invariant(on_curr_level, "No request have mixed levels");
+      adiar_debug(on_curr_level, "No request have mixed levels");
       return children;
     }
   };

--- a/src/adiar/internal/algorithms/pred.cpp
+++ b/src/adiar/internal/algorithms/pred.cpp
@@ -87,7 +87,7 @@ namespace adiar::internal
     static inline void compute_cofactor([[maybe_unused]] const bool on_curr_level,
                                         dd::ptr_t &/*low*/,
                                         dd::ptr_t &/*high*/)
-    { adiar_debug(on_curr_level, "No request have mixed levels"); }
+    { adiar_assert(on_curr_level, "No request have mixed levels"); }
 
     // Since we guarantee to be on the same level, then we merely provide a noop
     // (similar to the bdd_policy) for the cofactor.
@@ -95,7 +95,7 @@ namespace adiar::internal
     compute_cofactor([[maybe_unused]] const bool on_curr_level,
                      const dd::node_t::children_t &children)
     {
-      adiar_debug(on_curr_level, "No request have mixed levels");
+      adiar_assert(on_curr_level, "No request have mixed levels");
       return children;
     }
   };
@@ -139,7 +139,7 @@ namespace adiar::internal
 #ifdef ADIAR_STATS
       stats_equality.slow_check.exit_on_root += 1u;
 #endif
-      adiar_debug(v1.label() == v2.label(), "Levels match per the precondition");
+      adiar_assert(v1.label() == v2.label(), "Levels match per the precondition");
       return v1.low() == v2.low() && v1.high() == v2.high();
     }
 
@@ -204,7 +204,7 @@ namespace adiar::internal
     node_stream<> in_nodes_2(f1);
 
     while (in_nodes_1.can_pull()) {
-      adiar_debug(in_nodes_2.can_pull(), "The number of nodes should coincide");
+      adiar_assert(in_nodes_2.can_pull(), "The number of nodes should coincide");
       if (in_nodes_1.pull() != in_nodes_2.pull()) {
 #ifdef ADIAR_STATS
         stats_equality.fast_check.exit_on_mismatch += 1u;
@@ -264,7 +264,7 @@ namespace adiar::internal
       level_info_stream<> in_meta_1(f1);
 
       while (in_meta_0.can_pull()) {
-        adiar_debug(in_meta_1.can_pull(), "level_info files are same size");
+        adiar_assert(in_meta_1.can_pull(), "level_info files are same size");
         if (in_meta_0.pull() != in_meta_1.pull()) {
 #ifdef ADIAR_STATS
           stats_equality.exit_on_levels_mismatch += 1u;

--- a/src/adiar/internal/algorithms/prod2.h
+++ b/src/adiar/internal/algorithms/prod2.h
@@ -86,8 +86,8 @@ namespace adiar::internal
       arc out_arc = { source, op(target[0], target[1]) };
       aw.push_terminal(out_arc);
     } else {
-      adiar_debug(source.label() < std::min(target[0], target[1]).label(),
-                  "should always push recursion for 'later' level");
+      adiar_assert(source.label() < std::min(target[0], target[1]).label(),
+                   "should always push recursion for 'later' level");
 
       prod_pq_1.push({ target, {}, {source} });
     }
@@ -206,8 +206,8 @@ namespace adiar::internal
           r.target[1].is_terminal() ||
           r.target[0].label() != r.target[1].label()) {
 
-        adiar_debug(r.target[0] != r.target[1],
-                    "Cannot have mismatching levels and be equal");
+        adiar_assert(r.target[0] != r.target[1],
+                     "Cannot have mismatching levels and be equal");
 
         // t.target[0].label() < r.target[1].label() || r.target[1].is_terminal() ?
         const typename dd_policy::children_t pair_0 =
@@ -255,7 +255,7 @@ namespace adiar::internal
     size_t max_1level_cut = 0;
 
     while (!prod_pq.empty()){
-      adiar_debug(prod_pq.empty_level(), "pq has finished processing last layers");
+      adiar_assert(prod_pq.empty_level(), "pq has finished processing last layers");
 
       // Setup layer
       prod_pq.setup_next_level();
@@ -273,8 +273,8 @@ namespace adiar::internal
             v1 = in_nodes_1.pull();
           }
 
-          adiar_debug(v1.uid() == req.target[1],
-                      "Must have found correct node in `in_1`");
+          adiar_assert(v1.uid() == req.target[1],
+                       "Must have found correct node in `in_1`");
         }
 
         const typename prod_policy::children_t children_0 =
@@ -302,7 +302,7 @@ namespace adiar::internal
         if (prod_policy::no_skip || std::holds_alternative<prod2_rec_output>(rec_res)) {
           const prod2_rec_output r = std::get<prod2_rec_output>(rec_res);
 
-          adiar_debug(out_id < prod_policy::MAX_ID, "Has run out of ids");
+          adiar_assert(out_id < prod_policy::MAX_ID, "Has run out of ids");
           const node::uid_t out_uid(out_label, out_id++);
 
           __prod2_recurse_out(prod_pq, aw, op, out_uid.with(false), r.low);
@@ -404,10 +404,10 @@ namespace adiar::internal
         req = prod_pq_2.top();
       }
 
-      adiar_debug(req.target[0].is_terminal() || out_label <= req.target[0].label(),
-                  "Request should never level-wise be behind current position");
-      adiar_debug(req.target[1].is_terminal() || out_label <= req.target[1].label(),
-                  "Request should never level-wise be behind current position");
+      adiar_assert(req.target[0].is_terminal() || out_label <= req.target[0].label(),
+                   "Request should never level-wise be behind current position");
+      adiar_assert(req.target[1].is_terminal() || out_label <= req.target[1].label(),
+                   "Request should never level-wise be behind current position");
 
       // Seek request partially in stream
       const typename prod_policy::ptr_t t_seek =
@@ -456,7 +456,7 @@ namespace adiar::internal
       if (prod_policy::no_skip || std::holds_alternative<prod2_rec_output>(rec_res)) {
         const prod2_rec_output r = std::get<prod2_rec_output>(rec_res);
 
-        adiar_debug(out_id < prod_policy::MAX_ID, "Has run out of ids");
+        adiar_assert(out_id < prod_policy::MAX_ID, "Has run out of ids");
         const node::uid_t out_uid(out_label, out_id++);
 
         __prod2_recurse_out(prod_pq_1, aw, op, out_uid.with(false), r.low);
@@ -688,7 +688,7 @@ namespace adiar::internal
       stats_prod2.ra.runs += 1u;
 #endif
 
-      adiar_debug(in_0->canonical || in_1->canonical, "At least one input must be canonical");
+      adiar_assert(in_0->canonical || in_1->canonical, "At least one input must be canonical");
 
       // Determine if to flip the inputs
       // TODO: is the smallest or widest the best to random access on?

--- a/src/adiar/internal/algorithms/prod2.h
+++ b/src/adiar/internal/algorithms/prod2.h
@@ -161,11 +161,12 @@ namespace adiar::internal
     }
   };
 
+  template<typename dd_policy>
   inline shared_levelized_file<node>
   __prod2_terminal(const tuple<dd::ptr_t> &rp, const bool_op &op)
   {
     // TODO: Abuse that op(tgt[0], tgt[1]) already is a pointer.
-    return build_terminal(op(rp[0], rp[1]).value());
+    return build_terminal<dd_policy>(op(rp[0], rp[1]).value());
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -254,7 +255,7 @@ namespace adiar::internal
     size_t max_1level_cut = 0;
 
     while (!prod_pq.empty()){
-      adiar_invariant(prod_pq.empty_level(), "pq has finished processing last layers");
+      adiar_debug(prod_pq.empty_level(), "pq has finished processing last layers");
 
       // Setup layer
       prod_pq.setup_next_level();
@@ -272,8 +273,8 @@ namespace adiar::internal
             v1 = in_nodes_1.pull();
           }
 
-          adiar_invariant(v1.uid() == req.target[1],
-                          "Must have found correct node in `in_1`");
+          adiar_debug(v1.uid() == req.target[1],
+                      "Must have found correct node in `in_1`");
         }
 
         const typename prod_policy::children_t children_0 =
@@ -315,7 +316,7 @@ namespace adiar::internal
           if (r[0].is_terminal() && r[1].is_terminal()) {
             if (req.data.source.is_nil()) {
               // Skipped in both DAGs all the way from the root until a pair of terminals.
-              return __prod2_terminal(r, op);
+              return __prod2_terminal<prod_policy>(r, op);
             }
             __prod2_recurse_in__1<__prod2_recurse_in__output_terminal>
               (prod_pq, aw, op(r[0], r[1]), req.target);
@@ -403,10 +404,10 @@ namespace adiar::internal
         req = prod_pq_2.top();
       }
 
-      adiar_invariant(req.target[0].is_terminal() || out_label <= req.target[0].label(),
-                      "Request should never level-wise be behind current position");
-      adiar_invariant(req.target[1].is_terminal() || out_label <= req.target[1].label(),
-                      "Request should never level-wise be behind current position");
+      adiar_debug(req.target[0].is_terminal() || out_label <= req.target[0].label(),
+                  "Request should never level-wise be behind current position");
+      adiar_debug(req.target[1].is_terminal() || out_label <= req.target[1].label(),
+                  "Request should never level-wise be behind current position");
 
       // Seek request partially in stream
       const typename prod_policy::ptr_t t_seek =
@@ -469,7 +470,7 @@ namespace adiar::internal
         if (r[0].is_terminal() && r[1].is_terminal()) {
           if (req.data.source.is_nil()) {
             // Skipped in both DAGs all the way from the root until a pair of terminals.
-            return __prod2_terminal(r, op);
+            return __prod2_terminal<prod_policy>(r, op);
           }
           __prod2_recurse_in<__prod2_recurse_in__output_terminal>
             (prod_pq_1, prod_pq_2, aw, op(r[0], r[1]), req.target);

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -113,7 +113,7 @@ namespace adiar::internal
     // also prune some terminals.
     size_t ts_max_idx = 0;
     for (size_t i = ts_max_idx+1; i < ts.size(); ++i) {
-      adiar_invariant(ts_max_idx < i, "i is always ahead of 'ts_max_idx'");
+      adiar_debug(ts_max_idx < i, "i is always ahead of 'ts_max_idx'");
 
       // Stop early at maximum value of 'NIL'
       if (ts[i] == quantify_policy::ptr_t::NIL()) { break; }
@@ -175,7 +175,7 @@ namespace adiar::internal
 
     // Process requests in topological order of both BDDs
     while(!quantify_pq_1.empty()) {
-      adiar_invariant(quantify_pq_2.empty(),
+      adiar_debug(quantify_pq_2.empty(),
                       "Secondary priority queue is only non-empty while processing each level");
 
       // Set up level
@@ -225,8 +225,8 @@ namespace adiar::internal
           continue;
         }
 
-        adiar_invariant(req.target.first().label() == out_label,
-                        "Level of requests always ought to match the one currently processed");
+        adiar_debug(req.target.first().label() == out_label,
+                    "Level of requests always ought to match the one currently processed");
 
         // ---------------------------------------------------------------------
         // CASE: Quantification of Singleton f into (f[0], f[1]).

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -7,9 +7,11 @@
 
 #include <adiar/bool_op.h>
 #include <adiar/quantify_mode.h>
+#include <adiar/internal/assert.h>
 #include <adiar/internal/block_size.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/cnl.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/algorithms/nested_sweeping.h>
 #include <adiar/internal/data_structures/levelized_priority_queue.h>
 #include <adiar/internal/data_types/tuple.h>

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -67,12 +67,12 @@ namespace adiar::internal
                                          const typename quantify_policy::ptr_t source,
                                          const quantify_request<0>::target_t &target)
   {
-    adiar_debug(!target.first().is_nil(),
-                "ptr_t::NIL() should only ever end up being placed in target[1]");
+    adiar_assert(!target.first().is_nil(),
+                 "ptr_t::NIL() should only ever end up being placed in target[1]");
 
     if (target.first().is_terminal()) {
-      adiar_debug(target.second().is_nil(),
-                  "Operator should already be resolved at this point");
+      adiar_assert(target.second().is_nil(),
+                   "Operator should already be resolved at this point");
       aw.push({source, target.first()});
     } else {
       quantify_pq_1.push({target, {}, {source}});
@@ -113,7 +113,7 @@ namespace adiar::internal
     // also prune some terminals.
     size_t ts_max_idx = 0;
     for (size_t i = ts_max_idx+1; i < ts.size(); ++i) {
-      adiar_debug(ts_max_idx < i, "i is always ahead of 'ts_max_idx'");
+      adiar_assert(ts_max_idx < i, "i is always ahead of 'ts_max_idx'");
 
       // Stop early at maximum value of 'NIL'
       if (ts[i] == quantify_policy::ptr_t::NIL()) { break; }
@@ -139,7 +139,7 @@ namespace adiar::internal
     // If there are more than two targets but one of the two apply, then prune
     // it all the way down to a single target.
     if (1 <= ts_max_idx && (max_shortcuts || only_terminals)) {
-      adiar_debug(!ts[1].is_nil(), "Cannot be nil at i <= ts_max_elem");
+      adiar_assert(!ts[1].is_nil(), "Cannot be nil at i <= ts_max_elem");
       ts[0] = max_shortcuts ? ts[ts_max_idx] : op(ts[0], ts[1]);
       for (size_t i = 1u; i <= ts_max_idx; ++i) {
         ts[i] = quantify_policy::ptr_t::NIL();
@@ -175,8 +175,8 @@ namespace adiar::internal
 
     // Process requests in topological order of both BDDs
     while(!quantify_pq_1.empty()) {
-      adiar_debug(quantify_pq_2.empty(),
-                      "Secondary priority queue is only non-empty while processing each level");
+      adiar_assert(quantify_pq_2.empty(),
+                   "Secondary priority queue is only non-empty while processing each level");
 
       // Set up level
       quantify_pq_1.setup_next_level();
@@ -213,8 +213,8 @@ namespace adiar::internal
         if (req.empty_carry()
             && req.target.second().is_node()
             && req.target.first().label() == req.target.second().label()) {
-          adiar_debug(!req.target.second().is_nil(),
-                      "req.target.second().is_node ==> !req.target.second().is_nil()");
+          adiar_assert(!req.target.second().is_nil(),
+                       "req.target.second().is_node ==> !req.target.second().is_nil()");
 
           quantify_pq_2.push({ req.target, {v.children()}, req.data });
 
@@ -225,8 +225,8 @@ namespace adiar::internal
           continue;
         }
 
-        adiar_debug(req.target.first().label() == out_label,
-                    "Level of requests always ought to match the one currently processed");
+        adiar_assert(req.target.first().label() == out_label,
+                     "Level of requests always ought to match the one currently processed");
 
         // ---------------------------------------------------------------------
         // CASE: Quantification of Singleton f into (f[0], f[1]).
@@ -254,7 +254,7 @@ namespace adiar::internal
           ? v.children()
           : quantify_policy::reduction_rule_inv(req.target.second());
 
-        adiar_debug(out_id < quantify_policy::MAX_ID, "Has run out of ids");
+        adiar_assert(out_id < quantify_policy::MAX_ID, "Has run out of ids");
 
         // ---------------------------------------------------------------------
         // CASE: Partial Quantification of Tuple (f,g).
@@ -267,8 +267,8 @@ namespace adiar::internal
             if (rec_all[2] == quantify_policy::ptr_t::NIL()) {
               // Collapsed to a terminal?
               if (req.data.source.is_nil() && rec_all[0].is_terminal()) {
-                adiar_debug(rec_all[1] == quantify_policy::ptr_t::NIL(),
-                            "Operator should already be applied");
+                adiar_assert(rec_all[1] == quantify_policy::ptr_t::NIL(),
+                             "Operator should already be applied");
 
                 return typename quantify_policy::reduced_t(rec_all[0].value());
               }
@@ -428,7 +428,7 @@ namespace adiar::internal
              quantify_policy &policy_impl,
              const bool_op &op)
   {
-    adiar_debug(is_commutative(op), "A commutative operator must be used");
+    adiar_assert(is_commutative(op), "A commutative operator must be used");
 
     // Compute amount of memory available for auxiliary data structures after
     // having opened all streams.
@@ -1048,7 +1048,7 @@ namespace adiar::internal
            const typename multi_quantify_policy__gen<quantify_policy>::gen_t &gen,
            const bool_op &op)
   {
-    adiar_debug(is_commutative(op), "Operator must be commutative");
+    adiar_assert(is_commutative(op), "Operator must be commutative");
 
     // NOTE: read-once access with 'gen' makes partial quantification not
     //       possible.
@@ -1140,8 +1140,8 @@ namespace adiar::internal
                 return dd;
               }
 
-              adiar_debug(dd_level <= transposition_level,
-                          "Must be at or above candidate level");
+              adiar_assert(dd_level <= transposition_level,
+                           "Must be at or above candidate level");
 
               // Did we find the current candidate or skipped past it?
               if (dd_level == transposition_level) {

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -286,7 +286,7 @@ namespace adiar::internal
       const arc e_low  = __reduce_get_next(reduce_pq, arcs);
 
       const node n = node_of(e_low, e_high);
-      adiar_debug(n.label() == label, "Label is for desired level");
+      adiar_assert(n.label() == label, "Label is for desired level");
 
       // Apply Reduction rule 1
       const node::ptr_t reduction_rule_ret = dd_policy::reduction_rule(n);
@@ -322,7 +322,7 @@ namespace adiar::internal
       const node next_node = child_grouping.pull();
 
       if (out_node.low() != unflag(next_node.low()) || out_node.high() != unflag(next_node.high())) {
-        adiar_debug(0 <= out_id, "Should still have more ids left");
+        adiar_assert(0 <= out_id, "Should still have more ids left");
         out_node = node(label, out_id--, unflag(next_node.low()), unflag(next_node.high()));
         out_writer.unsafe_push(out_node);
 
@@ -370,9 +370,9 @@ namespace adiar::internal
 
       const mapping current_map = is_red1_current ? next_red1 : next_red2;
 
-      adiar_debug(!arcs.can_pull_internal()
-                  || current_map.old_uid == arcs.peek_internal().target(),
-                  "Mapping forwarded in sync with internal arcs");
+      adiar_assert(!arcs.can_pull_internal()
+                   || current_map.old_uid == arcs.peek_internal().target(),
+                   "Mapping forwarded in sync with internal arcs");
 
       // Find all arcs that have the target that match the current mapping's old_uid
       while (arcs.can_pull_internal() && current_map.old_uid == arcs.peek_internal().target()) {
@@ -384,7 +384,7 @@ namespace adiar::internal
           ? flag(current_map.new_uid)
           : static_cast<ptr_uint64>(current_map.new_uid);
 
-        adiar_debug(t.is_terminal() || t.out_idx() == false, "Created target is without an index");
+        adiar_assert(t.is_terminal() || t.out_idx() == false, "Created target is without an index");
         reduce_pq.push(arc(s,t));
       }
 
@@ -414,8 +414,8 @@ namespace adiar::internal
     const bool terminal_value = next_red1.new_uid.is_terminal() && next_red1.new_uid.value();
     __reduce_level__epilogue<>(arcs, label, reduce_pq, out_writer, terminal_value);
 
-    adiar_debug(reduced_width <= unreduced_width,
-                "Reduction should only ever remove nodes");
+    adiar_assert(reduced_width <= unreduced_width,
+                 "Reduction should only ever remove nodes");
 
     return reduced_width;
   }
@@ -432,15 +432,15 @@ namespace adiar::internal
                            const bool terminal_val)
   {
 
-    adiar_debug(reduce_pq.empty_level(),
-                "All forwarded arcs for 'label' should be processed");
+    adiar_assert(reduce_pq.empty_level(),
+                 "All forwarded arcs for 'label' should be processed");
 
     if (!reduce_pq.empty()) {
-      adiar_debug(!arcs.can_pull_terminal() || arcs.peek_terminal().source().label() < label,
-                  "All terminal arcs for 'label' should be processed");
+      adiar_assert(!arcs.can_pull_terminal() || arcs.peek_terminal().source().label() < label,
+                   "All terminal arcs for 'label' should be processed");
 
-      adiar_debug(!arcs.can_pull_internal() || arcs.peek_internal().target().label() < label,
-                  "All internal arcs for 'label' should be processed");
+      adiar_assert(!arcs.can_pull_internal() || arcs.peek_internal().target().label() < label,
+                   "All internal arcs for 'label' should be processed");
 
       if (arcs.can_pull_terminal()) {
         reduce_pq.setup_next_level(arcs.peek_terminal().source().label());
@@ -453,19 +453,19 @@ namespace adiar::internal
       //       empty() but the size still includes arcs stored in another
       //       priority queue.
 
-      adiar_debug(!arcs.can_pull_terminal() || arcs.peek_terminal().source().label() < label,
-                  "All terminal arcs for 'label' should be processed");
+      adiar_assert(!arcs.can_pull_terminal() || arcs.peek_terminal().source().label() < label,
+                   "All terminal arcs for 'label' should be processed");
 
-      adiar_debug(!arcs.can_pull_internal() || arcs.peek_internal().target().label() < label,
-                  "All internal arcs for 'label' should be processed");
+      adiar_assert(!arcs.can_pull_internal() || arcs.peek_internal().target().label() < label,
+                   "All internal arcs for 'label' should be processed");
     } else if (!out_writer.has_pushed()) {
-      adiar_debug(!arcs.can_pull_internal() && !arcs.can_pull_terminal(),
-                  "All nodes should be processed at this point");
+      adiar_assert(!arcs.can_pull_internal() && !arcs.can_pull_terminal(),
+                   "All nodes should be processed at this point");
 
-      adiar_debug(reduce_pq.size() == 0 && reduce_pq.empty(),
-                  "'reduce_pq.size() == 0' -> 'reduce_pq.empty()', i.e. no parents have been forwarded to'");
+      adiar_assert(reduce_pq.size() == 0 && reduce_pq.empty(),
+                   "'reduce_pq.size() == 0' -> 'reduce_pq.empty()', i.e. no parents have been forwarded to'");
 
-      //adiar_debug(next_red1.new_uid.is_terminal(),
+      //adiar_assert(next_red1.new_uid.is_terminal(),
       //            "A node must have been suppressed in favour of a terminal");
 
       out_writer.unsafe_push(node(terminal_val));
@@ -550,13 +550,13 @@ namespace adiar::internal
 
     // Process bottom-up each level
     while (levels.can_pull()) {
-      adiar_debug(arcs.can_pull_terminal() || !reduce_pq.empty(),
-                  "If there is a level, then there should also be something for it.");
+      adiar_assert(arcs.can_pull_terminal() || !reduce_pq.empty(),
+                   "If there is a level, then there should also be something for it.");
       const level_info current_level_info = levels.pull();
       const typename dd_policy::label_t level = current_level_info.level();
 
-      adiar_debug(!reduce_pq.has_current_level() || level == reduce_pq.current_level(),
-                  "level and priority queue should be in sync");
+      adiar_assert(!reduce_pq.has_current_level() || level == reduce_pq.current_level(),
+                   "level and priority queue should be in sync");
 
       const size_t unreduced_width = current_level_info.width();
       if(unreduced_width <= internal_sorter_can_fit) {
@@ -583,7 +583,7 @@ namespace adiar::internal
   typename dd_policy::reduced_t
   reduce(const typename dd_policy::unreduced_t &input)
   {
-    adiar_debug(!input.empty(), "Input for Reduce should always be non-empty");
+    adiar_assert(!input.empty(), "Input for Reduce should always be non-empty");
 
     // Is it already reduced?
     if (input.template has<typename dd_policy::shared_nodes_t>()) {

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -370,9 +370,9 @@ namespace adiar::internal
 
       const mapping current_map = is_red1_current ? next_red1 : next_red2;
 
-      adiar_invariant(!arcs.can_pull_internal()
-                      || current_map.old_uid == arcs.peek_internal().target(),
-                      "Mapping forwarded in sync with internal arcs");
+      adiar_debug(!arcs.can_pull_internal()
+                  || current_map.old_uid == arcs.peek_internal().target(),
+                  "Mapping forwarded in sync with internal arcs");
 
       // Find all arcs that have the target that match the current mapping's old_uid
       while (arcs.can_pull_internal() && current_map.old_uid == arcs.peek_internal().target()) {
@@ -555,8 +555,8 @@ namespace adiar::internal
       const level_info current_level_info = levels.pull();
       const typename dd_policy::label_t level = current_level_info.level();
 
-      adiar_invariant(!reduce_pq.has_current_level() || level == reduce_pq.current_level(),
-                      "level and priority queue should be in sync");
+      adiar_debug(!reduce_pq.has_current_level() || level == reduce_pq.current_level(),
+                  "level and priority queue should be in sync");
 
       const size_t unreduced_width = current_level_info.width();
       if(unreduced_width <= internal_sorter_can_fit) {

--- a/src/adiar/internal/algorithms/traverse.h
+++ b/src/adiar/internal/algorithms/traverse.h
@@ -20,13 +20,13 @@ namespace adiar::internal
     while (!tgt.is_terminal() && !tgt.is_nil()) {
       while (n.uid() < tgt) { n = in_nodes.pull(); }
 
-      adiar_debug(n.uid() == tgt,
-                  "Invalid uid chasing; fell out of Decision Diagram");
+      adiar_assert(n.uid() == tgt,
+                   "Invalid uid chasing; fell out of Decision Diagram");
 
       tgt = visitor.visit(n);
 
-      adiar_debug((tgt == n.low()) || (tgt == n.high()) || (tgt.is_nil()),
-                  "Visitor pointer should be within the diagram or NIL");
+      adiar_assert((tgt == n.low()) || (tgt == n.high()) || (tgt.is_nil()),
+                   "Visitor pointer should be within the diagram or NIL");
     }
     if (!tgt.is_nil()) {
       visitor.visit(tgt.value());

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -48,15 +48,6 @@ namespace adiar
 #   define adiar_assert2(Expr, Msg) ;
 #endif
 
-  // From: https://stackoverflow.com/a/65258501/13300643
-#ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
-  [[noreturn]] inline __attribute__((always_inline)) void adiar_unreachable() {__builtin_unreachable();}
-#elif defined(_MSC_VER) // MSVC
-  [[noreturn]] __forceinline void adiar_unreachable() {__assume(false);}
-#else // ???
-  inline void adiar_unreachable() {}
-#endif
-
   // LCOV_EXCL_STOP
 }
 

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -54,7 +54,7 @@ namespace adiar
 #elif defined(_MSC_VER) // MSVC
   [[noreturn]] __forceinline void adiar_unreachable() {__assume(false);}
 #else // ???
-  inline void unreachable() {}
+  inline void adiar_unreachable() {}
 #endif
 
   // LCOV_EXCL_STOP

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -10,65 +10,43 @@ namespace adiar
 {
   // LCOV_EXCL_START
 
-  // Based on the assert with messages as described here:
-  // https://stackoverflow.com/a/37264642
-
-#   define adiar_assert(Expr, Msg)                      \
-  __adiar_assert(#Expr, Expr, __FILE__, __LINE__, Msg)
-
-#ifndef NDEBUG
-#   define adiar_debug(Expr, Msg)                       \
-  __adiar_assert(#Expr, Expr, __FILE__, __LINE__, Msg)
-#else
-#   define adiar_debug(Expr, Msg) ;
-#endif
-
-  inline void __adiar_assert(const char* expr_str, bool expr, const char* file, int line, const char* msg)
-  {
-    if (!expr)
-      {
-        std::cerr << "Assert failed:\t" << msg << "\n"
-                  << "Expected:\t" << expr_str << "\n"
-                  << "Source:\t\t" << file << ", line " << line << "\n";
-        abort();
-      }
-  }
+  // Based on:
+  // - Assert with messages: https://stackoverflow.com/a/37264642
+  // - Variadic macro arguments: https://stackoverflow.com/a/11763277
+#define adiar_debug_macro(_1,_2,NAME,...) NAME
+#define adiar_debug(...) adiar_debug_macro(__VA_ARGS__, adiar_debug2, adiar_debug1)(__VA_ARGS__)
 
 #ifndef NDEBUG
-#   define adiar_invariant(Expr, Name)                      \
-  __adiar_invariant(#Expr, Expr, __FILE__, __LINE__, Name)
-#else
-#   define adiar_invariant(Expr, Name) ;
-#endif
+#   define adiar_debug1(Expr)      __adiar_debug(#Expr, Expr, __FILE__, __LINE__)
+#   define adiar_debug2(Expr, Msg) __adiar_debug(#Expr, Expr, __FILE__, __LINE__, Msg)
 
-  inline void __adiar_invariant(const char* expr_str, bool expr, const char* file, int line, const char* name)
+  inline
+  void
+  __adiar_debug(const char* expr_str, bool expr, const char* file, int line)
   {
-    if (!expr)
-      {
-        std::cerr << "Invariant '" << name << "' failed\n"
-                  << "Expected:\t" << expr_str << "\n"
-                  << "Source:\t\t" << file << ", line " << line << "\n";
-        abort();
-      }
+    if (!expr) {
+      std::cerr << "Assert failed!\n"
+                << "Expected:\t" << expr_str << "\n"
+                << "Source:\t\t" << file << ", line " << line << std::endl;
+      abort();
+    }
   }
 
-
-#ifndef NDEBUG
-#   define adiar_precondition(Expr)                     \
-  __adiar_precondition(#Expr, Expr, __FILE__, __LINE__)
-#else
-#   define adiar_precondition(Expr) ;
-#endif
-
-  inline void __adiar_precondition(const char* expr_str, bool expr, const char* file, int line)
+  inline
+  void
+  __adiar_debug(const char* expr_str, bool expr, const char* file, int line, const char* msg)
   {
-    if (!expr)
-      {
-        std::cerr << "Precondition \t'" << expr_str << "' failed\n"
-                  << "Source:\t\t" << file << ", line " << line << "\n";
-        abort();
-      }
+    if (!expr) {
+      std::cerr << "Assert failed:\t" << msg << "\n"
+                << "Expected:\t" << expr_str << "\n"
+                << "Source:\t\t" << file << ", line " << line << std::endl;
+      abort();
+    }
   }
+#else
+#   define adiar_debug1(Expr) ;
+#   define adiar_debug2(Expr, Msg) ;
+#endif
 
   // From: https://stackoverflow.com/a/65258501/13300643
 #ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -1,9 +1,6 @@
 #ifndef ADIAR_INTERNAL_ASSERT_H
 #define ADIAR_INTERNAL_ASSERT_H
 
-#include <tpie/tpie.h>
-#include <tpie/file_stream.h>
-
 #include <iostream>
 
 namespace adiar

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -17,6 +17,10 @@ namespace adiar
 
   public:
     ////////////////////////////////////////////////////////////////////////////
+    assert_error(const std::string &what)
+      : _what(what)
+    { }
+
     assert_error(const std::string &file, const int line)
     {
       std::stringstream s;
@@ -40,11 +44,13 @@ namespace adiar
     { return _what.data(); }
   };
 
-  // Based on:
-  // - Assert with messages: https://stackoverflow.com/a/37264642
+
+#ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
+  // Macros based on:
+  // - Assert with file information and messages: https://stackoverflow.com/a/37264642
   // - Variadic macro arguments: https://stackoverflow.com/a/11763277
-#define adiar_assert_macro(_1,_2,NAME,...) NAME
-#define adiar_assert(...) adiar_assert_macro(__VA_ARGS__, adiar_assert2, adiar_assert1)(__VA_ARGS__)
+#define adiar_assert_overload(_1,_2,NAME,...) NAME
+#define adiar_assert(...) adiar_assert_overload(__VA_ARGS__, adiar_assert2, adiar_assert1)(__VA_ARGS__)
 
 #ifndef NDEBUG
 #   define adiar_assert1(Expr)      __adiar_assert(#Expr, Expr, __FILE__, __LINE__)
@@ -78,6 +84,16 @@ namespace adiar
 #else
 #   define adiar_assert1(Expr) ;
 #   define adiar_assert2(Expr, Msg) ;
+#endif
+
+#else // MSVC and ??? compilers
+  inline void adiar_assert([[maybe_unused]] const bool expr,
+                           [[maybe_unused]] const std::string &what = "")
+  {
+#ifndef NDEBUG
+    if (!expr) { throw assert_error(what); }
+#endif
+  }
 #endif
 
   // LCOV_EXCL_STOP

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -13,16 +13,16 @@ namespace adiar
   // Based on:
   // - Assert with messages: https://stackoverflow.com/a/37264642
   // - Variadic macro arguments: https://stackoverflow.com/a/11763277
-#define adiar_debug_macro(_1,_2,NAME,...) NAME
-#define adiar_debug(...) adiar_debug_macro(__VA_ARGS__, adiar_debug2, adiar_debug1)(__VA_ARGS__)
+#define adiar_assert_macro(_1,_2,NAME,...) NAME
+#define adiar_assert(...) adiar_assert_macro(__VA_ARGS__, adiar_assert2, adiar_assert1)(__VA_ARGS__)
 
 #ifndef NDEBUG
-#   define adiar_debug1(Expr)      __adiar_debug(#Expr, Expr, __FILE__, __LINE__)
-#   define adiar_debug2(Expr, Msg) __adiar_debug(#Expr, Expr, __FILE__, __LINE__, Msg)
+#   define adiar_assert1(Expr)      __adiar_assert(#Expr, Expr, __FILE__, __LINE__)
+#   define adiar_assert2(Expr, Msg) __adiar_assert(#Expr, Expr, __FILE__, __LINE__, Msg)
 
   inline
   void
-  __adiar_debug(const char* expr_str, bool expr, const char* file, int line)
+  __adiar_assert(const char* expr_str, bool expr, const char* file, int line)
   {
     if (!expr) {
       std::cerr << "Assert failed!\n"
@@ -34,7 +34,7 @@ namespace adiar
 
   inline
   void
-  __adiar_debug(const char* expr_str, bool expr, const char* file, int line, const char* msg)
+  __adiar_assert(const char* expr_str, bool expr, const char* file, int line, const char* msg)
   {
     if (!expr) {
       std::cerr << "Assert failed:\t" << msg << "\n"
@@ -44,8 +44,8 @@ namespace adiar
     }
   }
 #else
-#   define adiar_debug1(Expr) ;
-#   define adiar_debug2(Expr, Msg) ;
+#   define adiar_assert1(Expr) ;
+#   define adiar_assert2(Expr, Msg) ;
 #endif
 
   // From: https://stackoverflow.com/a/65258501/13300643

--- a/src/adiar/internal/assert.h
+++ b/src/adiar/internal/assert.h
@@ -2,10 +2,43 @@
 #define ADIAR_INTERNAL_ASSERT_H
 
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 
 namespace adiar
 {
   // LCOV_EXCL_START
+
+  struct assert_error
+  {
+  private:
+    std::string _what;
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    assert_error(const std::string &file, const int line)
+    {
+      std::stringstream s;
+      s << file << "::" << line;
+      _what = s.str();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    assert_error(const std::string &file, const int line, const std::string &what)
+    {
+      std::stringstream s;
+      s << file << "::" << line << ": " << what;
+      _what = s.str();
+    }
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Explanatory string
+    ////////////////////////////////////////////////////////////////////////////
+    char* what()
+    { return _what.data(); }
+  };
 
   // Based on:
   // - Assert with messages: https://stackoverflow.com/a/37264642
@@ -25,7 +58,8 @@ namespace adiar
       std::cerr << "Assert failed!\n"
                 << "Expected:\t" << expr_str << "\n"
                 << "Source:\t\t" << file << ", line " << line << std::endl;
-      abort();
+
+      throw assert_error(file, line);
     }
   }
 
@@ -37,7 +71,8 @@ namespace adiar
       std::cerr << "Assert failed:\t" << msg << "\n"
                 << "Expected:\t" << expr_str << "\n"
                 << "Source:\t\t" << file << ", line " << line << std::endl;
-      abort();
+
+      throw assert_error(file, line, msg);
     }
   }
 #else

--- a/src/adiar/internal/data_structures/level_merger.h
+++ b/src/adiar/internal/data_structures/level_merger.h
@@ -103,8 +103,7 @@ namespace adiar::internal
 
     level_t peek()
     {
-      adiar_debug(can_pull(),
-                  "Cannot peek past end of all streams");
+      adiar_assert(can_pull(), "Cannot peek past end of all streams");
 
       bool has_min_level = false;
       level_t min_level = 0u;
@@ -121,8 +120,7 @@ namespace adiar::internal
 
     level_t pull()
     {
-      adiar_debug(can_pull(),
-                  "Cannot pull past end of all streams");
+      adiar_assert(can_pull(), "Cannot pull past end of all streams");
 
       level_t min_level = peek();
 

--- a/src/adiar/internal/data_structures/levelized_priority_queue.h
+++ b/src/adiar/internal/data_structures/levelized_priority_queue.h
@@ -459,7 +459,7 @@ namespace adiar::internal
       while (_back_bucket_idx + 1 < BUCKETS && _level_merger.can_pull()) {
         const ptr_uint64::label_t level = _level_merger.pull();
 
-        adiar_invariant(_front_bucket_idx == OUT_OF_BUCKETS_IDX,
+        adiar_debug(_front_bucket_idx == OUT_OF_BUCKETS_IDX,
                         "Front bucket not moved");
 
         _back_bucket_idx++;
@@ -678,7 +678,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t top()
     {
-      adiar_debug (can_pull(), "Can only obtain top element on non-empty level");
+      adiar_debug(can_pull(), "Can only obtain top element on non-empty level");
 
       if (!_has_top_elem) {
         _top_elem = pull();
@@ -707,14 +707,14 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t pull()
     {
-      adiar_debug (!empty_level(), "Can only pull on non-empty level");
+      adiar_debug(!empty_level(), "Can only pull on non-empty level");
 
       if (_has_top_elem) {
         _has_top_elem = false;
         return _top_elem;
       }
 
-      adiar_debug (_size > 0, "pull on non-top element requires content");
+      adiar_debug(_size > 0, "pull on non-top element requires content");
       _size--;
 
       // Merge bucket with overflow queue
@@ -849,17 +849,17 @@ namespace adiar::internal
     inline void forward_to_nonempty_bucket(const ptr_uint64::label_t stop_level, const bool has_stop_level)
     {
       do {
-        adiar_invariant(has_next_bucket(),
-                        "At least one more bucket can be forwarded to");
+        adiar_debug(has_next_bucket(),
+                    "At least one more bucket can be forwarded to");
 
         // Is the next bucket past the 'stop_level'?
         if (has_stop_level && level_cmp_lt<level_comp_t>(stop_level, next_bucket_level(), _level_comparator)) {
           break;
         }
 
-        adiar_invariant(!has_front_bucket()
-                        || level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
-                        "Inconsistency in has_next_bucket predicate");
+        adiar_debug(!has_front_bucket()
+                    || level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
+                    "Inconsistency in has_next_bucket predicate");
 
         // Replace the current read-only bucket, if there is one
         if (_level_merger.can_pull() && has_front_bucket()) {
@@ -1293,7 +1293,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t top()
     {
-      adiar_debug (can_pull(), "Can only obtain top element on non-empty level");
+      adiar_debug(can_pull(), "Can only obtain top element on non-empty level");
       return _priority_queue.top();
     }
 
@@ -1316,7 +1316,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t pull()
     {
-      adiar_debug (!empty_level(), "Can only pull on non-empty level");
+      adiar_debug(!empty_level(), "Can only pull on non-empty level");
 
       const elem_t ret = _priority_queue.top();
       _priority_queue.pop();

--- a/src/adiar/internal/data_structures/levelized_priority_queue.h
+++ b/src/adiar/internal/data_structures/levelized_priority_queue.h
@@ -212,8 +212,8 @@ namespace adiar::internal
         ::memory_fits(memory_per_data_structure);
 
       const size_t res = std::min(sorter_fits, priority_queue_fits);
-      adiar_debug(memory_usage(res) <= memory_bytes,
-                  "memory_fits and memory_usage should agree.");
+      adiar_assert(memory_usage(res) <= memory_bytes,
+                   "memory_fits and memory_usage should agree.");
       return res;
     }
 
@@ -337,8 +337,8 @@ namespace adiar::internal
     {
       const size_t const_memory = const_memory_usage();
 
-      adiar_debug(const_memory < memory_given,
-                  "There should be enough memory for the merger");
+      adiar_assert(const_memory < memory_given,
+                   "There should be enough memory for the merger");
 
       // subtract memory of the merger to not take any of its memory.
       memory_given -= const_memory;
@@ -382,8 +382,8 @@ namespace adiar::internal
       , _stats(stats)
 #endif
     {
-      adiar_debug(_memory_occupied_by_merger + _memory_for_buckets + _memory_occupied_by_overflow <= _memory_given,
-                  "the amount of memory used should be within the given bounds");
+      adiar_assert(_memory_occupied_by_merger + _memory_for_buckets + _memory_occupied_by_overflow <= _memory_given,
+                   "the amount of memory used should be within the given bounds");
     }
 
 
@@ -459,8 +459,8 @@ namespace adiar::internal
       while (_back_bucket_idx + 1 < BUCKETS && _level_merger.can_pull()) {
         const ptr_uint64::label_t level = _level_merger.pull();
 
-        adiar_debug(_front_bucket_idx == OUT_OF_BUCKETS_IDX,
-                        "Front bucket not moved");
+        adiar_assert(_front_bucket_idx == OUT_OF_BUCKETS_IDX,
+                     "Front bucket not moved");
 
         _back_bucket_idx++;
 
@@ -503,8 +503,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     ptr_uint64::label_t current_level() const
     {
-      adiar_debug(has_current_level(),
-                  "Needs to have a 'current' level to read the level from");
+      adiar_assert(has_current_level(),
+                   "Needs to have a 'current' level to read the level from");
 
       return _current_level;
     }
@@ -540,18 +540,18 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void push(const elem_t &e)
     {
-      adiar_debug(can_push(),
-                  "Should only push when there is a yet unvisited level.");
+      adiar_assert(can_push(),
+                   "Should only push when there is a yet unvisited level.");
 
       const ptr_uint64::label_t level = e.level();
 
-      adiar_debug(level_cmp_le<level_comp_t>(next_bucket_level(), level, _level_comparator),
-                  "Can only push element to next bucket or later.");
+      adiar_assert(level_cmp_le<level_comp_t>(next_bucket_level(), level, _level_comparator),
+                   "Can only push element to next bucket or later.");
 
       const size_t pushable_buckets = active_buckets() - has_front_bucket();
 
-      adiar_debug(pushable_buckets > 0,
-                  "There is at least one pushable bucket (i.e. level)");
+      adiar_assert(pushable_buckets > 0,
+                   "There is at least one pushable bucket (i.e. level)");
 
       _size++;
 #ifdef ADIAR_STATS
@@ -589,14 +589,14 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void setup_next_level(ptr_uint64::label_t stop_level = NO_LABEL)
     {
-      adiar_debug(stop_level <= ptr_uint64::MAX_LABEL || stop_level == NO_LABEL,
-                  "The stop level should be a legal value (or not given)");
+      adiar_assert(stop_level <= ptr_uint64::MAX_LABEL || stop_level == NO_LABEL,
+                   "The stop level should be a legal value (or not given)");
 
-      adiar_debug(!has_current_level() || empty_level(),
-                  "Level is empty before moving on to the next");
+      adiar_assert(!has_current_level() || empty_level(),
+                   "Level is empty before moving on to the next");
 
-      adiar_debug(stop_level != NO_LABEL || !empty(),
-                  "Either a stop level is given or we have some non-empty level to forward to");
+      adiar_assert(stop_level != NO_LABEL || !empty(),
+                   "Either a stop level is given or we have some non-empty level to forward to");
 
       const ptr_uint64::label_t overflow_level = !_overflow_queue.empty()
         ? _overflow_queue.top().level()
@@ -608,16 +608,16 @@ namespace adiar::internal
 
       const bool has_stop_level = stop_level != NO_LABEL;
 
-      adiar_debug(has_next_level(),
-                  "There should be a next level to go to");
+      adiar_assert(has_next_level(),
+                   "There should be a next level to go to");
 
-      adiar_debug(!has_stop_level || !has_front_bucket()
-                  || level_cmp_lt<level_comp_t>(front_bucket_level(), stop_level, _level_comparator),
-                  "'stop_level' should be past the current front bucket (if it exists)");
+      adiar_assert(!has_stop_level || !has_front_bucket()
+                   || level_cmp_lt<level_comp_t>(front_bucket_level(), stop_level, _level_comparator),
+                   "'stop_level' should be past the current front bucket (if it exists)");
 
-      adiar_debug(!has_front_bucket() ||
-                  level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
-                  "Back bucket should be (strictly) ahead of the back bucket");
+      adiar_assert(!has_front_bucket() ||
+                   level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
+                   "Back bucket should be (strictly) ahead of the back bucket");
 
       // TODO: Add statistics on what case is hit.
 
@@ -632,7 +632,7 @@ namespace adiar::internal
       //   any (re)initialisation. Furthermore, we can have one more bucket
       //   ready to 'catch' the next elements.
       if (size() == _overflow_queue.size()) {
-        adiar_debug(has_stop_level, "Must have a 'stop_level' to go to");
+        adiar_assert(has_stop_level, "Must have a 'stop_level' to go to");
 
         relabel_buckets(stop_level);
         return;
@@ -678,7 +678,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t top()
     {
-      adiar_debug(can_pull(), "Can only obtain top element on non-empty level");
+      adiar_assert(can_pull(), "Can only obtain top element on non-empty level");
 
       if (!_has_top_elem) {
         _top_elem = pull();
@@ -707,14 +707,14 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t pull()
     {
-      adiar_debug(!empty_level(), "Can only pull on non-empty level");
+      adiar_assert(!empty_level(), "Can only pull on non-empty level");
 
       if (_has_top_elem) {
         _has_top_elem = false;
         return _top_elem;
       }
 
-      adiar_debug(_size > 0, "pull on non-top element requires content");
+      adiar_assert(_size > 0, "pull on non-top element requires content");
       _size--;
 
       // Merge bucket with overflow queue
@@ -801,8 +801,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     ptr_uint64::label_t next_bucket_level() const
     {
-      adiar_debug(has_next_bucket(),
-                  "Cannot obtain level of non-existing next bucket");
+      adiar_assert(has_next_bucket(),
+                   "Cannot obtain level of non-existing next bucket");
 
       const ptr_uint64::label_t next_idx   = (_front_bucket_idx + 1) % BUCKETS;
       const ptr_uint64::label_t next_level = _buckets_level[next_idx];
@@ -849,17 +849,17 @@ namespace adiar::internal
     inline void forward_to_nonempty_bucket(const ptr_uint64::label_t stop_level, const bool has_stop_level)
     {
       do {
-        adiar_debug(has_next_bucket(),
-                    "At least one more bucket can be forwarded to");
+        adiar_assert(has_next_bucket(),
+                     "At least one more bucket can be forwarded to");
 
         // Is the next bucket past the 'stop_level'?
         if (has_stop_level && level_cmp_lt<level_comp_t>(stop_level, next_bucket_level(), _level_comparator)) {
           break;
         }
 
-        adiar_debug(!has_front_bucket()
-                    || level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
-                    "Inconsistency in has_next_bucket predicate");
+        adiar_assert(!has_front_bucket()
+                     || level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
+                     "Inconsistency in has_next_bucket predicate");
 
         // Replace the current read-only bucket, if there is one
         if (_level_merger.can_pull() && has_front_bucket()) {
@@ -873,13 +873,13 @@ namespace adiar::internal
         }
         _front_bucket_idx = (_front_bucket_idx + 1) % BUCKETS;
 
-        adiar_debug(!has_next_bucket() || !has_front_bucket()
-                    || level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
-                    "Inconsistency in has_next_bucket predicate");
+        adiar_assert(!has_next_bucket() || !has_front_bucket()
+                     || level_cmp_lt<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
+                     "Inconsistency in has_next_bucket predicate");
 
-        adiar_debug(has_next_bucket() || !has_front_bucket()
-                    || front_bucket_level() == back_bucket_level(),
-                    "Inconsistency in has_next_bucket predicate");
+        adiar_assert(has_next_bucket() || !has_front_bucket()
+                     || front_bucket_level() == back_bucket_level(),
+                     "Inconsistency in has_next_bucket predicate");
 
         // Sort front bucket
         _buckets_sorter[_front_bucket_idx] -> sort();
@@ -892,16 +892,16 @@ namespace adiar::internal
 
       _current_level = front_bucket_level();
 
-      adiar_debug(has_front_bucket(), "Ends with a front bucket");
+      adiar_assert(has_front_bucket(), "Ends with a front bucket");
 
-      adiar_debug((has_stop_level
-                   && (level_cmp_le<level_comp_t>(stop_level, front_bucket_level(), _level_comparator)
-                       || (!has_next_bucket() || level_cmp_lt<level_comp_t>(stop_level, next_bucket_level(), _level_comparator))) )
-                  || _has_next_from_bucket,
-                  "Either we stopped early or we found a non-bucket");
+      adiar_assert((has_stop_level
+                    && (level_cmp_le<level_comp_t>(stop_level, front_bucket_level(), _level_comparator)
+                        || (!has_next_bucket() || level_cmp_lt<level_comp_t>(stop_level, next_bucket_level(), _level_comparator))) )
+                   || _has_next_from_bucket,
+                   "Either we stopped early or we found a non-bucket");
 
-      adiar_debug(level_cmp_le<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
-                  "Consistent bucket levels");
+      adiar_assert(level_cmp_le<level_comp_t>(front_bucket_level(), back_bucket_level(), _level_comparator),
+                   "Consistent bucket levels");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -913,8 +913,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline void relabel_buckets(const ptr_uint64::label_t stop_level)
     {
-      adiar_debug(stop_level != NO_LABEL,
-                  "Relabelling of buckets require a valid 'stop_level'");
+      adiar_assert(stop_level != NO_LABEL,
+                   "Relabelling of buckets require a valid 'stop_level'");
 
       // Backup of start and end of circular array
       const size_t old_front_bucket_idx = _front_bucket_idx;
@@ -928,7 +928,7 @@ namespace adiar::internal
       do {
         _front_bucket_idx = (_front_bucket_idx + 1) % BUCKETS;
 
-        adiar_debug(has_front_bucket(), "After increment the front bucket will 'exist'");
+        adiar_assert(has_front_bucket(), "After increment the front bucket will 'exist'");
 
         if (level_cmp_le<level_comp_t>(front_bucket_level(), stop_level, _level_comparator)) {
           _current_level = front_bucket_level();
@@ -948,8 +948,8 @@ namespace adiar::internal
         new_levels[++_back_bucket_idx] = _level_merger.pull();
       }
 
-      adiar_debug(_back_bucket_idx == OUT_OF_BUCKETS_IDX || _back_bucket_idx < BUCKETS,
-                  "_back_bucket_idx is a valid index");
+      adiar_assert(_back_bucket_idx == OUT_OF_BUCKETS_IDX || _back_bucket_idx < BUCKETS,
+                   "_back_bucket_idx is a valid index");
 
       // Relabel all buckets
       if (_back_bucket_idx != OUT_OF_BUCKETS_IDX) {
@@ -1169,8 +1169,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     ptr_uint64::label_t current_level() const
     {
-      adiar_debug(has_current_level(),
-                  "Needs to have a 'current' level to read the level from");
+      adiar_assert(has_current_level(),
+                   "Needs to have a 'current' level to read the level from");
 
       return _current_level;
     }
@@ -1231,16 +1231,16 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void setup_next_level(ptr_uint64::label_t stop_level = NO_LABEL)
     {
-      adiar_debug(stop_level <= ptr_uint64::MAX_LABEL || stop_level == NO_LABEL,
-                  "The stop level should be a legal value (or not given)");
+      adiar_assert(stop_level <= ptr_uint64::MAX_LABEL || stop_level == NO_LABEL,
+                   "The stop level should be a legal value (or not given)");
 
-      adiar_debug(!has_current_level() || empty_level(),
-                  "Level is empty before moving on to the next");
+      adiar_assert(!has_current_level() || empty_level(),
+                   "Level is empty before moving on to the next");
 
       const bool has_stop_level = stop_level != NO_LABEL;
 
-      adiar_debug(has_stop_level || !empty(),
-                  "Either a stop level is given or we have some non-empty level to forward to");
+      adiar_assert(has_stop_level || !empty(),
+                   "Either a stop level is given or we have some non-empty level to forward to");
 
       // Edge Case: ---------------------------------------------------------- :
       //   The given stop_level is prior to the next level or there is nothing in the queue
@@ -1251,8 +1251,8 @@ namespace adiar::internal
 
       // Edge Case: ---------------------------------------------------------- :
       //   The stop level is before the next level of the queue
-      adiar_debug(has_next_level(),
-                  "There should be a next level to go to");
+      adiar_assert(has_next_level(),
+                   "There should be a next level to go to");
       ptr_uint64::label_t next_level_from_queue = next_level();
       if(has_stop_level && level_cmp_le<level_comp_t>(stop_level, next_level_from_queue, _level_comparator)) {
         _current_level = stop_level;
@@ -1293,7 +1293,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t top()
     {
-      adiar_debug(can_pull(), "Can only obtain top element on non-empty level");
+      adiar_assert(can_pull(), "Can only obtain top element on non-empty level");
       return _priority_queue.top();
     }
 
@@ -1316,7 +1316,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     elem_t pull()
     {
-      adiar_debug(!empty_level(), "Can only pull on non-empty level");
+      adiar_assert(!empty_level(), "Can only pull on non-empty level");
 
       const elem_t ret = _priority_queue.top();
       _priority_queue.pop();

--- a/src/adiar/internal/data_structures/priority_queue.h
+++ b/src/adiar/internal/data_structures/priority_queue.h
@@ -40,7 +40,7 @@ namespace adiar::internal
     static tpie::memory_size_type memory_fits(tpie::memory_size_type memory_bytes)
     {
       const tpie::memory_size_type ret = tpie::internal_priority_queue<elem_t, comp_t>::memory_fits(memory_bytes);
-      adiar_debug(unsafe_memory_usage(ret) <= memory_bytes,
+      adiar_assert(unsafe_memory_usage(ret) <= memory_bytes,
                    "memory_fits and memory_usage should agree.");
       return ret;
     }
@@ -54,8 +54,8 @@ namespace adiar::internal
     priority_queue([[maybe_unused]] size_t memory_bytes, size_t max_size)
       : pq(max_size)
     {
-      adiar_debug(max_size <= memory_fits(memory_bytes),
-                  "Must be instantiated with enough memory.");
+      adiar_assert(max_size <= memory_fits(memory_bytes),
+                   "Must be instantiated with enough memory.");
     }
 
     elem_t top() const

--- a/src/adiar/internal/data_structures/priority_queue.h
+++ b/src/adiar/internal/data_structures/priority_queue.h
@@ -40,7 +40,7 @@ namespace adiar::internal
     static tpie::memory_size_type memory_fits(tpie::memory_size_type memory_bytes)
     {
       const tpie::memory_size_type ret = tpie::internal_priority_queue<elem_t, comp_t>::memory_fits(memory_bytes);
-      adiar_assert(unsafe_memory_usage(ret) <= memory_bytes,
+      adiar_debug(unsafe_memory_usage(ret) <= memory_bytes,
                    "memory_fits and memory_usage should agree.");
       return ret;
     }

--- a/src/adiar/internal/data_structures/sorter.h
+++ b/src/adiar/internal/data_structures/sorter.h
@@ -52,8 +52,8 @@ namespace adiar::internal
     memory_fits(tpie::memory_size_type memory_bytes)
     {
       const tpie::memory_size_type ret = tpie::array<elem_t>::memory_fits(memory_bytes);
-      adiar_assert(unsafe_memory_usage(ret) <= memory_bytes,
-                   "memory_fits and memory_usage should agree.");
+      adiar_debug(unsafe_memory_usage(ret) <= memory_bytes,
+                  "memory_fits and memory_usage should agree.");
       return ret;
     }
 
@@ -98,7 +98,7 @@ namespace adiar::internal
 
     void push(const elem_t& t)
     {
-      adiar_precondition(can_push());
+      adiar_debug(can_push());
       _array[_size++] = t;
     }
 
@@ -116,13 +116,13 @@ namespace adiar::internal
 
     elem_t top() const
     {
-      adiar_precondition(can_pull());
+      adiar_debug(can_pull());
       return _array[_front_idx];
     }
 
     elem_t pull()
     {
-      adiar_precondition(can_pull());
+      adiar_debug(can_pull());
       return _array[_front_idx++];
     }
 
@@ -326,7 +326,7 @@ namespace adiar::internal
 
     elem_t top()
     {
-      adiar_precondition(can_pull());
+      adiar_debug(can_pull());
       if (!_has_peeked) {
         _has_peeked = true;
         _peeked = _sorter.pull();
@@ -336,7 +336,7 @@ namespace adiar::internal
 
     elem_t pull()
     {
-      adiar_precondition(can_pull());
+      adiar_debug(can_pull());
       _pulls++;
       if (_has_peeked) {
         _has_peeked = false;

--- a/src/adiar/internal/data_structures/sorter.h
+++ b/src/adiar/internal/data_structures/sorter.h
@@ -52,8 +52,8 @@ namespace adiar::internal
     memory_fits(tpie::memory_size_type memory_bytes)
     {
       const tpie::memory_size_type ret = tpie::array<elem_t>::memory_fits(memory_bytes);
-      adiar_debug(unsafe_memory_usage(ret) <= memory_bytes,
-                  "memory_fits and memory_usage should agree.");
+      adiar_assert(unsafe_memory_usage(ret) <= memory_bytes,
+                   "memory_fits and memory_usage should agree.");
       return ret;
     }
 
@@ -86,8 +86,8 @@ namespace adiar::internal
            pred_t pred = pred_t())
       : _array(no_elements), _pred(pred), _size(0), _front_idx(0)
     {
-      adiar_debug(no_elements <= memory_fits(memory_bytes / no_sorters),
-                  "Must be instantiated with enough memory.");
+      adiar_assert(no_elements <= memory_fits(memory_bytes / no_sorters),
+                   "Must be instantiated with enough memory.");
     }
 
   public:
@@ -98,7 +98,7 @@ namespace adiar::internal
 
     void push(const elem_t& t)
     {
-      adiar_debug(can_push());
+      adiar_assert(can_push());
       _array[_size++] = t;
     }
 
@@ -116,13 +116,13 @@ namespace adiar::internal
 
     elem_t top() const
     {
-      adiar_debug(can_pull());
+      adiar_assert(can_pull());
       return _array[_front_idx];
     }
 
     elem_t pull()
     {
-      adiar_debug(can_pull());
+      adiar_assert(can_pull());
       return _array[_front_idx++];
     }
 
@@ -202,7 +202,7 @@ namespace adiar::internal
     {
       // =======================================================================
       // Case 0: No sorters - why are we then instantiating one?
-      adiar_debug(number_of_sorters > 0, "Number of sorters should be positive");
+      adiar_assert(number_of_sorters > 0, "Number of sorters should be positive");
 
       // Consult the internal sorter to get a bound of how much memory is
       // necessary to sort these elements in internal memory. We don't need to
@@ -215,8 +215,8 @@ namespace adiar::internal
       if (number_of_sorters == 1u) {
         const size_t sorter_memory = std::min(no_elements_memory, memory_bytes);
 
-        adiar_debug(sorter_memory <= memory_bytes,
-                    "Memory of a single sorter does not exceed given amount.");
+        adiar_assert(sorter_memory <= memory_bytes,
+                     "Memory of a single sorter does not exceed given amount.");
 
         // ---------------------------------------------------------------------
         // Use TPIE's default settings for the three phases.
@@ -227,7 +227,7 @@ namespace adiar::internal
 
       // ======================================================================
       // Case: 2+: Distribute a common area of memory between all sorters.
-      adiar_debug(number_of_sorters > 1, "Edge case for a single sorter taken care of above");
+      adiar_assert(number_of_sorters > 1, "Edge case for a single sorter taken care of above");
 
       // -----------------------------------------------------------------------
       // We intend to have the memory divided between all the sorters, such that
@@ -285,17 +285,17 @@ namespace adiar::internal
 
       // -----------------------------------------------------------------------
       // Sanity tests...
-      adiar_debug(number_of_sorters * phase1 <= memory_bytes,
-                  "Memory is enough to have 'N' pushable sorters.");
+      adiar_assert(number_of_sorters * phase1 <= memory_bytes,
+                   "Memory is enough to have 'N' pushable sorters.");
 
-      adiar_debug((number_of_sorters-1) * phase1 + phase2 <= memory_bytes,
-                  "Memory is enough to have 'N-1' pushable sorters and '1' sorting one.");
+      adiar_assert((number_of_sorters-1) * phase1 + phase2 <= memory_bytes,
+                   "Memory is enough to have 'N-1' pushable sorters and '1' sorting one.");
 
-      adiar_debug((number_of_sorters-1) * phase1 + phase3 <= memory_bytes,
-                  "Memory is enough to have 'N-1' pushable sorters and '1' pullable one.");
+      adiar_assert((number_of_sorters-1) * phase1 + phase3 <= memory_bytes,
+                   "Memory is enough to have 'N-1' pushable sorters and '1' pullable one.");
 
-      adiar_debug((number_of_sorters-1) * phase1 + phase3 + phase1 <= memory_bytes,
-                  "Memory is enough to replace the pullable sorter with an 'Nth' pushable one.");
+      adiar_assert((number_of_sorters-1) * phase1 + phase3 + phase1 <= memory_bytes,
+                   "Memory is enough to replace the pullable sorter with an 'Nth' pushable one.");
 
       // -----------------------------------------------------------------------
       // Set the available memory and start the sorter
@@ -326,7 +326,7 @@ namespace adiar::internal
 
     elem_t top()
     {
-      adiar_debug(can_pull());
+      adiar_assert(can_pull());
       if (!_has_peeked) {
         _has_peeked = true;
         _peeked = _sorter.pull();
@@ -336,7 +336,7 @@ namespace adiar::internal
 
     elem_t pull()
     {
-      adiar_debug(can_pull());
+      adiar_assert(can_pull());
       _pulls++;
       if (_has_peeked) {
         _has_peeked = false;

--- a/src/adiar/internal/data_types/arc.h
+++ b/src/adiar/internal/data_types/arc.h
@@ -76,7 +76,7 @@ namespace adiar::internal
     arc(const ptr_t &source, const ptr_t &target)
       : _source(source), _target(target)
     {
-      adiar_debug(!target.is_node() || target.out_idx() == 0u);
+      adiar_assert(!target.is_node() || target.out_idx() == 0u);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -90,7 +90,7 @@ namespace adiar::internal
       : _source(source.with(out_idx))
       , _target(target)
     {
-      adiar_debug(!target.is_node() || target.out_idx() == 0u);
+      adiar_assert(!target.is_node() || target.out_idx() == 0u);
     }
 
     /* ================================ NODES =============================== */

--- a/src/adiar/internal/data_types/arc.h
+++ b/src/adiar/internal/data_types/arc.h
@@ -76,7 +76,7 @@ namespace adiar::internal
     arc(const ptr_t &source, const ptr_t &target)
       : _source(source), _target(target)
     {
-      adiar_precondition(!target.is_node() || target.out_idx() == 0u);
+      adiar_debug(!target.is_node() || target.out_idx() == 0u);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -90,7 +90,7 @@ namespace adiar::internal
       : _source(source.with(out_idx))
       , _target(target)
     {
-      adiar_precondition(!target.is_node() || target.out_idx() == 0u);
+      adiar_debug(!target.is_node() || target.out_idx() == 0u);
     }
 
     /* ================================ NODES =============================== */

--- a/src/adiar/internal/data_types/convert.h
+++ b/src/adiar/internal/data_types/convert.h
@@ -30,17 +30,16 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////
   inline node node_of(const arc &low, const arc &high)
   {
-    adiar_debug(essential(low.source()) == essential(high.source()),
-                "Source are the same origin");
+    adiar_assert(essential(low.source()) == essential(high.source()), "Source are the same origin");
 
-    adiar_debug(low.out_idx()  == 0u, "Out-index is correct on low arc");
-    adiar_debug(high.out_idx() == 1u,  "Out-index is correct on high arc");
+    adiar_assert(low.out_idx()  == 0u, "Out-index is correct on low arc");
+    adiar_assert(high.out_idx() == 1u,  "Out-index is correct on high arc");
 
-    adiar_debug(!low.target().is_node()  || low.target().out_idx()  == 0u, "Out-index is empty in low target");
-    adiar_debug(!high.target().is_node() || high.target().out_idx() == 0u, "Out-index is empty in high target");
+    adiar_assert(!low.target().is_node()  || low.target().out_idx()  == 0u, "Out-index is empty in low target");
+    adiar_assert(!high.target().is_node() || high.target().out_idx() == 0u, "Out-index is empty in high target");
 
-    adiar_debug(low.source().is_flagged()  == false, "Source is not flagged on low arc");
-    adiar_debug(high.source().is_flagged() == false, "Source is not flagged on high arc");
+    adiar_assert(low.source().is_flagged()  == false, "Source is not flagged on low arc");
+    adiar_assert(high.source().is_flagged() == false, "Source is not flagged on high arc");
 
     return node(essential(low.source()), low.target(), high.target());
   }

--- a/src/adiar/internal/data_types/node.h
+++ b/src/adiar/internal/data_types/node.h
@@ -120,7 +120,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline value_t value() const
     {
-      adiar_precondition(is_terminal());
+      adiar_debug(is_terminal());
       return _uid.value();
     }
 
@@ -205,7 +205,7 @@ namespace adiar::internal
     // TODO: Rename to `level()` when introducing variable ordering
     inline label_t label() const
     {
-      adiar_precondition(!is_terminal());
+      adiar_debug(!is_terminal());
       return uid().label();
     }
 
@@ -216,7 +216,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline id_t id() const
     {
-      adiar_precondition(!is_terminal());
+      adiar_debug(!is_terminal());
       return uid().id();
     }
 

--- a/src/adiar/internal/data_types/node.h
+++ b/src/adiar/internal/data_types/node.h
@@ -120,7 +120,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline value_t value() const
     {
-      adiar_debug(is_terminal());
+      adiar_assert(is_terminal());
       return _uid.value();
     }
 
@@ -161,13 +161,13 @@ namespace adiar::internal
     node(const label_t label, const id_t id, const ptr_t &l, const ptr_t &h)
       : _uid(label, id), _children{l, h}
     {
-      adiar_debug(!l.is_nil(), "Cannot create a node with NIL child");
-      adiar_debug(l.is_terminal() || label < l.label(),
-                  "Node is not prior to given low child");
+      adiar_assert(!l.is_nil(), "Cannot create a node with NIL child");
+      adiar_assert(l.is_terminal() || label < l.label(),
+                   "Node is not prior to given low child");
 
-      adiar_debug(!h.is_nil(), "Cannot create a node with NIL child");
-      adiar_debug(h.is_terminal() || label < h.label(),
-                  "Node is not prior to given high child");
+      adiar_assert(!h.is_nil(), "Cannot create a node with NIL child");
+      adiar_assert(h.is_terminal() || label < h.label(),
+                   "Node is not prior to given high child");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -176,7 +176,7 @@ namespace adiar::internal
     node(const label_t label, const id_t id, const node &l, const ptr_t &h)
       : node(label, id, l.uid(), h)
     {
-      adiar_debug(OUTDEGREE == 2, "Constructor is for binary node only.");
+      adiar_assert(OUTDEGREE == 2, "Constructor is for binary node only.");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -185,7 +185,7 @@ namespace adiar::internal
     node(const label_t label, const id_t id, const ptr_t &l, const node &h)
       : node(label, id, l, h.uid())
     {
-      adiar_debug(OUTDEGREE == 2, "Constructor is for binary node only.");
+      adiar_assert(OUTDEGREE == 2, "Constructor is for binary node only.");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -194,7 +194,7 @@ namespace adiar::internal
     node(const label_t label, const id_t id, const node &l, const node &h)
       : node(label, id, l.uid(), h.uid())
     {
-      adiar_debug(OUTDEGREE == 2, "Constructor is for binary node only.");
+      adiar_assert(OUTDEGREE == 2, "Constructor is for binary node only.");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -205,7 +205,7 @@ namespace adiar::internal
     // TODO: Rename to `level()` when introducing variable ordering
     inline label_t label() const
     {
-      adiar_debug(!is_terminal());
+      adiar_assert(!is_terminal());
       return uid().label();
     }
 
@@ -216,7 +216,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline id_t id() const
     {
-      adiar_debug(!is_terminal());
+      adiar_assert(!is_terminal());
       return uid().id();
     }
 
@@ -239,7 +239,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline ptr_t child(const size_t i) const
     {
-      adiar_debug(i < OUTDEGREE, "'i' must be a valid children index.");
+      adiar_assert(i < OUTDEGREE, "'i' must be a valid children index.");
       return _children[i];
     }
 
@@ -253,8 +253,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline ptr_t low() const
     {
-      adiar_debug(OUTDEGREE == 2,
-                  "Semantics of 'low' is only defined for binary nodes.");
+      adiar_assert(OUTDEGREE == 2,
+                   "Semantics of 'low' is only defined for binary nodes.");
 
       return child(false);
     }
@@ -269,8 +269,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline ptr_t high() const
     {
-      adiar_debug(OUTDEGREE == 2,
-                  "Semantics of 'high' is only defined for binary node.");
+      adiar_assert(OUTDEGREE == 2,
+                   "Semantics of 'high' is only defined for binary node.");
 
       return child(true);
     }

--- a/src/adiar/internal/data_types/ptr.h
+++ b/src/adiar/internal/data_types/ptr.h
@@ -389,7 +389,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline value_t value() const
     {
-      adiar_precondition(is_terminal());
+      adiar_debug(is_terminal());
 
       // TODO (Attributed Edges):
       //   Negate resulting value based on 'is_flagged()'? It might actually be
@@ -453,7 +453,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator~ () const
     {
-      adiar_precondition(this->is_terminal());
+      adiar_debug(this->is_terminal());
       return ptr_uint64(VALUE_MASK ^ _raw);
     }
 
@@ -465,8 +465,8 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator^ (const ptr_uint64 &o) const
     {
-      adiar_precondition(this->is_terminal());
-      adiar_precondition(o.is_terminal());
+      adiar_debug(this->is_terminal());
+      adiar_debug(o.is_terminal());
 
       return ptr_uint64(TERMINAL_BIT | (this->_raw ^ o._raw));
     }
@@ -479,8 +479,8 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator& (const ptr_uint64 &o) const
     {
-      adiar_precondition(this->is_terminal());
-      adiar_precondition(o.is_terminal());
+      adiar_debug(this->is_terminal());
+      adiar_debug(o.is_terminal());
 
       return ptr_uint64(this->_raw & o._raw);
     }
@@ -493,8 +493,8 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator| (const ptr_uint64 &o) const
     {
-      adiar_precondition(this->is_terminal());
-      adiar_precondition(o.is_terminal());
+      adiar_debug(this->is_terminal());
+      adiar_debug(o.is_terminal());
 
       return ptr_uint64(this->_raw | o._raw);
     }
@@ -547,7 +547,7 @@ namespace adiar::internal
   inline ptr_uint64 with_out_idx(const ptr_uint64 &p,
                                  const ptr_uint64::out_idx_t out_idx)
   {
-    adiar_precondition(p.is_node());
+    adiar_debug(p.is_node());
 
     constexpr uint64_t out_idx_mask =
       ~(((1ull << ptr_uint64::OUT_IDX_BITS) - 1u) << ptr_uint64::FLAG_BITS);

--- a/src/adiar/internal/data_types/ptr.h
+++ b/src/adiar/internal/data_types/ptr.h
@@ -262,13 +262,13 @@ namespace adiar::internal
   protected:
     static uint64_t encode_label(const label_t label)
     {
-      adiar_debug(label <= MAX_LABEL, "Cannot represent given label");
+      adiar_assert(label <= MAX_LABEL, "Cannot represent given label");
       return (uint64_t) label << (ID_BITS + OUT_IDX_BITS + FLAG_BITS);
     }
 
     static uint64_t encode_id(const id_t id)
     {
-      adiar_debug(id <= MAX_ID, "Cannot represent given id");
+      adiar_assert(id <= MAX_ID, "Cannot represent given id");
       return (uint64_t) id << (OUT_IDX_BITS + FLAG_BITS);
     }
 
@@ -389,7 +389,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline value_t value() const
     {
-      adiar_debug(is_terminal());
+      adiar_assert(is_terminal());
 
       // TODO (Attributed Edges):
       //   Negate resulting value based on 'is_flagged()'? It might actually be
@@ -453,7 +453,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator~ () const
     {
-      adiar_debug(this->is_terminal());
+      adiar_assert(this->is_terminal());
       return ptr_uint64(VALUE_MASK ^ _raw);
     }
 
@@ -465,8 +465,8 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator^ (const ptr_uint64 &o) const
     {
-      adiar_debug(this->is_terminal());
-      adiar_debug(o.is_terminal());
+      adiar_assert(this->is_terminal());
+      adiar_assert(o.is_terminal());
 
       return ptr_uint64(TERMINAL_BIT | (this->_raw ^ o._raw));
     }
@@ -479,8 +479,8 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator& (const ptr_uint64 &o) const
     {
-      adiar_debug(this->is_terminal());
-      adiar_debug(o.is_terminal());
+      adiar_assert(this->is_terminal());
+      adiar_assert(o.is_terminal());
 
       return ptr_uint64(this->_raw & o._raw);
     }
@@ -493,8 +493,8 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     ptr_uint64 operator| (const ptr_uint64 &o) const
     {
-      adiar_debug(this->is_terminal());
-      adiar_debug(o.is_terminal());
+      adiar_assert(this->is_terminal());
+      adiar_assert(o.is_terminal());
 
       return ptr_uint64(this->_raw | o._raw);
     }
@@ -547,7 +547,7 @@ namespace adiar::internal
   inline ptr_uint64 with_out_idx(const ptr_uint64 &p,
                                  const ptr_uint64::out_idx_t out_idx)
   {
-    adiar_debug(p.is_node());
+    adiar_assert(p.is_node());
 
     constexpr uint64_t out_idx_mask =
       ~(((1ull << ptr_uint64::OUT_IDX_BITS) - 1u) << ptr_uint64::FLAG_BITS);

--- a/src/adiar/internal/data_types/ptr.h
+++ b/src/adiar/internal/data_types/ptr.h
@@ -1,6 +1,7 @@
 #ifndef ADIAR_INTERNAL_DATA_TYPES_PTR_H
 #define ADIAR_INTERNAL_DATA_TYPES_PTR_H
 
+#include <limits>
 #include <stdint.h>
 
 #include <adiar/internal/assert.h>

--- a/src/adiar/internal/data_types/request.h
+++ b/src/adiar/internal/data_types/request.h
@@ -199,8 +199,8 @@ namespace adiar::internal
       uint8_t sum = 0u;
       for (uint8_t n_idx = 0u; n_idx < node_carry_size; n_idx++) {
         if (node_carry[n_idx][0] == base::ptr_t::NIL()) {
-          adiar_debug(node_carry[n_idx] == base::NO_CHILDREN(),
-                      "Either no entry is NIL or all of them are");
+          adiar_assert(node_carry[n_idx] == base::NO_CHILDREN(),
+                       "Either no entry is NIL or all of them are");
           break;
         }
         sum++;

--- a/src/adiar/internal/data_types/tuple.h
+++ b/src/adiar/internal/data_types/tuple.h
@@ -113,7 +113,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline const elem_t& at(const size_t idx) const
     {
-      adiar_debug(idx < cardinality, "Tuple index must be within its cardinality.");
+      adiar_assert(idx < cardinality, "Tuple index must be within its cardinality.");
       return _elems[idx];
     }
 
@@ -237,7 +237,7 @@ namespace adiar::internal
                     "Constructor is only designed for 2-ary tuples.");
 
       if constexpr (is_sorted) {
-        adiar_debug(elem1 <= elem2);
+        adiar_assert(elem1 <= elem2);
       }
     }
 
@@ -251,8 +251,8 @@ namespace adiar::internal
                     "Constructor is only designed for 3-ary tuples.");
 
       if constexpr (is_sorted) {
-        adiar_debug(elem1 <= elem2);
-        adiar_debug(elem2 <= elem3);
+        adiar_assert(elem1 <= elem2);
+        adiar_assert(elem2 <= elem3);
         }
     }
 
@@ -269,9 +269,9 @@ namespace adiar::internal
                     "Constructor is only designed for 4-ary tuples.");
 
       if constexpr (is_sorted) {
-        adiar_debug(elem1 <= elem2);
-        adiar_debug(elem2 <= elem3);
-        adiar_debug(elem3 <= elem4);
+        adiar_assert(elem1 <= elem2);
+        adiar_assert(elem2 <= elem3);
+        adiar_assert(elem3 <= elem4);
       }
     }
 
@@ -283,7 +283,7 @@ namespace adiar::internal
     {
       if constexpr (is_sorted) {
         for (size_t i = 0; i < (cardinality-1); ++i) {
-          adiar_debug(this->at(i) <= this->at(i+1));
+          adiar_assert(this->at(i) <= this->at(i+1));
         }
       }
     }

--- a/src/adiar/internal/data_types/tuple.h
+++ b/src/adiar/internal/data_types/tuple.h
@@ -237,7 +237,7 @@ namespace adiar::internal
                     "Constructor is only designed for 2-ary tuples.");
 
       if constexpr (is_sorted) {
-        adiar_precondition(elem1 <= elem2);
+        adiar_debug(elem1 <= elem2);
       }
     }
 
@@ -251,8 +251,8 @@ namespace adiar::internal
                     "Constructor is only designed for 3-ary tuples.");
 
       if constexpr (is_sorted) {
-        adiar_precondition(elem1 <= elem2);
-        adiar_precondition(elem2 <= elem3);
+        adiar_debug(elem1 <= elem2);
+        adiar_debug(elem2 <= elem3);
         }
     }
 
@@ -269,9 +269,9 @@ namespace adiar::internal
                     "Constructor is only designed for 4-ary tuples.");
 
       if constexpr (is_sorted) {
-        adiar_precondition(elem1 <= elem2);
-        adiar_precondition(elem2 <= elem3);
-        adiar_precondition(elem3 <= elem4);
+        adiar_debug(elem1 <= elem2);
+        adiar_debug(elem2 <= elem3);
+        adiar_debug(elem3 <= elem4);
       }
     }
 
@@ -283,7 +283,7 @@ namespace adiar::internal
     {
       if constexpr (is_sorted) {
         for (size_t i = 0; i < (cardinality-1); ++i) {
-          adiar_precondition(this->at(i) <= this->at(i+1));
+          adiar_debug(this->at(i) <= this->at(i+1));
         }
       }
     }

--- a/src/adiar/internal/data_types/uid.h
+++ b/src/adiar/internal/data_types/uid.h
@@ -39,7 +39,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     __uid(const ptr_t &p) : ptr_t(essential(p))
     {
-      adiar_debug(!p.is_nil(), "UID must be created from non-nil value");
+      adiar_assert(!p.is_nil(), "UID must be created from non-nil value");
     }
 
     /* ============================= ATTRIBUTES ============================= */
@@ -64,7 +64,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline ptr_t with(const typename ptr_t::out_idx_t out_idx) const
     {
-      adiar_debug(ptr_t::is_node());
+      adiar_assert(ptr_t::is_node());
       return ptr_t(ptr_t::label(), ptr_t::id(), out_idx);
     }
 

--- a/src/adiar/internal/data_types/uid.h
+++ b/src/adiar/internal/data_types/uid.h
@@ -39,9 +39,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     __uid(const ptr_t &p) : ptr_t(essential(p))
     {
-#ifndef NDEBUG
-      if (p.is_nil()) throw std::invalid_argument("Pointer must be non-NIL");
-#endif
+      adiar_debug(!p.is_nil(), "UID must be created from non-nil value");
     }
 
     /* ============================= ATTRIBUTES ============================= */
@@ -66,7 +64,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     inline ptr_t with(const typename ptr_t::out_idx_t out_idx) const
     {
-      adiar_precondition(ptr_t::is_node());
+      adiar_debug(ptr_t::is_node());
       return ptr_t(ptr_t::label(), ptr_t::id(), out_idx);
     }
 

--- a/src/adiar/internal/io/arc_stream.h
+++ b/src/adiar/internal/io/arc_stream.h
@@ -75,7 +75,7 @@ namespace adiar::internal
     void attach(const levelized_file<arc> &f,
                 const bool negate = false)
     {
-      //adiar_precondition(f.semi_transposed);
+      //adiar_debug(f.semi_transposed);
       parent_t::attach(f, negate);
       _unread_terminals[negate ^ false] = f.number_of_terminals[false];
       _unread_terminals[negate ^ true]  = f.number_of_terminals[true];
@@ -89,7 +89,7 @@ namespace adiar::internal
     void attach(const shared_ptr<levelized_file<arc>> &f,
                 const bool negate = false)
     {
-      //adiar_precondition(f->semi_transposed);
+      //adiar_debug(f->semi_transposed);
       parent_t::attach(f, negate);
       _unread_terminals[negate ^ false] = f->number_of_terminals[false];
       _unread_terminals[negate ^ true]  = f->number_of_terminals[true];

--- a/src/adiar/internal/io/arc_stream.h
+++ b/src/adiar/internal/io/arc_stream.h
@@ -75,7 +75,7 @@ namespace adiar::internal
     void attach(const levelized_file<arc> &f,
                 const bool negate = false)
     {
-      //adiar_debug(f.semi_transposed);
+      //adiar_assert(f.semi_transposed);
       parent_t::attach(f, negate);
       _unread_terminals[negate ^ false] = f.number_of_terminals[false];
       _unread_terminals[negate ^ true]  = f.number_of_terminals[true];
@@ -89,7 +89,7 @@ namespace adiar::internal
     void attach(const shared_ptr<levelized_file<arc>> &f,
                 const bool negate = false)
     {
-      //adiar_debug(f->semi_transposed);
+      //adiar_assert(f->semi_transposed);
       parent_t::attach(f, negate);
       _unread_terminals[negate ^ false] = f->number_of_terminals[false];
       _unread_terminals[negate ^ true]  = f->number_of_terminals[true];
@@ -175,8 +175,8 @@ namespace adiar::internal
         ? parent_t::template pull<IDX__TERMINALS__IN_ORDER>()
         : parent_t::template pull<IDX__TERMINALS__OUT_OF_ORDER>();
 
-      adiar_debug(_unread_terminals[a.target().value()] > 0,
-                  "Terminal counter should not be zero");
+      adiar_assert(_unread_terminals[a.target().value()] > 0,
+                   "Terminal counter should not be zero");
       _unread_terminals[a.target().value()]--;
 
       return a;

--- a/src/adiar/internal/io/arc_writer.h
+++ b/src/adiar/internal/io/arc_writer.h
@@ -79,7 +79,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void attach(levelized_file<arc> &af) {
       if (attached()) detach();
-      adiar_debug(af.empty());
+      adiar_assert(af.empty());
 
       // TODO: remove precondition and set up __latest_terminal.
 
@@ -93,7 +93,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void attach(shared_ptr<levelized_file<arc>> &af) {
       if (attached()) detach();
-      adiar_debug(af->empty());
+      adiar_assert(af->empty());
 
       // TODO: remove precondition and set up __latest_terminal.
 
@@ -154,7 +154,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     void push(const arc &a)
     {
-      adiar_debug(!a.target().is_nil(), "Should not push an arc to NIL.");
+      adiar_assert(!a.target().is_nil(), "Should not push an arc to NIL.");
       if (a.target().is_node()) {
         push_internal(a);
       } else { // a.target().is_terminal()
@@ -180,9 +180,9 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     void push_internal(const arc &a)
     {
-      adiar_debug(attached());
-      adiar_debug(a.target().is_node());
-      adiar_debug(!a.source().is_nil());
+      adiar_assert(attached());
+      adiar_assert(a.target().is_node());
+      adiar_assert(!a.source().is_nil());
 #ifdef ADIAR_STATS
       stats_arc_file.push_internal += 1;
 #endif
@@ -196,9 +196,9 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     void push_terminal(const arc &a)
     {
-      adiar_debug(attached());
-      adiar_debug(a.target().is_terminal());
-      adiar_debug(!a.source().is_nil());
+      adiar_assert(attached());
+      adiar_assert(a.target().is_terminal());
+      adiar_assert(!a.source().is_nil());
 
       if (!__has_latest_terminal || a.source() > __latest_terminal.source()) {
         // Given arc is 'in-order' compared to latest 'in-order' pushed

--- a/src/adiar/internal/io/arc_writer.h
+++ b/src/adiar/internal/io/arc_writer.h
@@ -79,7 +79,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void attach(levelized_file<arc> &af) {
       if (attached()) detach();
-      adiar_precondition(af.empty());
+      adiar_debug(af.empty());
 
       // TODO: remove precondition and set up __latest_terminal.
 
@@ -93,7 +93,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void attach(shared_ptr<levelized_file<arc>> &af) {
       if (attached()) detach();
-      adiar_precondition(af->empty());
+      adiar_debug(af->empty());
 
       // TODO: remove precondition and set up __latest_terminal.
 
@@ -180,9 +180,9 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     void push_internal(const arc &a)
     {
-      adiar_precondition(attached());
-      adiar_precondition(a.target().is_node());
-      adiar_precondition(!a.source().is_nil());
+      adiar_debug(attached());
+      adiar_debug(a.target().is_node());
+      adiar_debug(!a.source().is_nil());
 #ifdef ADIAR_STATS
       stats_arc_file.push_internal += 1;
 #endif
@@ -196,9 +196,9 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     void push_terminal(const arc &a)
     {
-      adiar_precondition(attached());
-      adiar_precondition(a.target().is_terminal());
-      adiar_precondition(!a.source().is_nil());
+      adiar_debug(attached());
+      adiar_debug(a.target().is_terminal());
+      adiar_debug(!a.source().is_nil());
 
       if (!__has_latest_terminal || a.source() > __latest_terminal.source()) {
         // Given arc is 'in-order' compared to latest 'in-order' pushed

--- a/src/adiar/internal/io/file_stream.h
+++ b/src/adiar/internal/io/file_stream.h
@@ -214,7 +214,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const elem_t pull()
     {
-      adiar_precondition(can_pull());
+      adiar_debug(can_pull());
       if (_has_peeked) {
         _has_peeked = false;
         return _peeked;
@@ -230,7 +230,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const elem_t peek()
     {
-      adiar_precondition(can_pull());
+      adiar_debug(can_pull());
       if (!_has_peeked) {
         _peeked = __read();
         _has_peeked = true;

--- a/src/adiar/internal/io/file_stream.h
+++ b/src/adiar/internal/io/file_stream.h
@@ -214,7 +214,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const elem_t pull()
     {
-      adiar_debug(can_pull());
+       adiar_assert(can_pull());
       if (_has_peeked) {
         _has_peeked = false;
         return _peeked;
@@ -230,7 +230,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const elem_t peek()
     {
-      adiar_debug(can_pull());
+      adiar_assert(can_pull());
       if (!_has_peeked) {
         _peeked = __read();
         _has_peeked = true;

--- a/src/adiar/internal/io/file_writer.h
+++ b/src/adiar/internal/io/file_writer.h
@@ -81,7 +81,7 @@ namespace adiar::internal
     void attach(file<elem_t> &f, adiar::shared_ptr<void> p)
     {
       if (f.is_persistent())
-        throw std::runtime_error("Cannot attach writer to a persisted file");
+        throw runtime_error("Cannot attach writer to a persisted file");
 
       if (attached()) { detach(); }
       _file_ptr = p;

--- a/src/adiar/internal/io/levelized_file.h
+++ b/src/adiar/internal/io/levelized_file.h
@@ -4,11 +4,10 @@
 #include <array>
 #include <sstream>
 #include <string>
-#include <stdexcept>
 
+#include <adiar/exception.h>
 #include <adiar/internal/io/file.h>
 #include <adiar/internal/io/file_stream.h>
-
 #include <adiar/internal/cut.h>
 #include <adiar/internal/data_types/arc.h>
 #include <adiar/internal/data_types/level_info.h>
@@ -59,14 +58,14 @@ namespace adiar::internal
     inline void throw_if_bad_idx(const size_t idx) const
     {
       if (FILES <= idx)
-        throw std::out_of_range("Index must be within interval [0;FILES-1]");
+        throw out_of_range("Index must be within interval [0;FILES-1]");
     }
 
     ///////////////////////////////////////////////////////////////////////////
     inline void throw_if_persistent() const
     {
       if (is_persistent())
-        throw std::runtime_error("'"+_level_info_file.path()+"' is persisted.");
+        throw runtime_error("'"+_level_info_file.path()+"' is persisted.");
     }
 
   private:
@@ -130,7 +129,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Constructor for a prior named \em persisted file.
     ///
-    /// \throws std::runtime_error If one or more files are missing in relation
+    /// \throws runtime_error If one or more files are missing in relation
     ///                            to the given path-prefix.
     ////////////////////////////////////////////////////////////////////////////
     levelized_file(const std::string path_prefix)
@@ -142,7 +141,7 @@ namespace adiar::internal
           _files[idx].set_path(path);
           _files[idx].make_persistent();
         } else { // '_files[idx]' is missing
-          throw std::runtime_error("'"+path+"' does not exist");
+          throw runtime_error("'"+path+"' does not exist");
         }
       }
 
@@ -152,7 +151,7 @@ namespace adiar::internal
           _level_info_file.set_path(path);
           _level_info_file.make_persistent();
         } else { // '_level_info_file' is missing
-          throw std::runtime_error("'"+path+"' does not exist");
+          throw runtime_error("'"+path+"' does not exist");
         }
       }
 
@@ -191,14 +190,14 @@ namespace adiar::internal
     ///
     /// \pre   `canonical_paths() == true` (use `move()` to make them so).
     ///
-    /// \throws std::runtime_error If `canonical_paths() == false`.
+    /// \throws runtime_error If `canonical_paths() == false`.
     ///
     /// \sa is_persistent, canonical_paths, move
     ////////////////////////////////////////////////////////////////////////////
     void make_persistent()
     {
       if (!canonical_paths()) {
-        throw std::runtime_error("Cannot persist a file with non-canonical paths");
+        throw runtime_error("Cannot persist a file with non-canonical paths");
       }
       for (size_t idx = 0u; idx < FILES; idx++) {
         _files[idx].make_persistent();
@@ -214,7 +213,7 @@ namespace adiar::internal
     ///
     /// \pre   `can_move() == true`
     ///
-    /// \throws std::runtime_error If `can_move() == false` or
+    /// \throws runtime_error If `can_move() == false` or
     ///                            `move(path_prefix)` operation fails.
     ///
     /// \sa is_persistent, move
@@ -287,7 +286,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     size_t first_level() const
     {
-      adiar_precondition(this->levels() > 0u);
+      adiar_debug(this->levels() > 0u);
       file_stream<level_info, true> fs(this->_level_info_file);
       return fs.pull().level();
     }
@@ -299,7 +298,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     size_t last_level() const
     {
-      adiar_precondition(this->levels() > 0u);
+      adiar_debug(this->levels() > 0u);
       file_stream<level_info, false> fs(this->_level_info_file);
       return fs.pull().level();
     }
@@ -377,7 +376,7 @@ namespace adiar::internal
     ///      `path_prefix` names a yet non-existing file. Neither should a
     ///      `file_stream` nor a `file_writer` be hooked into this file.
     ///
-    /// \throws std::runtime_error Preconditions are violated.
+    /// \throws runtime_error Preconditions are violated.
     ////////////////////////////////////////////////////////////////////////////
     void move(const std::string &path_prefix)
     {
@@ -388,18 +387,18 @@ namespace adiar::internal
       // TODO: allow this? the path-prefix might be an independently created,
       //       but intendedly related, file made by the user.
       if (std::filesystem::exists(path_prefix))
-        throw std::runtime_error("path-prefix '"+path_prefix+"' exists.");
+        throw runtime_error("path-prefix '"+path_prefix+"' exists.");
 
       // Disallow moving a file on-top of another.
       {
         std::string path = canonical_levels_path(path_prefix);
         if (std::filesystem::exists(path))
-          throw std::runtime_error("'"+path+"' already exists.");
+          throw runtime_error("'"+path+"' already exists.");
       }
       for (size_t idx = 0; idx < FILES; idx++) {
         std::string path = canonical_file_path(path_prefix, idx);
         if (std::filesystem::exists(path))
-          throw std::runtime_error("'"+path+"' already exists.");
+          throw runtime_error("'"+path+"' already exists.");
       }
 
       // Move files

--- a/src/adiar/internal/io/levelized_file.h
+++ b/src/adiar/internal/io/levelized_file.h
@@ -176,8 +176,8 @@ namespace adiar::internal
       const bool res = _level_info_file.is_persistent();
 #ifndef NDEBUG
       for (size_t idx = 0; idx < FILES; idx++) {
-        adiar_debug(_files[idx].is_persistent() == res,
-                    "Persistence ought to be synchronised.");
+        adiar_assert(_files[idx].is_persistent() == res,
+                     "Persistence ought to be synchronised.");
       }
 #endif
       return res;
@@ -242,8 +242,8 @@ namespace adiar::internal
       const bool res = std::filesystem::exists(_level_info_file.path());
 #ifndef NDEBUG
       for (size_t idx = 0; idx < FILES; idx++) {
-        adiar_debug(std::filesystem::exists(_files[idx].path()) == res,
-                    "Persistence ought to be synchronised.");
+        adiar_assert(std::filesystem::exists(_files[idx].path()) == res,
+                     "Persistence ought to be synchronised.");
       }
 #endif
       return res;
@@ -286,7 +286,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     size_t first_level() const
     {
-      adiar_debug(this->levels() > 0u);
+      adiar_assert(this->levels() > 0u);
       file_stream<level_info, true> fs(this->_level_info_file);
       return fs.pull().level();
     }
@@ -298,7 +298,7 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     size_t last_level() const
     {
-      adiar_debug(this->levels() > 0u);
+      adiar_assert(this->levels() > 0u);
       file_stream<level_info, false> fs(this->_level_info_file);
       return fs.pull().level();
     }
@@ -359,8 +359,8 @@ namespace adiar::internal
       const bool res = _level_info_file.can_move();
 #ifndef NDEBUG
       for (size_t idx = 0; idx < FILES; idx++) {
-        adiar_debug(_files[idx].can_move() == res,
-                    "'can_move()' ought to be synchronised.");
+        adiar_assert(_files[idx].can_move() == res,
+                     "'can_move()' ought to be synchronised.");
       }
 #endif
       return res;

--- a/src/adiar/internal/io/levelized_file_stream.h
+++ b/src/adiar/internal/io/levelized_file_stream.h
@@ -3,6 +3,7 @@
 
 #include <adiar/internal/assert.h>
 #include <adiar/internal/dd.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/data_types/level_info.h>
 #include <adiar/internal/io/file_stream.h>
 #include <adiar/internal/io/levelized_file.h>

--- a/src/adiar/internal/io/levelized_file_stream.h
+++ b/src/adiar/internal/io/levelized_file_stream.h
@@ -108,9 +108,10 @@ namespace adiar::internal
     {
       const bool res = _streams[0].attached();
 #ifndef NDEBUG
+      // TODO: trust the compiler to notice this is an empty for-loop?
       for (size_t s_idx = 1; s_idx < streams; s_idx++) {
-        adiar_debug(_streams[s_idx].attached() == res,
-                    "Attachment ought to be synchronised.");
+        adiar_assert(_streams[s_idx].attached() == res,
+                     "Attachment ought to be synchronised.");
       }
 #endif
       return res;

--- a/src/adiar/internal/io/levelized_file_writer.h
+++ b/src/adiar/internal/io/levelized_file_writer.h
@@ -115,8 +115,8 @@ namespace adiar::internal
       const bool res = _level_writer.attached();
 #ifndef NDEBUG
       for (size_t s_idx = 0; s_idx < ELEM_WRITERS; s_idx++) {
-        adiar_debug(_elem_writers[s_idx].attached() == res,
-                    "Attachment ought to be synchronised.");
+        adiar_assert(_elem_writers[s_idx].attached() == res,
+                     "Attachment ought to be synchronised.");
       }
 #endif
       return res;
@@ -179,8 +179,8 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     size_t size(const size_t s_idx) const
     {
-      adiar_debug(s_idx < ELEM_WRITERS,
-                  "Sub-stream index must be within [0; ELEM_WRITERS).");
+      adiar_assert(s_idx < ELEM_WRITERS,
+                   "Sub-stream index must be within [0; ELEM_WRITERS).");
       return _elem_writers[s_idx].size();
     }
 

--- a/src/adiar/internal/io/node_arc_stream.h
+++ b/src/adiar/internal/io/node_arc_stream.h
@@ -77,7 +77,7 @@ namespace adiar::internal
     node_arc_stream(const __dd &diagram)
       : parent_t(/*need to sort before attach*/)
     {
-      adiar_precondition(diagram.template has<__dd::shared_arcs_t>());
+      adiar_debug(diagram.template has<__dd::shared_arcs_t>());
       attach(diagram.template get<__dd::shared_arcs_t>(), diagram.negate);
     }
 

--- a/src/adiar/internal/io/node_arc_stream.h
+++ b/src/adiar/internal/io/node_arc_stream.h
@@ -77,7 +77,7 @@ namespace adiar::internal
     node_arc_stream(const __dd &diagram)
       : parent_t(/*need to sort before attach*/)
     {
-      adiar_debug(diagram.template has<__dd::shared_arcs_t>());
+      adiar_assert(diagram.template has<__dd::shared_arcs_t>());
       attach(diagram.template get<__dd::shared_arcs_t>(), diagram.negate);
     }
 
@@ -175,8 +175,8 @@ namespace adiar::internal
         if (!parent_t::can_pull_terminal()) { return true;  }
         if (!parent_t::can_pull_internal()) { return false; }
       } else {
-        adiar_debug(parent_t::can_pull_terminal(),
-                    "When reading top-down there must be terminal arcs left");
+        adiar_assert(parent_t::can_pull_terminal(),
+                     "When reading top-down there must be terminal arcs left");
 
         if (!parent_t::can_pull_internal()) { return false; }
       }

--- a/src/adiar/internal/io/node_file.h
+++ b/src/adiar/internal/io/node_file.h
@@ -102,7 +102,7 @@ namespace adiar::internal
       //////////////////////////////////////////////////////////////////////////
       inline bool value() const
       {
-        adiar_precondition(this->is_terminal());
+        adiar_debug(this->is_terminal());
 
         // Since the sum of the number of terminals is exactly one, then we can
         // use the value of the number of true terminals to indirectly derive

--- a/src/adiar/internal/io/node_file.h
+++ b/src/adiar/internal/io/node_file.h
@@ -102,7 +102,7 @@ namespace adiar::internal
       //////////////////////////////////////////////////////////////////////////
       inline bool value() const
       {
-        adiar_debug(this->is_terminal());
+        adiar_assert(this->is_terminal());
 
         // Since the sum of the number of terminals is exactly one, then we can
         // use the value of the number of true terminals to indirectly derive

--- a/src/adiar/internal/io/node_random_access.h
+++ b/src/adiar/internal/io/node_random_access.h
@@ -96,7 +96,7 @@ namespace adiar::internal
                        const bool negate = false)
       : _ns(f, negate), _max_width(f.width), _level_buffer(f.width)
     {
-      adiar_precondition(f.canonical);
+      adiar_debug(f.canonical);
       init();
     }
 
@@ -109,7 +109,7 @@ namespace adiar::internal
                        const bool negate = false)
       : _ns(f, negate), _max_width(f->width), _level_buffer(f->width)
     {
-      adiar_precondition(f->canonical);
+      adiar_debug(f->canonical);
       init();
     }
 
@@ -121,7 +121,7 @@ namespace adiar::internal
     node_random_access(const dd &diagram)
       : _ns(diagram), _max_width(diagram->width), _level_buffer(diagram->width)
     {
-      adiar_precondition(diagram->canonical);
+      adiar_debug(diagram->canonical);
       init();
     }
 
@@ -168,7 +168,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void setup_next_level(const label_t level)
     {
-      adiar_precondition(!has_current_level() || current_level() < level);
+      adiar_debug(!has_current_level() || current_level() < level);
 
       // Set to new level and mark the entire buffer's content garbage.
       _curr_level = level;
@@ -229,7 +229,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const node_t& at(id_t idx) const
     {
-      adiar_precondition(idx < current_width());
+      adiar_debug(idx < current_width());
       return _level_buffer[idx];
     }
 
@@ -238,9 +238,9 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const node_t& at(uid_t u) const
     {
-      adiar_precondition(u.label() == current_level());
+      adiar_debug(u.label() == current_level());
 
-      // adiar_precondition(... < current_width()); is in 'return at(...)'
+      // adiar_debug(... < current_width()); is in 'return at(...)'
       return at(current_width() - ((uid_t::MAX_ID + 1u) - u.id()));
     }
   };

--- a/src/adiar/internal/io/node_random_access.h
+++ b/src/adiar/internal/io/node_random_access.h
@@ -96,7 +96,7 @@ namespace adiar::internal
                        const bool negate = false)
       : _ns(f, negate), _max_width(f.width), _level_buffer(f.width)
     {
-      adiar_debug(f.canonical);
+      adiar_assert(f.canonical);
       init();
     }
 
@@ -109,7 +109,7 @@ namespace adiar::internal
                        const bool negate = false)
       : _ns(f, negate), _max_width(f->width), _level_buffer(f->width)
     {
-      adiar_debug(f->canonical);
+      adiar_assert(f->canonical);
       init();
     }
 
@@ -121,14 +121,14 @@ namespace adiar::internal
     node_random_access(const dd &diagram)
       : _ns(diagram), _max_width(diagram->width), _level_buffer(diagram->width)
     {
-      adiar_debug(diagram->canonical);
+      adiar_assert(diagram->canonical);
       init();
     }
 
   private:
     void init()
     {
-      adiar_debug(_ns.can_pull(), "given file should be non-empty");
+      adiar_assert(_ns.can_pull(), "given file should be non-empty");
 
       // Skip the terminal node for terminal only BDDs.
       _root = _ns.peek().uid();
@@ -168,7 +168,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     void setup_next_level(const label_t level)
     {
-      adiar_debug(!has_current_level() || current_level() < level);
+      adiar_assert(!has_current_level() || current_level() < level);
 
       // Set to new level and mark the entire buffer's content garbage.
       _curr_level = level;
@@ -229,7 +229,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const node_t& at(id_t idx) const
     {
-      adiar_debug(idx < current_width());
+      adiar_assert(idx < current_width());
       return _level_buffer[idx];
     }
 
@@ -238,9 +238,9 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     const node_t& at(uid_t u) const
     {
-      adiar_debug(u.label() == current_level());
+      adiar_assert(u.label() == current_level());
 
-      // adiar_debug(... < current_width()); is in 'return at(...)'
+      // adiar_assert(... < current_width()); is in 'return at(...)'
       return at(current_width() - ((uid_t::MAX_ID + 1u) - u.id()));
     }
   };

--- a/src/adiar/internal/io/node_writer.h
+++ b/src/adiar/internal/io/node_writer.h
@@ -195,9 +195,9 @@ namespace adiar::internal
           _file_ptr->number_of_terminals[n.uid().value()]++;
         }
       } else { // Check validity of input based on prior written node
-        adiar_debug(!_latest_node.is_terminal(),
+        adiar_assert(!_latest_node.is_terminal(),
                      "Cannot push a node after having pushed a terminal");
-        adiar_debug(!n.is_terminal(),
+        adiar_assert(!n.is_terminal(),
                      "Cannot push a terminal into non-empty file");
 
         // Check it is canonically sorted

--- a/src/adiar/internal/io/node_writer.h
+++ b/src/adiar/internal/io/node_writer.h
@@ -1,6 +1,7 @@
 #ifndef ADIAR_INTERNAL_IO_NODE_WRITER_H
 #define ADIAR_INTERNAL_IO_NODE_WRITER_H
 
+#include <adiar/exception.h>
 #include <adiar/internal/cut.h>
 #include <adiar/internal/data_types/node.h>
 #include <adiar/internal/data_types/level_info.h>
@@ -179,10 +180,14 @@ namespace adiar::internal
     ///          valid children (not checked), no duplicate nodes created (not
     ///          properly checked), and must be topologically prior to any nodes
     ///          already written to the file (checked).
+    ///
+    /// \throws domain_error If the writer is yet not attached.
     ////////////////////////////////////////////////////////////////////////////
     void push(const node &n)
     {
-      adiar_assert(attached(), "file_writer is not yet attached to any file");
+      if (!attached()) {
+        throw domain_error("node_writer is not yet attached to any levelized_file<node>");
+      }
 
       if (_latest_node == dummy()) { // First node pushed
         _canonical = n.is_terminal() || n.id() == node::MAX_ID;

--- a/src/adiar/internal/unreachable.h
+++ b/src/adiar/internal/unreachable.h
@@ -1,0 +1,20 @@
+#ifndef ADIAR_INTERNAL_UNREACHABLE_H
+#define ADIAR_INTERNAL_UNREACHABLE_H
+
+namespace adiar
+{
+  // LCOV_EXCL_START
+
+  // From: https://stackoverflow.com/a/65258501/13300643
+#ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
+  [[noreturn]] inline __attribute__((always_inline)) void adiar_unreachable() {__builtin_unreachable();}
+#elif defined(_MSC_VER) // MSVC
+  [[noreturn]] __forceinline void adiar_unreachable() {__assume(false);}
+#else // ???
+  inline void adiar_unreachable() {}
+#endif
+
+  // LCOV_EXCL_STOP
+}
+
+#endif // ADIAR_INTERNAL_UNREACHABLE_H

--- a/src/adiar/internal/util.h
+++ b/src/adiar/internal/util.h
@@ -92,7 +92,7 @@ namespace adiar::internal
   inline shared_levelized_file<arc>
   transpose(const dd_t &dd)
   {
-    adiar_precondition(!dd->is_terminal());
+    adiar_debug(!dd->is_terminal());
 
     shared_levelized_file<arc> af;
 

--- a/src/adiar/internal/util.h
+++ b/src/adiar/internal/util.h
@@ -92,7 +92,7 @@ namespace adiar::internal
   inline shared_levelized_file<arc>
   transpose(const dd_t &dd)
   {
-    adiar_debug(!dd->is_terminal());
+    adiar_assert(!dd->is_terminal());
 
     shared_levelized_file<arc> af;
 

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -689,10 +689,6 @@ namespace adiar
   ///
   /// \returns   ZDD that is true for the exact same assignments to variables in
   ///            the given domain.
-  ///
-  /// \throws invalid_argument If a label in `dom` is too large.
-  ///
-  /// \throws invalid_argument If labels in `dom` are not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_from(const bdd &f, const shared_file<zdd::label_t> &dom);
 

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -76,6 +76,8 @@ namespace adiar
   /// \pre       The variable `var` should occur in `dom`.
   ///
   /// \throws invalid_argument If `dom` is not in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_ithvar(zdd::label_t var, const shared_file<zdd::label_t> &dom);
 
@@ -119,8 +121,6 @@ namespace adiar
   ///
   /// \pre       `adiar_has_domain() == true` and the variable `var` should
   ///            occur in the global domain.
-  ///
-  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_nithvar(zdd::label_t var);
 

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -74,6 +74,8 @@ namespace adiar
   /// \param dom Labels of the desired variables (in ascending order)
   ///
   /// \pre       The variable `var` should occur in `dom`.
+  ///
+  /// \throws invalid_argument If `dom` is not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_ithvar(zdd::label_t var, const shared_file<zdd::label_t> &dom);
 
@@ -102,6 +104,10 @@ namespace adiar
   /// \param dom Labels of the desired variables (in ascending order)
   ///
   /// \pre       The variable `var` should occur in `dom`.
+  ///
+  /// \throws invalid_argument If `dom` is not in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_nithvar(zdd::label_t var, const shared_file<zdd::label_t> &dom);
 
@@ -113,6 +119,8 @@ namespace adiar
   ///
   /// \pre       `adiar_has_domain() == true` and the variable `var` should
   ///            occur in the global domain.
+  ///
+  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_nithvar(zdd::label_t var);
 
@@ -124,6 +132,10 @@ namespace adiar
   ///            smaller than or equal to `zdd::MAX_LABEL`.
   ///
   /// \param vars Labels of the desired variables (in ascending order)
+  ///
+  /// \throws invalid_argument If `vars` are not in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_vars(const shared_file<zdd::label_t> &vars);
 
@@ -135,6 +147,8 @@ namespace adiar
   ///            `zdd::MAX_LABEL`.
   ///
   /// \param var The label of the desired variable to include
+  ///
+  /// \throws invalid_argument If `var` is a too large value.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_singleton(zdd::label_t var);
 
@@ -146,6 +160,10 @@ namespace adiar
   ///            smaller than or equal to `zdd::MAX_LABEL`.
   ///
   /// \param vars Labels of the desired variables (in ascending order)
+  ///
+  /// \throws invalid_argument If `vars` are not in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_singletons(const shared_file<zdd::label_t> &vars);
 
@@ -157,6 +175,10 @@ namespace adiar
   ///            `zdd::MAX_LABEL`.
   ///
   /// \param vars Labels of the desired variables (in ascending order)
+  ///
+  /// \throws invalid_argument If `vars` are not in ascending order.
+  ///
+  /// \throws invalid_argument If `vars` includes a label that is too large.
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_powerset(const shared_file<zdd::label_t> &vars);
 
@@ -667,6 +689,10 @@ namespace adiar
   ///
   /// \returns   ZDD that is true for the exact same assignments to variables in
   ///            the given domain.
+  ///
+  /// \throws invalid_argument If a label in `dom` is too large.
+  ///
+  /// \throws invalid_argument If labels in `dom` are not in ascending order.
   //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_from(const bdd &f, const shared_file<zdd::label_t> &dom);
 

--- a/src/adiar/zdd/binop.cpp
+++ b/src/adiar/zdd/binop.cpp
@@ -1,6 +1,7 @@
+#include <limits>
+
 #include <adiar/zdd.h>
 #include <adiar/zdd/zdd_policy.h>
-
 
 #include <adiar/internal/assert.h>
 #include <adiar/internal/algorithms/prod2.h>

--- a/src/adiar/zdd/binop.cpp
+++ b/src/adiar/zdd/binop.cpp
@@ -65,7 +65,7 @@ namespace adiar
                                        const zdd& zdd_2,
                                        const bool_op &op)
     {
-      adiar_precondition(is_terminal(zdd_1) || is_terminal(zdd_2));
+      adiar_debug(is_terminal(zdd_1) || is_terminal(zdd_2));
 
       const zdd::ptr_t terminal_F = zdd::ptr_t(false);
 

--- a/src/adiar/zdd/binop.cpp
+++ b/src/adiar/zdd/binop.cpp
@@ -65,7 +65,7 @@ namespace adiar
                                        const zdd& zdd_2,
                                        const bool_op &op)
     {
-      adiar_debug(is_terminal(zdd_1) || is_terminal(zdd_2));
+      adiar_assert(is_terminal(zdd_1) || is_terminal(zdd_2));
 
       const zdd::ptr_t terminal_F = zdd::ptr_t(false);
 

--- a/src/adiar/zdd/build.cpp
+++ b/src/adiar/zdd/build.cpp
@@ -11,17 +11,17 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_terminal(bool value)
   {
-    return internal::build_terminal(value);
+    return internal::build_terminal<zdd_policy>(value);
   }
 
   zdd zdd_empty()
   {
-    return internal::build_terminal(false);
+    return internal::build_terminal<zdd_policy>(false);
   }
 
   zdd zdd_null()
   {
-    return internal::build_terminal(true);
+    return internal::build_terminal<zdd_policy>(true);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -109,7 +109,7 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_singleton(const zdd::label_t label)
   {
-    return internal::build_ithvar(label);
+    return internal::build_ithvar<zdd_policy>(label);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/zdd/build.cpp
+++ b/src/adiar/zdd/build.cpp
@@ -1,5 +1,7 @@
 #include "build.h"
 
+#include <limits>
+
 #include <adiar/zdd/zdd_policy.h>
 #include <adiar/domain.h>
 

--- a/src/adiar/zdd/build.h
+++ b/src/adiar/zdd/build.h
@@ -63,16 +63,16 @@ namespace adiar
       return zdd_empty();
     }
 
-    adiar_debug(lt_terminal_val || eq_terminal_val || gt_terminal_val,
-                "Some set size must be allowed to exist");
+    adiar_assert(lt_terminal_val || eq_terminal_val || gt_terminal_val,
+                 "Some set size must be allowed to exist");
 
     // Take care of the edge cases, where the construction below would collapse.
     if (set_size == 0) {
       if (!gt_terminal_val) { return zdd_terminal(eq_terminal_val); }
     }
 
-    adiar_debug(set_size > 0 || gt_terminal_val,
-                "Set size is only 0 if we accept a non-negative number of elements");
+    adiar_assert(set_size > 0 || gt_terminal_val,
+                 "Set size is only 0 if we accept a non-negative number of elements");
 
     if (set_size == 1) {
       if (!eq_terminal_val && !gt_terminal_val) { return zdd_null(); }
@@ -161,14 +161,14 @@ namespace adiar
           high = zdd::ptr_t(prior_label, curr_id + 1u);
         }
 
-        adiar_debug(high != zdd::ptr_t(false), "Should not create a reducible node");
+        adiar_assert(high != zdd::ptr_t(false), "Should not create a reducible node");
 
         nw.unsafe_push(zdd::node_t(curr_label, curr_id, low, high));
 
         level_size++;
       } while (curr_id-- > min_id);
 
-      adiar_debug(level_size > 0, "Should have output a node");
+      adiar_assert(level_size > 0, "Should have output a node");
       nw.unsafe_push(internal::level_info(curr_label, level_size));
 
       prior_label = curr_label;

--- a/src/adiar/zdd/complement.cpp
+++ b/src/adiar/zdd/complement.cpp
@@ -2,6 +2,7 @@
 #include <adiar/zdd/zdd_policy.h>
 
 #include <adiar/domain.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/algorithms/build.h>
 #include <adiar/internal/algorithms/intercut.h>
 #include <adiar/internal/data_types/uid.h>

--- a/src/adiar/zdd/complement.cpp
+++ b/src/adiar/zdd/complement.cpp
@@ -33,7 +33,7 @@ namespace adiar
       make_node(const zdd::label_t &l, const zdd::ptr_t &r) const
       {
         if (r.is_terminal()) {
-          adiar_debug(r.value() == false, "Root should be Ø");
+          adiar_assert(r.value() == false, "Root should be Ø");
           return zdd::node_t(l, zdd::MAX_ID, r, zdd_policy::ptr_t(true));
         } else {
           return zdd::node_t(l, zdd::MAX_ID, r, r);

--- a/src/adiar/zdd/elem.cpp
+++ b/src/adiar/zdd/elem.cpp
@@ -60,7 +60,7 @@ namespace adiar
 
     zdd::ptr_t visit(const zdd::node_t n)
     {
-      adiar_debug(!n.high().is_terminal() || n.high().value(), "high terminals are never false");
+      adiar_assert(!n.high().is_terminal() || n.high().value(), "high terminals are never false");
       const zdd::ptr_t next_ptr = _visitor.visit(n);
 
       if (next_ptr == n.high() && (next_ptr != n.low() || visitor_t::default_direction)) {

--- a/src/adiar/zdd/expand.cpp
+++ b/src/adiar/zdd/expand.cpp
@@ -1,6 +1,7 @@
 #include <adiar/zdd.h>
 #include <adiar/zdd/zdd_policy.h>
 
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/algorithms/intercut.h>
 #include <adiar/internal/data_types/node.h>
 

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -21,8 +21,8 @@ namespace adiar
 
       // Return the True terminal if any (including its tainting flags).
       if (r.low().is_terminal() && r.high().is_terminal()) {
-        adiar_debug(r.low().value() || r.high().value(),
-                    "At least one of the terminals should be True in a ZDD");
+        adiar_assert(r.low().value() || r.high().value(),
+                     "At least one of the terminals should be True in a ZDD");
 
         return r.low().value() ? r.low() : r.high();
       }

--- a/src/adiar/zdd/subset.cpp
+++ b/src/adiar/zdd/subset.cpp
@@ -2,6 +2,7 @@
 #include <adiar/zdd/zdd_policy.h>
 
 #include <adiar/internal/assert.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/util.h>
 #include <adiar/internal/algorithms/substitution.h>
 #include <adiar/internal/io/file_stream.h>

--- a/src/adiar/zdd/subset.cpp
+++ b/src/adiar/zdd/subset.cpp
@@ -30,8 +30,8 @@ namespace adiar
 
   private:
     inline void forward_to_level(const zdd::label_t new_level) {
-      adiar_debug(alg_level <= new_level,
-                  "The algorithm should ask for the levels in increasing order.");
+      adiar_assert(alg_level <= new_level,
+                   "The algorithm should ask for the levels in increasing order.");
 
       alg_level = new_level;
 

--- a/test/adiar/bdd/test_apply.cpp
+++ b/test/adiar/bdd/test_apply.cpp
@@ -158,8 +158,8 @@ go_bandit([]() {
       nw_t << nt_5 << nt_4 << nt_3 << nt_2 << nt_1;
     }
 
-    adiar_assert(bdd_thin->canonical == true, "Input validation failed");
-    adiar_assert(bdd_thin->width == 2u, "Input validation failed");
+    AssertThat(bdd_thin->canonical, Is().EqualTo(true));
+    AssertThat(bdd_thin->width, Is().EqualTo(2u));
 
     shared_levelized_file<bdd::node_t> bdd_wide;
     /*
@@ -188,8 +188,8 @@ go_bandit([]() {
       nw_w << nw_7 << nw_6 << nw_5 << nw_4 << nw_3 << nw_2 << nw_1;
     }
 
-    adiar_assert(bdd_wide->canonical == true, "Input validation failed");
-    adiar_assert(bdd_wide->width == 3u, "Input validation failed");
+    // bdd_wide->canonical == true
+    // bdd_wide->width == 3u
 
     shared_levelized_file<bdd::node_t> bdd_canon;
     /*
@@ -220,8 +220,8 @@ go_bandit([]() {
       nw_c << nc_9 << nc_8 << nc_7 << nc_6 << nc_5 << nc_4 << nc_3 << nc_2 << nc_1;
     }
 
-    adiar_assert(bdd_canon->canonical == true, "Input validation failed");
-    adiar_assert(bdd_canon->width == 4u, "Input validation failed");
+    // bdd_canon->canonical == true
+    // bdd_canon->width == 4u
 
     shared_levelized_file<bdd::node_t> bdd_non_canon;
     /*
@@ -250,8 +250,8 @@ go_bandit([]() {
       nw_n << nn_7 << nn_6 << nn_5 << nn_4 << nn_3 << nn_2 << nn_1;
     }
 
-    adiar_assert(bdd_non_canon->canonical == false, "Input validation failed");
-    adiar_assert(bdd_non_canon->width == 3u, "Input validation failed");
+    // bdd_non_canon->canonical == false
+    // bdd_non_canon->width == 3u
 
     describe("simple cases without access mode requirements", [&]() {
       // Cases with the same file (same DAG) or at least one terminal does not need to run complicated algorithm

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -5,7 +5,7 @@ go_bandit([]() {
     ptr_uint64 terminal_T = ptr_uint64(true);
     ptr_uint64 terminal_F = ptr_uint64(false);
 
-    describe("bdd_terminal", [&]() {
+    describe("bdd_terminal(v)", [&]() {
       it("can create true terminal [bdd_terminal]", [&]() {
         bdd res = bdd_terminal(true);
         node_test_stream ns(res);
@@ -123,7 +123,7 @@ go_bandit([]() {
       });
     });
 
-    describe("bdd_ithvar", [&]() {
+    describe("bdd_ithvar(i)", [&]() {
       it("can create x0", [&]() {
         bdd res = bdd_ithvar(0);
         node_test_stream ns(res);
@@ -187,9 +187,13 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
       });
+
+      it("throws exception for a too large label", []() {
+        AssertThrows(invalid_argument, bdd_nithvar(bdd::MAX_LABEL+1));
+      });
     });
 
-    describe("bdd_nithvar", [&]() {
+    describe("bdd_nithvar(i)", [&]() {
       it("can create !x1", [&]() {
         bdd res = bdd_nithvar(1);
         node_test_stream ns(res);
@@ -253,9 +257,13 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
       });
+
+      it("throws exception for a too large label", []() {
+        AssertThrows(invalid_argument, bdd_nithvar(bdd::MAX_LABEL+1));
+      });
     });
 
-    describe("bdd_and", [&]() {
+    describe("bdd_and(vars)", [&]() {
       it("can create {x1, x2, x5}", [&]() {
         adiar::shared_file<bdd::label_t> labels;
 
@@ -345,9 +353,20 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(0u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
       });
+
+      it("throws exception for non-ascending list", []() {
+        adiar::shared_file<bdd::label_t> labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 2 << 2;
+        }
+
+        AssertThrows(invalid_argument, bdd_and(labels));
+      });
     });
 
-    describe("bdd_or", [&]() {
+    describe("bdd_or(vars)", [&]() {
       it("can create {x1, x2, x5}", [&]() {
         adiar::shared_file<bdd::label_t> labels;
 
@@ -432,9 +451,20 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(0u));
       });
+
+      it("throws exception for non-ascending list", []() {
+        adiar::shared_file<bdd::label_t> labels;
+
+        { // Garbage collect writer to free write-lock
+          label_writer lw(labels);
+          lw << 2 << 2;
+        }
+
+        AssertThrows(invalid_argument, bdd_or(labels));
+      });
     });
 
-    describe("bdd_counter", [&]() {
+    describe("bdd_counter(min_var, max_var, threshold)", [&]() {
       it("collapses to trivially true for empty interval [4,2]", [&]() {
         bdd res = bdd_counter(4, 2, 10);
 

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -435,6 +435,34 @@ go_bandit([]() {
     });
 
     describe("bdd_counter", [&]() {
+      it("collapses to trivially true for empty interval [4,2]", [&]() {
+        bdd res = bdd_counter(4, 2, 10);
+
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(true)));
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream ms(res);
+        AssertThat(ms.can_pull(), Is().False());
+
+        AssertThat(res->width, Is().EqualTo(0u));
+
+        AssertThat(res->max_1level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(res->max_1level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(res->max_1level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(res->max_1level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(res->max_2level_cut[cut_type::INTERNAL], Is().EqualTo(0u));
+        AssertThat(res->max_2level_cut[cut_type::INTERNAL_FALSE], Is().EqualTo(0u));
+        AssertThat(res->max_2level_cut[cut_type::INTERNAL_TRUE], Is().EqualTo(1u));
+        AssertThat(res->max_2level_cut[cut_type::ALL], Is().EqualTo(1u));
+
+        AssertThat(res->number_of_terminals[false], Is().EqualTo(0u));
+        AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
+      });
+
       it("collapses impossible counting to 10 in [0,8] to F", [&]() {
         bdd res = bdd_counter(0, 8, 10);
 

--- a/test/adiar/bdd/test_count.cpp
+++ b/test/adiar/bdd/test_count.cpp
@@ -241,6 +241,22 @@ go_bandit([]() {
         AssertThat(bdd_satcount(bdd_not(bdd_F), 3), Is().EqualTo(8u));
         AssertThat(bdd_satcount(bdd_not(bdd_F), 2), Is().EqualTo(4u));
       });
+
+      it("throws exception on varcount being smaller than the number of levels [1]", [&]() {
+        AssertThrows(invalid_argument, bdd_satcount(bdd_1, 3));
+      });
+
+      it("throws exception on varcount being smaller than the number of levels [2]", [&]() {
+        AssertThrows(invalid_argument, bdd_satcount(bdd_2, 1));
+      });
+
+      it("throws exception on varcount being smaller than the number of levels [3]", [&]() {
+        AssertThrows(invalid_argument, bdd_satcount(bdd_3, 1));
+      });
+
+      it("throws exception on varcount being smaller than the number of levels [4]", [&]() {
+        AssertThrows(invalid_argument, bdd_satcount(bdd_4, 3));
+      });
     });
 
     describe("bdd_satcount(f) [empty dom]", [&]() {

--- a/test/adiar/bdd/test_evaluate.cpp
+++ b/test/adiar/bdd/test_evaluate.cpp
@@ -287,6 +287,53 @@ go_bandit([]() {
 
           AssertThat(bdd_eval(bdd_T, ass), Is().True());
         });
+
+        it("throws exception when given non-ascending list of assignments", [&]() {
+          adiar::shared_file<map_pair<bdd::label_t, boolean>> ass;
+
+          { // Garbage collect writer to free write-lock
+            adiar::file_writer<map_pair<bdd::label_t, boolean>> aw(ass);
+
+            aw << map_pair<bdd::label_t, boolean>(0, true)
+               << map_pair<bdd::label_t, boolean>(2, true)
+               << map_pair<bdd::label_t, boolean>(1, true)
+               << map_pair<bdd::label_t, boolean>(3, true)
+               << map_pair<bdd::label_t, boolean>(4, true)
+              ;
+          }
+
+          AssertThrows(invalid_argument, bdd_eval(skip_bdd, ass));
+        });
+
+        it("throws exception when running out of assignments", [&]() {
+          adiar::shared_file<map_pair<bdd::label_t, boolean>> ass;
+
+          { // Garbage collect writer to free write-lock
+            adiar::file_writer<map_pair<bdd::label_t, boolean>> aw(ass);
+
+            aw << map_pair<bdd::label_t, boolean>(0, true)
+               << map_pair<bdd::label_t, boolean>(1, true)
+              ;
+          }
+
+          AssertThrows(out_of_range, bdd_eval(skip_bdd, ass));
+        });
+
+        it("throws exception when list is missing a needed assignment", [&]() {
+          adiar::shared_file<map_pair<bdd::label_t, boolean>> ass;
+
+          { // Garbage collect writer to free write-lock
+            adiar::file_writer<map_pair<bdd::label_t, boolean>> aw(ass);
+
+            aw << map_pair<bdd::label_t, boolean>(0, true)
+               << map_pair<bdd::label_t, boolean>(1, true)
+               << map_pair<bdd::label_t, boolean>(3, true)
+               << map_pair<bdd::label_t, boolean>(4, true)
+              ;
+          }
+
+          AssertThrows(invalid_argument, bdd_eval(skip_bdd, ass));
+        });
       });
 
       describe("bdd_eval(bdd, std::function<...>)", [&]() {

--- a/test/adiar/internal/algorithms/test_nested_sweeping.cpp
+++ b/test/adiar/internal/algorithms/test_nested_sweeping.cpp
@@ -83,8 +83,8 @@ public:
         const node::uid_t u(level_label, level_size++);
 
         // Get target of next request
-        adiar_debug(!inner_pq.top().target.first().is_flagged(),
-                    "Double checking decorator indeed hides taint");
+        adiar_assert(!inner_pq.top().target.first().is_flagged(),
+                     "Double checking decorator indeed hides taint");
 
         const node::ptr_t next = inner_pq.top().target.first();
 

--- a/test/adiar/internal/data_types/test_uid.cpp
+++ b/test/adiar/internal/data_types/test_uid.cpp
@@ -60,18 +60,6 @@ go_bandit([]() {
       });
     });
 
-    describe("NIL", [&](){
-#ifndef NDEBUG
-      it("throws 'std::illegal_argument' when given NIL [unflagged]", [&]() {
-        AssertThrows(std::invalid_argument, uid_uint64(ptr_uint64::NIL()));
-      });
-
-      it("throws 'std::illegal_argument' when given NIL [flagged]", [&]() {
-        AssertThrows(std::invalid_argument, uid_uint64(flag(ptr_uint64::NIL())));
-      });
-#endif
-    });
-
     describe("terminals", [&](){
       it("should take up 8 bytes of memory", [&]() {
         AssertThat(sizeof(uid_uint64(false)), Is().EqualTo(8u));

--- a/test/adiar/internal/io/test_file.cpp
+++ b/test/adiar/internal/io/test_file.cpp
@@ -95,7 +95,7 @@ go_bandit([]() {
         f2.touch();
 
         AssertThat(f1.can_move(), Is().True());
-        AssertThrows(std::runtime_error, f1.move(f2.path()));
+        AssertThrows(runtime_error, f1.move(f2.path()));
       });
 
       it("can be 'moved' when existing [/tmp/]", [&tmp_path]() {
@@ -706,7 +706,7 @@ go_bandit([]() {
 
     describe("file(path)", []() {
       it("throws exception on path to non-existing file", []() {
-        AssertThrows(std::runtime_error,
+        AssertThrows(runtime_error,
                      file<int>("./non-existing-file.adiar"));
       });
 
@@ -755,7 +755,7 @@ go_bandit([]() {
         std::string old_path = f.path();
 
         AssertThat(f.can_move(), Is().False());
-        AssertThrows(std::runtime_error, f.move(new_path));
+        AssertThrows(runtime_error, f.move(new_path));
       });
 
       // Clean up for above tests
@@ -842,7 +842,7 @@ go_bandit([]() {
       it("cannot reattach a writer to a persisted file", [&path]() {
         file<int> f(path);
         adiar::file_writer<int> fw;
-        AssertThrows(std::runtime_error, fw.attach(f));
+        AssertThrows(runtime_error, fw.attach(f));
       });
 
       // Clean up for above tests
@@ -935,7 +935,7 @@ go_bandit([]() {
           f.make_persistent();
           AssertThat(std::filesystem::exists(path), Is().True());
 
-          AssertThrows(std::runtime_error, f.sort<std::less<int>>());
+          AssertThrows(runtime_error, f.sort<std::less<int>>());
         }
         AssertThat(std::filesystem::exists(path), Is().True());
 
@@ -957,7 +957,7 @@ go_bandit([]() {
           f.make_persistent();
           AssertThat(std::filesystem::exists(path), Is().True());
 
-          AssertThrows(std::runtime_error, f.sort<std::less<int>>());
+          AssertThrows(runtime_error, f.sort<std::less<int>>());
         }
         AssertThat(std::filesystem::exists(path), Is().True());
 

--- a/test/adiar/internal/io/test_levelized_file.cpp
+++ b/test/adiar/internal/io/test_levelized_file.cpp
@@ -371,7 +371,7 @@ go_bandit([]() {
 
           levelized_file<int> lf;
 
-          AssertThrows(std::runtime_error, lf.move(path_prefix));
+          AssertThrows(runtime_error, lf.move(path_prefix));
         }
 
         // Clean up of this test
@@ -400,7 +400,7 @@ go_bandit([]() {
 
         levelized_file<int> lf2;
 
-        AssertThrows(std::runtime_error, lf2.move(path_prefix));
+        AssertThrows(runtime_error, lf2.move(path_prefix));
       });
 
       it("can be made persistent (not removed from disk)", [&curr_path]() {
@@ -496,7 +496,7 @@ go_bandit([]() {
         {
           levelized_file<int> lf;
           lf.make_persistent(path_prefix);
-          AssertThrows(std::runtime_error, lf.move(path_prefix));
+          AssertThrows(runtime_error, lf.move(path_prefix));
         }
 
         // Clean up for this test
@@ -987,7 +987,7 @@ go_bandit([]() {
     describe("levelized_file(path_prefix)", [&tmp_path, &curr_path]() {
       it("throws exception on path-prefix to completely non-existing files", [&curr_path]() {
         const std::string path_prefix = curr_path + "non-existing-prefix.adiar";
-        AssertThrows(std::runtime_error, levelized_file<int>(path_prefix));
+        AssertThrows(runtime_error, levelized_file<int>(path_prefix));
       });
 
 
@@ -1015,7 +1015,7 @@ go_bandit([]() {
           f_levels.make_persistent();
         }
 
-        AssertThrows(std::runtime_error, levelized_file<int>(path_prefix));
+        AssertThrows(runtime_error, levelized_file<int>(path_prefix));
 
         // Cleanup after this test
         if (std::filesystem::exists(path_prefix+".file_1"))
@@ -1048,7 +1048,7 @@ go_bandit([]() {
           f_levels.make_persistent();
         }
 
-        AssertThrows(std::runtime_error, levelized_file<int>(path_prefix));
+        AssertThrows(runtime_error, levelized_file<int>(path_prefix));
 
         // Cleanup after this test
         if (std::filesystem::exists(path_prefix+".file_0"))
@@ -1081,7 +1081,7 @@ go_bandit([]() {
             std::filesystem::remove(path_prefix+".levels");
         }
 
-        AssertThrows(std::runtime_error, levelized_file<int>(path_prefix));
+        AssertThrows(runtime_error, levelized_file<int>(path_prefix));
 
         // Cleanup after this test
         if (std::filesystem::exists(path_prefix+".file_0"))
@@ -1239,7 +1239,7 @@ go_bandit([]() {
       it("cannot reattach a writer to a persisted file", [&path_prefix]() {
         levelized_file<int> lf(path_prefix);
         levelized_file_writer<int> lfw;
-        AssertThrows(std::runtime_error, lfw.attach(lf));
+        AssertThrows(runtime_error, lfw.attach(lf));
       });
 
       it("is unchanged after marking it persistent once more", [&path_prefix]() {
@@ -1261,7 +1261,7 @@ go_bandit([]() {
         lf.make_persistent();
 
         AssertThat(lf.can_move(), Is().False());
-        AssertThrows(std::runtime_error, lf.move(tmp_path+"alternative-prefix.adiar"));
+        AssertThrows(runtime_error, lf.move(tmp_path+"alternative-prefix.adiar"));
       });
 
       // TODO: test data is persisted.
@@ -1302,7 +1302,7 @@ go_bandit([]() {
         levelized_file<int> lf;
         lf.touch();
 
-        AssertThrows(std::out_of_range, lf.sort<std::less<int>>(2));
+        AssertThrows(out_of_range, lf.sort<std::less<int>>(2));
       });
 
       it("can sort a temporary non-empty file", []() {
@@ -1412,8 +1412,8 @@ go_bandit([]() {
           levelized_file<int> lf;
           lf.make_persistent(path_prefix);
 
-          AssertThrows(std::runtime_error, lf.sort<std::less<int>>(0));
-          AssertThrows(std::runtime_error, lf.sort<std::less<int>>(1));
+          AssertThrows(runtime_error, lf.sort<std::less<int>>(0));
+          AssertThrows(runtime_error, lf.sort<std::less<int>>(1));
         }
         AssertThat(std::filesystem::exists(path_prefix+".file_0"), Is().True());
         std::filesystem::remove(path_prefix+".file_0");
@@ -1455,8 +1455,8 @@ go_bandit([]() {
 
         { // Try to sort it
           levelized_file<int> lf(path_prefix);
-          AssertThrows(std::runtime_error, lf.sort<std::less<int>>(0));
-          AssertThrows(std::runtime_error, lf.sort<std::less<int>>(1));
+          AssertThrows(runtime_error, lf.sort<std::less<int>>(0));
+          AssertThrows(runtime_error, lf.sort<std::less<int>>(1));
         }
 
         { // Check content is not sorted

--- a/test/adiar/test_builder.cpp
+++ b/test/adiar/test_builder.cpp
@@ -164,7 +164,7 @@ go_bandit([]() {
     it("throws an exception when create is called on an empty file", [&]() {
       bdd_builder b;
 
-      AssertThrows(std::domain_error, b.build());
+      AssertThrows(domain_error, b.build());
     });
 
     it("throws an exception when calling create a second time with no new nodes in between", [&]() {
@@ -173,7 +173,7 @@ go_bandit([]() {
       b.add_node(0,false,true);
       b.build();
 
-      AssertThrows(std::domain_error, b.build());
+      AssertThrows(domain_error, b.build());
     });
 
     it("can create a single-node BDD", [&]() {
@@ -232,7 +232,7 @@ go_bandit([]() {
 
       builder_ptr p = b1.add_node(true);
 
-      AssertThrows(std::invalid_argument, b2.add_node(0,false,p));
+      AssertThrows(invalid_argument, b2.add_node(0,false,p));
     });
 
     it("throws an exception if pointers are used from a different builder [2]", [&]() {
@@ -241,7 +241,7 @@ go_bandit([]() {
 
       builder_ptr p = b1.add_node(1,true,false);
 
-      AssertThrows(std::invalid_argument, b2.add_node(0,p,false));
+      AssertThrows(invalid_argument, b2.add_node(0,p,false));
     });
 
     it("throws an exception if pointers are used after reset", [&]() {
@@ -250,7 +250,7 @@ go_bandit([]() {
       builder_ptr p = b.add_node(1,true,false);
       b.clear();
 
-      AssertThrows(std::invalid_argument, b.add_node(0,p,false));
+      AssertThrows(invalid_argument, b.add_node(0,p,false));
     });
 
     it("throws an exception if pointers are used after create", [&]() {
@@ -259,13 +259,13 @@ go_bandit([]() {
       builder_ptr p = b.add_node(1,true,false);
       b.build();
 
-      AssertThrows(std::invalid_argument, b.add_node(0,p,false));
+      AssertThrows(invalid_argument, b.add_node(0,p,false));
     });
 
     it("throws an exception when label > MAX_LABEL", [&]() {
       bdd_builder b;
 
-      AssertThrows(std::invalid_argument, b.add_node(node::MAX_LABEL + 1,false,true));
+      AssertThrows(invalid_argument, b.add_node(node::MAX_LABEL + 1,false,true));
     });
 
     it("throws an exception when label > last label", [&]() {
@@ -273,7 +273,7 @@ go_bandit([]() {
 
       b.add_node(0,false,true);
 
-      AssertThrows(std::invalid_argument, b.add_node(1,false,true));
+      AssertThrows(invalid_argument, b.add_node(1,false,true));
     });
 
     it("throws an exception when low.label() >= label [1]", [&]() {
@@ -281,7 +281,7 @@ go_bandit([]() {
 
       const bdd_ptr p = b.add_node(0,false,true);
 
-      AssertThrows(std::invalid_argument, b.add_node(0,p,true));
+      AssertThrows(invalid_argument, b.add_node(0,p,true));
     });
 
     it("throws an exception when low.label() >= label [2]", [&]() {
@@ -289,7 +289,7 @@ go_bandit([]() {
 
       const bdd_ptr p = b.add_node(3,false,true);
 
-      AssertThrows(std::invalid_argument, b.add_node(3,p,true));
+      AssertThrows(invalid_argument, b.add_node(3,p,true));
     });
 
     it("throws an exception when high.label() >= label [1]", [&]() {
@@ -297,7 +297,7 @@ go_bandit([]() {
 
       const bdd_ptr p = b.add_node(0,false,true);
 
-      AssertThrows(std::invalid_argument, b.add_node(0,false,p));
+      AssertThrows(invalid_argument, b.add_node(0,false,p));
     });
 
     it("throws an exception when high.label() >= label [2]", [&]() {
@@ -305,7 +305,7 @@ go_bandit([]() {
 
       const bdd_ptr p = b.add_node(6,false,true);
 
-      AssertThrows(std::invalid_argument, b.add_node(6,false,p));
+      AssertThrows(invalid_argument, b.add_node(6,false,p));
     });
 
     it("can create nodes on different levels", [&]() {
@@ -524,7 +524,7 @@ go_bandit([]() {
 
       b.clear();
 
-      AssertThrows(std::domain_error, b.build());
+      AssertThrows(domain_error, b.build());
     });
 
     it("can create two different BDDs", [&]() {
@@ -620,7 +620,7 @@ go_bandit([]() {
       b.add_node(0,false,true);
       b.add_node(0,true,false);
 
-      AssertThrows(std::domain_error, b.build());
+      AssertThrows(domain_error, b.build());
     });
 
     it("throws an exception when there is more than one root [2]", [&]() {
@@ -629,7 +629,7 @@ go_bandit([]() {
       b.add_node(4,false,true);
       b.add_node(2,true,false);
 
-      AssertThrows(std::domain_error, b.build());
+      AssertThrows(domain_error, b.build());
     });
 
     it("throws an exception when there is more than one root [3]", [&]() {
@@ -641,7 +641,7 @@ go_bandit([]() {
       const bdd_ptr p2 = b.add_node(2,p3,p4);
       const bdd_ptr p1 = b.add_node(1,p3,p5);
 
-      AssertThrows(std::domain_error, b.build());
+      AssertThrows(domain_error, b.build());
     });
 
     it("recognizes copies of nodes", [&]() {
@@ -1009,7 +1009,7 @@ go_bandit([]() {
         const bdd_ptr p1 = b.add_node(1,p3,p4); // root
         const bdd_ptr p0 = b.add_node(0,p2,p2); // root
 
-        AssertThrows(std::domain_error, b.build());
+        AssertThrows(domain_error, b.build());
       });
     });
 
@@ -1216,7 +1216,7 @@ go_bandit([]() {
         const zdd_ptr p1 = b.add_node(1,p3,p4);    // root
         const zdd_ptr p0 = b.add_node(0,p2,false); // root
 
-        AssertThrows(std::domain_error, b.build());
+        AssertThrows(domain_error, b.build());
       });
     });
   });

--- a/test/adiar/test_domain.cpp
+++ b/test/adiar/test_domain.cpp
@@ -7,7 +7,7 @@ go_bandit([]() {
     describe("adiar_has_domain(), adiar_get_domain()", []() {
       it("throws exception when getting missing domain", []() {
         AssertThat(adiar_has_domain(), Is().False());
-        AssertThrows(std::domain_error, adiar_get_domain());
+        AssertThrows(domain_error, adiar_get_domain());
       });
     });
 

--- a/test/adiar/zdd/test_binop.cpp
+++ b/test/adiar/zdd/test_binop.cpp
@@ -1530,7 +1530,7 @@ go_bandit([]() {
       // Reset access mode
       access_mode = access_mode_t::AUTO;
     });
-  
+
     describe("access mode: random access", [&]() {
       // Set access mode to random access for this batch of tests
       access_mode = access_mode_t::RA;
@@ -1553,7 +1553,7 @@ go_bandit([]() {
 
             /*
             // Result of { {0} } U { Ø, {0} }
-            // 
+            //
             //                      (1,1)                   ---- x0
             //                      /   \
             //                  (F,T)   (T,T)
@@ -1630,7 +1630,7 @@ go_bandit([]() {
           AssertThat(out.get<__zdd::shared_arcs_t>()->number_of_terminals[false], Is().EqualTo(1u));
           AssertThat(out.get<__zdd::shared_arcs_t>()->number_of_terminals[true],  Is().EqualTo(2u));
         });
-        
+
         it("computes { {1} } U { {0} } (different levels, random access for second level)", [&]() {
           /*
           //             1     ---- x0
@@ -1702,8 +1702,8 @@ go_bandit([]() {
           nw_t << nt_5 << nt_4 << nt_3 << nt_2 << nt_1;
         }
 
-        adiar_assert(zdd_thin->canonical == true, "Input validation failed");
-        adiar_assert(zdd_thin->width == 2u, "Input validation failed");
+        // zdd_thin->canonical == true
+        // zdd_thin->width == 2u
 
         shared_levelized_file<zdd::node_t> zdd_wide;
         /*
@@ -1720,7 +1720,7 @@ go_bandit([]() {
         //            / \
         //            F T
         */
-        
+
         node nw_7 = node(3, node::MAX_ID, terminal_F, terminal_T);
         node nw_6 = node(2, node::MAX_ID, terminal_T, terminal_T);
         node nw_5 = node(2, node::MAX_ID - 1, terminal_F, terminal_T);
@@ -1734,12 +1734,12 @@ go_bandit([]() {
           nw_w << nw_7 << nw_6 << nw_5 << nw_4 << nw_3 << nw_2 << nw_1;
         }
 
-        adiar_assert(zdd_wide->canonical == true, "Input validation failed");
-        adiar_assert(zdd_wide->width == 3u, "Input validation failed");
-        
+        // zdd_wide->canonical == true
+        // zdd_wide->width == 3u
+
         /*
         // Result of [thin] U [wide]
-        // 
+        //
         //                      (1,1)                   ---- x0
         //                      /   \
         //                  (2,2)   (3,3)               ---- x1
@@ -1913,7 +1913,7 @@ go_bandit([]() {
         //         / \  / \
         //         F T  T T
         */
-        
+
         node nc_9 = node(3, node::MAX_ID, terminal_T, terminal_T);
         node nc_8 = node(3, node::MAX_ID - 1, terminal_F, terminal_T);
         node nc_7 = node(2, node::MAX_ID, terminal_T, terminal_T);
@@ -1929,9 +1929,9 @@ go_bandit([]() {
           nw_c << nc_9 << nc_8 << nc_7 << nc_6 << nc_5 << nc_4 << nc_3 << nc_2 << nc_1;
         }
 
-        adiar_assert(zdd_canon->canonical == true, "Input validation failed");
-        adiar_assert(zdd_canon->width == 4u, "Input validation failed");
-        
+        // zdd_canon->canonical == true
+        // zdd_canon->width == 4u
+
         shared_levelized_file<zdd::node_t> zdd_non_canon;
         /*
         //  { {0}, {2}, {0, 2}, {1, 3}, {1, 2}, {0, 1, 2} }
@@ -1961,9 +1961,9 @@ go_bandit([]() {
           nw_n << nn_7 << nn_6 << nn_5 << nn_4 << nn_3 << nn_2 << nn_1;
         }
 
-        adiar_assert(zdd_non_canon->canonical == false, "Input validation failed");
-        adiar_assert(zdd_non_canon->width == 3u, "Input validation failed");
-        
+        // zdd_non_canon->canonical == false
+        // zdd_non_canon->width == 3u
+
         /*
         // Result of [canon] U [non_canon]
         //
@@ -1973,7 +1973,7 @@ go_bandit([]() {
         //              (2,2)                 (3,3)                   ---- x1
         //              /   \________ __________X
         //            _/          ___X___        \___
-        //           /           /       \           \ 
+        //           /           /       \           \
         //       (4,4)       (7,4)       (6,5)       (5,6)            ---- x2
         //       /   \       /   \       /   \       /   \
         //    (F,F) (8,T) (T,F) (T,T) (F,7) (T,T) (F,T) (9,T)         ---- x3
@@ -2170,8 +2170,8 @@ go_bandit([]() {
             //               2 T      | |                    (2,2)   \       ---- x1
             //              / \       | |                    /   \    |
             //              3  \      | |     ==>         (3,2)   \   |      ---- x2
-            //              || |      | |                 /   \____\ /  
-            //              \\ /      \ /                /          X   
+            //              || |      | |                 /   \____\ /
+            //              \\ /      \ /                /          X
             //                4        2              (4,2)    (T,2) (4,F)   ---- x3
             //               / \      / \              / \      / \   / \
             //               F T      F T              F T      T T   T T
@@ -2199,11 +2199,11 @@ go_bandit([]() {
                 ;
             }
 
-            adiar_assert(zdd_a->width == 1u, "Input validation failed");
-            adiar_assert(zdd_a->canonical == true, "Input validation failed");
+            // zdd_a->width == 1u
+            // zdd_a->canonical == true
 
-            adiar_assert(zdd_b->width == 1u, "Input validation failed");
-            adiar_assert(zdd_b->canonical == true, "Input validation failed");
+            // zdd_b->width == 1u
+            // zdd_b->canonical == true
 
             __zdd out = zdd_union(zdd_a, zdd_b);
 
@@ -2220,7 +2220,7 @@ go_bandit([]() {
 
             AssertThat(arcs.can_pull_internal(), Is().True());
             AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,1) }));
-            
+
             AssertThat(arcs.can_pull_internal(), Is().True());
             AssertThat(arcs.pull_internal(), Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(3,2) }));
 
@@ -2288,8 +2288,8 @@ go_bandit([]() {
               nw_a << na_2 << na_1;
             }
 
-            adiar_assert(zdd_a->width == 1u, "Input validation failed");
-            adiar_assert(zdd_a->canonical == true, "Input validation failed");
+            // zdd_a->width == 1u
+            // zdd_a->canonical == true
 
             shared_levelized_file<zdd::node_t> zdd_b;
             /*
@@ -2311,8 +2311,8 @@ go_bandit([]() {
               nw_b << nb_3 << nb_2 << nb_1;
             }
 
-            adiar_assert(zdd_b->width == 2u, "Input validation failed");
-            adiar_assert(zdd_b->canonical == true, "Input validation failed");
+            // zdd_b->width == 2u
+            // zdd_b->canonical == true
 
             /*
             //    { {0}, {1} } U { {0}, {1}, {0, 1} }
@@ -2321,7 +2321,7 @@ go_bandit([]() {
             //                 /   \
             //             (2,2)    (T,3)         ---- x1
             //             /   \    /   \
-            //         (F,F)    (T,T)   (F,T)   
+            //         (F,F)    (T,T)   (F,T)
             */
 
             __zdd out = zdd_union(zdd_a, zdd_b);
@@ -2389,8 +2389,8 @@ go_bandit([]() {
               nw_a << na_3 << na_2 << na_1;
             }
 
-            adiar_assert(zdd_a->width == 1u, "Input validation failed");
-            adiar_assert(zdd_a->canonical == true, "Input validation failed");
+            // zdd_a->width == 1u
+            // zdd_a->canonical == true
 
             shared_levelized_file<zdd::node_t> zdd_b;
             /*
@@ -2412,8 +2412,8 @@ go_bandit([]() {
               nw_b << nb_3 << nb_2 << nb_1;
             }
 
-            adiar_assert(zdd_b->width == 2u, "Input validation failed");
-            adiar_assert(zdd_b->canonical == true, "Input validation failed");
+            // zdd_b->width == 2u
+            // zdd_b->canonical == true
 
             /*
             //    { {0}, {1}, {0, 3} } U { {0}, {1}, {0, 1} }
@@ -2424,8 +2424,8 @@ go_bandit([]() {
             //          (2,2)         (3,3)        ---- x1
             //          /   \         /   \
             //       (F,F) (T,T)   (3,T) (F,T)     ---- x2
-            //                      | |   
-            //                     (T,T)   
+            //                      | |
+            //                     (T,T)
             */
 
             __zdd out = zdd_union(zdd_a, zdd_b);
@@ -2479,7 +2479,7 @@ go_bandit([]() {
             AssertThat(out.get<__zdd::shared_arcs_t>()->number_of_terminals[true],  Is().EqualTo(4u));
         });
       });
-      
+
       describe("zdd_intsec", [&]() {
         it("should shortcircuit intermediate nodes", [&]() {
             shared_levelized_file<zdd::node_t> zdd_a;
@@ -2505,8 +2505,8 @@ go_bandit([]() {
               nw_a << na_4 << na_3 << na_2 << na_1;
             }
 
-            adiar_assert(zdd_a->canonical == true, "Input validation failed");
-            adiar_assert(zdd_a->width == 2u, "Input validation failed");
+            // zdd_a->canonical == true
+            // zdd_a->width == 2u
 
             shared_levelized_file<zdd::node_t> zdd_b;
             /*
@@ -2530,12 +2530,12 @@ go_bandit([]() {
               nw_b << nb_3 << nb_2 << nb_1;
             }
 
-            adiar_assert(zdd_b->canonical == true, "Input validation failed");
-            adiar_assert(zdd_b->width == 1u, "Input validation failed");
-            
+            // zdd_b->canonical == true
+            // zdd_b->width == 1u
+
             /*
             // Result of { {0, 1}, {0, 2}, {0, 1, 2} } ∩ { {1, 2}, {0, 1, 2} }
-            // 
+            //
             //                  (1,1)               ---- x0
             //                  /   \
             //             (F,2)     (2,2)          ---- x1
@@ -2612,8 +2612,8 @@ go_bandit([]() {
               nw_a << na_2 << na_1;
             }
 
-            adiar_assert(zdd_a->canonical == true, "Input validation failed");
-            adiar_assert(zdd_a->width == 1u, "Input validation failed");
+            // zdd_a->canonical == true
+            // zdd_a->width == 1u
 
             shared_levelized_file<zdd::node_t> zdd_b;
             /*
@@ -2631,12 +2631,12 @@ go_bandit([]() {
               nw_b << nb_1;
             }
 
-            adiar_assert(zdd_b->canonical == true, "Input validation failed");
-            adiar_assert(zdd_b->width == 1u, "Input validation failed");
-            
+            // zdd_b->canonical == true
+            // zdd_b->width == 1u
+
             /*
             // Result of { {0}, {1} } ∩ { Ø, {0} }
-            // 
+            //
             //                  (1,1)               ---- x0
             //                  /   \
             //             (2,T)     (T,T)          ---- x1
@@ -2704,8 +2704,8 @@ go_bandit([]() {
               nw_a << na_3 << na_2 << na_1;
             }
 
-            adiar_assert(zdd_a->canonical == false, "Input validation failed");
-            adiar_assert(zdd_a->width == 2u, "Input validation failed");
+            // zdd_a->canonical == false
+            // zdd_a->width == 2u
 
             shared_levelized_file<zdd::node_t> zdd_b;
             /*
@@ -2727,12 +2727,12 @@ go_bandit([]() {
               nw_b << nb_3 << nb_2 << nb_1;
             }
 
-            adiar_assert(zdd_b->canonical == true, "Input validation failed");
-            adiar_assert(zdd_b->width == 2u, "Input validation failed");
-            
+            // zdd_b->canonical == true
+            // zdd_b->width == 2u
+
             /*
             // Result of { Ø, {1}, {0, 1} } \ { {0}, {1}, {0, 1} }
-            // 
+            //
             //                      (1,1)               ---- x0
             //                    __/   \__
             //                   /         \

--- a/test/adiar/zdd/test_build.cpp
+++ b/test/adiar/zdd/test_build.cpp
@@ -5,7 +5,7 @@ go_bandit([]() {
     ptr_uint64 terminal_T = ptr_uint64(true);
     ptr_uint64 terminal_F = ptr_uint64(false);
 
-    describe("zdd_terminal", [&]() {
+    describe("zdd_terminal(v)", [&]() {
       it("can create { Ø } [zdd_terminal]", [&]() {
         zdd res = zdd_terminal(true);
         node_test_stream ns(res);
@@ -395,6 +395,28 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(2u));
       });
+
+      it("throws exception when domain is not in ascending order", [&]() {
+        adiar::shared_file<zdd::label_t> dom;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> dw(dom);
+          dw << 3 << 2 << 1 << 0;
+        }
+
+        AssertThrows(invalid_argument, zdd_ithvar(2, dom));
+      });
+
+      it("throws exception if domain includes too large label", [&]() {
+        adiar::shared_file<zdd::label_t> dom;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> dw(dom);
+          dw << 0 << 1 << 42 << zdd::MAX_LABEL+1;
+        }
+
+        AssertThrows(invalid_argument, zdd_ithvar(42, dom));
+      });
     });
 
     describe("zdd_ithvar(i)", [&]() {
@@ -666,6 +688,28 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(0u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(2u));
       });
+
+      it("throws exception when domain is not in ascending order", [&]() {
+        adiar::shared_file<zdd::label_t> dom;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> dw(dom);
+          dw << 3 << 2 << 1 << 0;
+        }
+
+        AssertThrows(invalid_argument, zdd_nithvar(2, dom));
+      });
+
+      it("throws exception if domain includes too large label", [&]() {
+        adiar::shared_file<zdd::label_t> dom;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> dw(dom);
+          dw << 0 << 1 << 42 << zdd::MAX_LABEL+1;
+        }
+
+        AssertThrows(invalid_argument, zdd_nithvar(42, dom));
+      });
     });
 
     describe("zdd_nithvar(i)", [&]() {
@@ -829,7 +873,7 @@ go_bandit([]() {
       });
     });
 
-    describe("zdd_vars", [&]() {
+    describe("zdd_vars(vars)", [&]() {
       it("can create { Ø } on empty list", [&]() {
         adiar::shared_file<zdd::label_t> labels;
 
@@ -949,10 +993,31 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(3u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
       });
+
+      it("throws exception when domain is not in ascending order", [&]() {
+        adiar::shared_file<zdd::label_t> vars;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> vw(vars);
+          vw << 3 << 2 << 1 << 0;
+        }
+
+        AssertThrows(invalid_argument, zdd_vars(vars));
+      });
+
+      it("throws exception if domain includes too large label", [&]() {
+        adiar::shared_file<zdd::label_t> vars;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> vw(vars);
+          vw << 0 << 1 << 42 << zdd::MAX_LABEL+1;
+        }
+
+        AssertThrows(invalid_argument, zdd_vars(vars));
+      });
     });
 
-
-    describe("zdd_singleton", [&]() {
+    describe("zdd_singleton(i)", [&]() {
       it("can create { {0} }", [&]() {
         zdd res = zdd_singleton(0);
         node_test_stream ns(res);
@@ -1016,9 +1081,13 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
       });
+
+      it("throws exception if the label is too large", [&]() {
+        AssertThrows(invalid_argument, zdd_singleton(zdd::MAX_LABEL+1));
+      });
     });
 
-    describe("zdd_singletons", [&]() {
+    describe("zdd_singletons(vars)", [&]() {
       it("can create Ø on empty list", [&]() {
         adiar::shared_file<zdd::label_t> labels;
 
@@ -1136,9 +1205,31 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(3u));
       });
+
+      it("throws exception when domain is not in ascending order", [&]() {
+        adiar::shared_file<zdd::label_t> vars;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> vw(vars);
+          vw << 3 << 2 << 1 << 0;
+        }
+
+        AssertThrows(invalid_argument, zdd_singletons(vars));
+      });
+
+      it("throws exception if domain includes too large label", [&]() {
+        adiar::shared_file<zdd::label_t> vars;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> vw(vars);
+          vw << 0 << 1 << 42 << zdd::MAX_LABEL+1;
+        }
+
+        AssertThrows(invalid_argument, zdd_singletons(vars));
+      });
     });
 
-    describe("zdd_powerset", [&]() {
+    describe("zdd_powerset(vars)", [&]() {
       it("can create { Ø } on empty list", [&]() {
         adiar::shared_file<zdd::label_t> labels;
 
@@ -1253,9 +1344,31 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[false], Is().EqualTo(0u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(2u));
       });
+
+      it("throws exception when domain is not in ascending order", [&]() {
+        adiar::shared_file<zdd::label_t> vars;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> vw(vars);
+          vw << 3 << 2 << 1 << 0;
+        }
+
+        AssertThrows(invalid_argument, zdd_powerset(vars));
+      });
+
+      it("throws exception if domain includes too large label", [&]() {
+        adiar::shared_file<zdd::label_t> vars;
+
+        { // Garbage collect writer to free write-lock
+          adiar::file_writer<zdd::label_t> vw(vars);
+          vw << 0 << 1 << 42 << zdd::MAX_LABEL+1;
+        }
+
+        AssertThrows(invalid_argument, zdd_powerset(vars));
+      });
     });
 
-    describe("zdd_sized_sets", [&]() {
+    describe("zdd_sized_sets(vars, threshold, op)", [&]() {
       // Edge cases
       it("can compute { s <= Ø | |s| <= 0 } to be { Ø }", [&]() {
         adiar::shared_file<zdd::label_t> labels;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,11 +13,11 @@ go_bandit([]() {
     });
 
     it("throws exception when given '0' memory", [&]() {
-      AssertThrows(std::invalid_argument, adiar_init(0));
+      AssertThrows(invalid_argument, adiar_init(0));
     });
 
     it("throws exception when given 'MINIMUM_MEMORY - 1' memory", [&]() {
-      AssertThrows(std::invalid_argument, adiar_init(MINIMUM_MEMORY - 1));
+      AssertThrows(invalid_argument, adiar_init(MINIMUM_MEMORY - 1));
     });
 
     it("can run 'adiar_init()'", [&]() {
@@ -131,7 +131,7 @@ go_bandit([]() {
 
     it("throws exception when reinitialized", [&]() {
       // TODO: remove when 'github.com/thomasmoelhave/tpie/issues/265' is fixed.
-      AssertThrows(std::runtime_error, adiar_init(MINIMUM_MEMORY));
+      AssertThrows(runtime_error, adiar_init(MINIMUM_MEMORY));
     });
   });
  });


### PR DESCRIPTION
Partly based on the need to clean up the assertion mess, as was evident in #527 .

- [x] Remove all `adiar_assert(...)` statements. Do one of the following two
  - [x] Turn input-checks into an if-throw (+ unit tests)
  - [x] Turn remaining internal checks into an `adiar_debug(...)`.
- [x] Simplify `adiar_invariant` and `adiar_precondition` into a variadic `adiar_debug`.
- [x] Rename `adiar_debug` into `adiar_assert`.
- [x] Make `adiar_assert` throw an `adiar::assert_errror` instead of terminating.
- [x] Move `adiar_unreachable()` into its own header file.

This closes #422.

Some input validation checks are not consistent from an end-users perspective.

- [x] Remove the checks for `bdd_from` and `zdd_from`.