### PR TITLE
Bug/527

### DIFF
--- a/src/adiar/internal/data_structures/priority_queue.h
+++ b/src/adiar/internal/data_structures/priority_queue.h
@@ -21,34 +21,28 @@ namespace adiar::internal
   template<typename elem_t, typename comp_t>
   class priority_queue<memory_mode_t::INTERNAL, elem_t, comp_t>
   {
-  public:
-    static tpie::memory_size_type unsafe_memory_usage(tpie::memory_size_type no_elements)
-    {
-      return tpie::internal_priority_queue<elem_t, comp_t>::memory_usage(no_elements);
-    }
+  private:
+    using pq_t = tpie::internal_priority_queue<elem_t, comp_t>;
+    pq_t pq;
 
+  public:
     static tpie::memory_size_type memory_usage(tpie::memory_size_type no_elements)
     {
-      const tpie::memory_size_type max_value = std::numeric_limits<tpie::memory_size_type>::max();
-      const tpie::memory_size_type max_elem = memory_fits(max_value);
-      if (no_elements > max_elem) {
-        return max_value;
-      }
-      return unsafe_memory_usage(no_elements);
+      adiar_assert(no_elements < pq_t::memory_fits(tpie_max_bytes));
+      return pq_t::memory_usage(no_elements);
     }
 
     static tpie::memory_size_type memory_fits(tpie::memory_size_type memory_bytes)
     {
-      const tpie::memory_size_type ret = tpie::internal_priority_queue<elem_t, comp_t>::memory_fits(memory_bytes);
-      adiar_assert(unsafe_memory_usage(ret) <= memory_bytes,
+      adiar_assert(memory_bytes < tpie_max_bytes);
+      const tpie::memory_size_type ret = pq_t::memory_fits(memory_bytes);
+
+      adiar_assert(pq_t::memory_usage(ret) <= memory_bytes,
                    "memory_fits and memory_usage should agree.");
       return ret;
     }
 
     static constexpr size_t DATA_STRUCTURES = 1u;
-
-  private:
-    tpie::internal_priority_queue<elem_t, comp_t> pq;
 
   public:
     priority_queue([[maybe_unused]] size_t memory_bytes, size_t max_size)

--- a/src/adiar/internal/data_structures/priority_queue.h
+++ b/src/adiar/internal/data_structures/priority_queue.h
@@ -28,16 +28,14 @@ namespace adiar::internal
   public:
     static tpie::memory_size_type memory_usage(tpie::memory_size_type no_elements)
     {
-      adiar_assert(no_elements < pq_t::memory_fits(tpie_max_bytes));
       return pq_t::memory_usage(no_elements);
     }
 
     static tpie::memory_size_type memory_fits(tpie::memory_size_type memory_bytes)
     {
-      adiar_assert(memory_bytes < tpie_max_bytes);
       const tpie::memory_size_type ret = pq_t::memory_fits(memory_bytes);
 
-      adiar_assert(pq_t::memory_usage(ret) <= memory_bytes,
+      adiar_assert(memory_usage(ret) <= memory_bytes,
                    "memory_fits and memory_usage should agree.");
       return ret;
     }

--- a/src/adiar/internal/data_structures/sorter.h
+++ b/src/adiar/internal/data_structures/sorter.h
@@ -35,17 +35,15 @@ namespace adiar::internal
     static tpie::memory_size_type
     memory_usage(tpie::memory_size_type no_elements)
     {
-      adiar_assert(no_elements < array_t::memory_fits(tpie_max_bytes));
       return array_t::memory_usage(no_elements);
     }
 
     static tpie::memory_size_type
     memory_fits(tpie::memory_size_type memory_bytes)
     {
-      adiar_assert(memory_bytes < tpie_max_bytes);
       const tpie::memory_size_type ret = array_t::memory_fits(memory_bytes);
 
-      adiar_assert(array_t::memory_usage(ret) <= memory_bytes,
+      adiar_assert(memory_usage(ret) <= memory_bytes,
                    "memory_fits and memory_usage should agree.");
       return ret;
     }

--- a/src/adiar/internal/data_structures/sorter.h
+++ b/src/adiar/internal/data_structures/sorter.h
@@ -25,34 +25,27 @@ namespace adiar::internal
   class sorter<memory_mode_t::INTERNAL, elem_t, pred_t>
   {
   private:
-    tpie::array<elem_t> _array;
+    using array_t = tpie::array<elem_t>;
+    array_t _array;
     pred_t _pred;
     size_t _size;
     size_t _front_idx;
 
   public:
     static tpie::memory_size_type
-    unsafe_memory_usage(tpie::memory_size_type no_elements)
-    {
-      return tpie::array<elem_t>::memory_usage(no_elements);
-    }
-
-    static tpie::memory_size_type
     memory_usage(tpie::memory_size_type no_elements)
     {
-      const tpie::memory_size_type max_value = std::numeric_limits<tpie::memory_size_type>::max();
-      const tpie::memory_size_type max_elem = memory_fits(max_value);
-      if (no_elements > max_elem) {
-        return max_value;
-      }
-      return unsafe_memory_usage(no_elements);
+      adiar_assert(no_elements < array_t::memory_fits(tpie_max_bytes));
+      return array_t::memory_usage(no_elements);
     }
 
     static tpie::memory_size_type
     memory_fits(tpie::memory_size_type memory_bytes)
     {
-      const tpie::memory_size_type ret = tpie::array<elem_t>::memory_fits(memory_bytes);
-      adiar_assert(unsafe_memory_usage(ret) <= memory_bytes,
+      adiar_assert(memory_bytes < tpie_max_bytes);
+      const tpie::memory_size_type ret = array_t::memory_fits(memory_bytes);
+
+      adiar_assert(array_t::memory_usage(ret) <= memory_bytes,
                    "memory_fits and memory_usage should agree.");
       return ret;
     }

--- a/src/adiar/internal/memory.h
+++ b/src/adiar/internal/memory.h
@@ -17,28 +17,6 @@ namespace adiar::internal
   {
     return tpie::get_memory_manager().available();
   }
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief The largest value that TPIE can use without some computation for
-  /// internal memory breaking.
-  ///
-  /// TPIE's data structures provide the `memory_usage` and `memory_fits`
-  /// functions. These cast the `tpie::memory_size_type` (an alias for
-  /// `std::size_t`) into a `double`, do some computations and then cast them
-  /// back into a `tpie::memory_size_type`.
-  ///
-  /// Yet, on Clang with specific optimisations enabled some parts of this
-  /// computation is cast to an `unsigned long` (32 bits) which leads to
-  /// undefined behaviour. Due to this, `memory_usage(memory_fits(x))` is
-  /// unexpectedly larger than `x`.
-  ///
-  /// This value is an empirically derived value for a `tpie::array<int>` and is
-  /// equivalent to 4 PiB for which these computations by TPIE are safe.
-  ///
-  /// \see priority_queue sorter
-  //////////////////////////////////////////////////////////////////////////////
-  constexpr tpie::memory_size_type tpie_max_bytes =
-    std::numeric_limits<tpie::memory_size_type>::max() >> 12;
 }
 
 namespace adiar

--- a/src/adiar/internal/memory.h
+++ b/src/adiar/internal/memory.h
@@ -45,6 +45,9 @@ namespace adiar
 {
   // TODO: add std::move(...) alias
 
+  // TODO: use TPIE allocation for `make_unique` and `make_shared`. This way we
+  //       also account for the memory usage of each BDD.
+
   // Based on <tpie/memory.h>
 
   //////////////////////////////////////////////////////////////////////////////
@@ -59,7 +62,8 @@ namespace adiar
   /// \brief Creates a new object on the heap with shared ownership.
   //////////////////////////////////////////////////////////////////////////////
   template <typename T, typename ... TT>
-  inline shared_ptr<T> make_shared(TT && ... tt) {
+  inline shared_ptr<T> make_shared(TT && ... tt)
+  {
     return std::make_shared<T>(std::forward<TT>(tt)...);
   }
 
@@ -75,7 +79,8 @@ namespace adiar
   /// \brief Creates a new object on the heap with unique ownership.
   //////////////////////////////////////////////////////////////////////////////
   template <typename T, typename ... TT>
-  inline unique_ptr<T> make_unique(TT && ... tt) {
+  inline unique_ptr<T> make_unique(TT && ... tt)
+  {
     return std::make_unique<T>(std::forward<TT>(tt)...);
   }
 }

--- a/src/adiar/internal/memory.h
+++ b/src/adiar/internal/memory.h
@@ -17,6 +17,28 @@ namespace adiar::internal
   {
     return tpie::get_memory_manager().available();
   }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief The largest value that TPIE can use without some computation for
+  /// internal memory breaking.
+  ///
+  /// TPIE's data structures provide the `memory_usage` and `memory_fits`
+  /// functions. These cast the `tpie::memory_size_type` (an alias for
+  /// `std::size_t`) into a `double`, do some computations and then cast them
+  /// back into a `tpie::memory_size_type`.
+  ///
+  /// Yet, on Clang with specific optimisations enabled some parts of this
+  /// computation is cast to an `unsigned long` (32 bits) which leads to
+  /// undefined behaviour. Due to this, `memory_usage(memory_fits(x))` is
+  /// unexpectedly larger than `x`.
+  ///
+  /// This value is an empirically derived value for a `tpie::array<int>` and is
+  /// equivalent to 4 PiB for which these computations by TPIE are safe.
+  ///
+  /// \see priority_queue sorter
+  //////////////////////////////////////////////////////////////////////////////
+  constexpr tpie::memory_size_type tpie_max_bytes =
+    std::numeric_limits<tpie::memory_size_type>::max() >> 12;
 }
 
 namespace adiar


### PR DESCRIPTION
Hotfix to close #527 .

Essentially we remove the faulty computation that was trying to safe-guard against TPIE overflowing. While I was thinking to add a safe-guard for TPIE's max memory, it just seems best to trust this piece of code and know, that we never call it with so large values that Clang introduces undefined behaviour.