### PR TITLE
BDD/ `bdd_and` and `bdd_or` with negation

### DIFF
--- a/makefile
+++ b/makefile
@@ -72,6 +72,9 @@ test/adiar/domain:
 test/adiar/exec_policy:
 	make $(MAKE_FLAGS) test TEST_FOLDER=test/adiar TEST_NAME=exec_policy
 
+test/adiar/functional:
+	make $(MAKE_FLAGS) test TEST_FOLDER=test/adiar TEST_NAME=functional
+
 test/adiar/bdd/apply:
 	make $(MAKE_FLAGS) test TEST_FOLDER=test/adiar/bdd TEST_NAME=apply
 

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -39,15 +39,10 @@ namespace adiar
   template<>
   struct generator_end<pair<bdd::label_type, bool>>
   {
-    // TODO: use `generator_end<bdd::label_type>::value` instead of code duplication.
-  private:
-    static constexpr bdd::label_type max_label =
-      std::numeric_limits<bdd::label_type>::max();
-
   public:
     using value_type = pair<bdd::label_type, bool>;
 
-    static constexpr value_type value{max_label, false};
+    static constexpr value_type value{generator_end<bdd::label_type>::value, false};
   };
   /// \endcond
 

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -39,11 +39,15 @@ namespace adiar
   template<>
   struct generator_end<pair<bdd::label_type, bool>>
   {
+    // TODO: use `generator_end<bdd::label_type>::value` instead of code duplication.
+  private:
+    static constexpr bdd::label_type max_label =
+      std::numeric_limits<bdd::label_type>::max();
+
+  public:
     using value_type = pair<bdd::label_type, bool>;
 
-    // TODO: use `generator_end<bdd::label_type>::value` instead of code duplication.
-    static constexpr value_type value =
-      make_pair(static_cast<bdd::label_type>(-1), false);
+    static constexpr value_type value{max_label, false};
   };
   /// \endcond
 
@@ -124,8 +128,11 @@ namespace adiar
   bdd bdd_nithvar(bdd::label_type var);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief       The BDD representing the logical 'and' of all the given
-  ///              variables, i.e. a *term* of variables.
+  /// \brief      The BDD representing the logical 'and' of all the given
+  ///             variables, i.e. a *term* of variables.
+  ///
+  /// \details    Any negative labels provided by the generator are interpreted
+  ///             as the negation of said variable.
   ///
   /// \param vars Generator of labels of variables in \em descending order. When
   ///             none are left it must return a value greater than
@@ -135,11 +142,28 @@ namespace adiar
   ///
   /// \throws invalid_argument If `vars` are not in descending order.
   //////////////////////////////////////////////////////////////////////////////
-  bdd bdd_and(const generator<bdd::label_type> &vars);
+  bdd bdd_and(const generator<int> &vars);
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief      The BDD representing the logical 'and' of all the given
+  ///             variables, i.e. a *term* of variables.
+  ///
+  /// \param vars Generator of pairs (label, negated) in \em descending order.
+  ///             When none are left it must return a value greater than
+  ///             `(bdd::max_label, _)`.
+  ///
+  /// \returns    \f$ \bigwedge_{x \in \mathit{vars}} x \f$
+  ///
+  /// \throws invalid_argument If `vars` are not in descending order.
+  //////////////////////////////////////////////////////////////////////////////
+  bdd bdd_and(const generator<pair<bdd::label_type, bool>> &vars);
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief       The BDD representing the logical 'and' of all the given
   ///              variables, i.e. a *term* of variables.
+  ///
+  /// \details     Any negative labels provided by the generator are interpreted
+  ///              as the negation of said variable.
   ///
   /// \param begin Single-pass forward iterator that provides the variables in
   ///              \em descending order.
@@ -159,8 +183,8 @@ namespace adiar
   /// \brief      The BDD representing the logical 'or' of all the given
   ///             variables, i.e. a *clause* of variables.
   ///
-  /// \details    Creates a BDD with a chain of nodes on the 'low' arc to the
-  ///             true child, and false otherwise.
+  /// \details    Any negative labels provided by the generator are interpreted
+  ///             as the negation of said variable.
   ///
   /// \param vars Generator of labels of variables in \em descending order. When
   ///             none are left it must return a value greater than
@@ -170,11 +194,28 @@ namespace adiar
   ///
   /// \throws invalid_argument If `vars` are not in descending order.
   //////////////////////////////////////////////////////////////////////////////
-  bdd bdd_or(const generator<bdd::label_type> &vars);
+  bdd bdd_or(const generator<int> &vars);
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief      The BDD representing the logical 'or' of all the given
   ///             variables, i.e. a *clause* of variables.
+  ///
+  /// \param vars Generator of pairs (label, negated) in \em descending order.
+  ///             When none are left it must return a value greater than
+  ///             `(bdd::max_label, _)`.
+  ///
+  /// \returns    \f$ \bigvee_{x \in \mathit{vars}} x \f$
+  ///
+  /// \throws invalid_argument If `vars` are not in descending order.
+  //////////////////////////////////////////////////////////////////////////////
+  bdd bdd_or(const generator<pair<bdd::label_type, bool>> &vars);
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief       The BDD representing the logical 'or' of all the given
+  ///              variables, i.e. a *clause* of variables.
+  ///
+  /// \details     Any negative labels provided by the generator are interpreted
+  ///              as the negation of said variable.
   ///
   /// \param begin Single-pass forward iterator that provides the variables in
   ///              \em descending order.

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -32,20 +32,6 @@ namespace adiar
   ///
   /// \{
 
-  /// \cond
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief End marker for the BDD assignment generators.
-  //////////////////////////////////////////////////////////////////////////////
-  template<>
-  struct generator_end<pair<bdd::label_type, bool>>
-  {
-  public:
-    using value_type = pair<bdd::label_type, bool>;
-
-    static constexpr value_type value{generator_end<bdd::label_type>::value, false};
-  };
-  /// \endcond
-
   //////////////////////////////////////////////////////////////////////////////
   /// \name Basic BDD Constructors
   ///
@@ -129,9 +115,8 @@ namespace adiar
   /// \details    Any negative labels provided by the generator are interpreted
   ///             as the negation of said variable.
   ///
-  /// \param vars Generator of labels of variables in \em descending order. When
-  ///             none are left it must return a value greater than
-  ///             `bdd::max_label`.
+  /// \param vars Generator of labels of variables in \em descending order.
+  ///             These values can at most be `bdd::max_label`.
   ///
   /// \returns    \f$ \bigwedge_{x \in \mathit{vars}} x \f$
   ///
@@ -144,8 +129,7 @@ namespace adiar
   ///             variables, i.e. a *term* of variables.
   ///
   /// \param vars Generator of pairs (label, negated) in \em descending order.
-  ///             When none are left it must return a value greater than
-  ///             `(bdd::max_label, _)`.
+  ///             These values can at most be `bdd::max_label`.
   ///
   /// \returns    \f$ \bigwedge_{x \in \mathit{vars}} x \f$
   ///
@@ -161,7 +145,8 @@ namespace adiar
   ///              as the negation of said variable.
   ///
   /// \param begin Single-pass forward iterator that provides the variables in
-  ///              \em descending order.
+  ///              \em descending order. All its values should be smaller than
+  ///              or equals to `bdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -182,8 +167,7 @@ namespace adiar
   ///             as the negation of said variable.
   ///
   /// \param vars Generator of labels of variables in \em descending order. When
-  ///             none are left it must return a value greater than
-  ///             `bdd::max_label`.
+  ///             These values can at most be `bdd::max_label`.
   ///
   /// \returns    \f$ \bigvee_{x \in \mathit{vars}} x \f$
   ///
@@ -196,8 +180,7 @@ namespace adiar
   ///             variables, i.e. a *clause* of variables.
   ///
   /// \param vars Generator of pairs (label, negated) in \em descending order.
-  ///             When none are left it must return a value greater than
-  ///             `(bdd::max_label, _)`.
+  ///             These values can at most be `bdd::max_label`.
   ///
   /// \returns    \f$ \bigvee_{x \in \mathit{vars}} x \f$
   ///
@@ -213,7 +196,8 @@ namespace adiar
   ///              as the negation of said variable.
   ///
   /// \param begin Single-pass forward iterator that provides the variables in
-  ///              \em descending order.
+  ///              \em descending order. All its values should be smaller than
+  ///              or equals to `bdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -575,7 +559,8 @@ namespace adiar
   /// \param f     BDD to restrict
   ///
   /// \param begin Single-pass forward iterator that provides the to-be
-  ///              restricted variables in \em ascending order.
+  ///              restricted variables in \em ascending order. All variables
+  ///              should be smaller than or equals to `bdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -703,8 +688,8 @@ namespace adiar
   /// \param f   BDD to be quantified.
   ///
   /// \param vars Generator function, that produces variables to be quantified in
-  ///             \em descending order. When none are left to-be quantified, it
-  ///             returns a value larger than `bdd::max_label`.
+  ///             \em descending order. These values have to be smaller than or
+  ///             equals to `bdd::max_label`.
   ///
   /// \returns   \f$ \exists x_i \in \texttt{gen()} : f \f$
   //////////////////////////////////////////////////////////////////////////////
@@ -736,7 +721,8 @@ namespace adiar
   /// \param f     BDD to be quantified.
   ///
   /// \param begin Single-pass forward iterator that provides the to-be
-  ///              quantified variables in \em descending order.
+  ///              quantified variables in \em descending order. All variables
+  ///              should be smaller than or equals to `bdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -814,7 +800,7 @@ namespace adiar
   ///             ascending/descending order of the levels in `f` (but,
   ///             with retraversals).
   ///
-  /// \returns    \f$ \exists x_i \in \texttt{vars} : f \f$
+  /// \returns    \f$ \forall x_i \in \texttt{vars} : f \f$
   //////////////////////////////////////////////////////////////////////////////
   __bdd bdd_forall(const bdd &f, const predicate<bdd::label_type> &vars);
 
@@ -844,8 +830,8 @@ namespace adiar
   /// \param f   BDD to be quantified.
   ///
   /// \param gen Generator function, that produces variables to be quantified in
-  ///            \em descending order. When none are left to-be quantified, it
-  ///            returns a value larger than `bdd::max_label`, e.g. -1.
+  ///            \em descending order. These values have to be smaller than or
+  ///             equals to `bdd::max_label`.
   ///
   /// \returns   \f$ \forall x_i \in \texttt{gen()} : f \f$
   //////////////////////////////////////////////////////////////////////////////
@@ -877,7 +863,8 @@ namespace adiar
   /// \param f     BDD to be quantified.
   ///
   /// \param begin Single-pass forward iterator that provides the to-be
-  ///              quantified variables in \em descending order.
+  ///              quantified variables in \em descending order. All values
+  ///              should be smaller than or equals to `bdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -1284,8 +1271,7 @@ namespace adiar
   /// \param A   Family of a set (within the given domain)
   ///
   /// \param dom Generator function of domain variables in \em ascending order.
-  ///            When none are left it must return a value greater than
-  ///            `bdd::max_label`.
+  ///            These values may not exceed `bdd::max_label`.
   ///
   /// \returns   BDD that is true for the exact same assignments to variables in
   ///            the given domain.
@@ -1304,10 +1290,11 @@ namespace adiar
   /// \brief       Obtains the BDD that represents the same function/set as the
   ///              given ZDD within the given domain.
   ///
-  /// \param A     amily of a set (within the given domain)
+  /// \param A     Family of a set (within the given domain)
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em ascending order.
+  ///              variables in \em ascending order. These values may not exceed
+  ///              `bdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -1,14 +1,15 @@
 #include <adiar/bdd.h>
 
 #include <adiar/bdd/bdd_policy.h>
-#include <adiar/internal/io/file_stream.h>
-#include <adiar/internal/io/levelized_file_writer.h>
 #include <adiar/internal/assert.h>
 #include <adiar/internal/cut.h>
+#include <adiar/internal/io/file_stream.h>
+#include <adiar/internal/io/levelized_file_writer.h>
 #include <adiar/internal/algorithms/build.h>
 #include <adiar/internal/data_types/uid.h>
 #include <adiar/internal/data_types/level_info.h>
 #include <adiar/internal/data_types/ptr.h>
+#include <adiar/internal/util.h>
 
 namespace adiar
 {
@@ -46,16 +47,71 @@ namespace adiar
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  bdd bdd_and(const generator<bdd::label_type> &vars)
+  class bdd_and_policy : public bdd_policy
   {
-    internal::chain_high<bdd_policy> p;
+  public:
+    static constexpr bool init_terminal = true;
+
+    constexpr bool
+    skip(const bdd::label_type &) const
+    { return false; }
+
+    inline typename bdd::node_type
+    make_node(const bdd::label_type &l,
+              const bdd::pointer_type &r,
+              const bool negated) const
+    {
+      const bdd::pointer_type low  = negated ? r : bdd::pointer_type(false);
+      const bdd::pointer_type high = negated ? bdd::pointer_type(false) : r;
+
+      return typename bdd::node_type(l, bdd::max_id, low, high);
+    }
+  };
+
+  bdd bdd_and(const generator<pair<bdd::label_type, bool>> &vars)
+  {
+    bdd_and_policy p;
     return internal::build_chain<>(p, vars);
   }
 
-  //////////////////////////////////////////////////////////////////////////////
-  bdd bdd_or(const generator<bdd::label_type> &vars)
+  bdd bdd_and(const generator<int> &vars)
   {
-    internal::chain_low<bdd_policy> p;
+    return bdd_and(internal::wrap_signed_generator<bdd_policy>(vars));
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // TODO: Remove `bdd_or_policy` in favour of using De Morgan's law with
+  //       `bdd_and`
+  class bdd_or_policy : public bdd_policy
+  {
+  public:
+    static constexpr bool init_terminal = false;
+
+    constexpr bool
+    skip(const bdd::label_type &) const
+    { return false; }
+
+    inline typename bdd::node_type
+    make_node(const bdd::label_type &l,
+              const bdd::pointer_type &r,
+              const bool negated) const
+    {
+      const bdd::pointer_type low  = negated ? bdd::pointer_type(true) : r;
+      const bdd::pointer_type high = negated ? r : bdd::pointer_type(true);
+
+      return typename bdd::node_type(l, bdd::max_id, low, high);
+    }
+  };
+
+
+  bdd bdd_or(const generator<pair<bdd::label_type, bool>> &vars)
+  {
+    bdd_or_policy p;
     return internal::build_chain<>(p, vars);
+  }
+
+  bdd bdd_or(const generator<int> &vars)
+  {
+    return bdd_or(internal::wrap_signed_generator<bdd_policy>(vars));
   }
 }

--- a/src/adiar/bdd/build.cpp
+++ b/src/adiar/bdd/build.cpp
@@ -13,6 +13,9 @@
 
 namespace adiar
 {
+  template<typename Generator>
+  using bdd_chain_converter = internal::chain_converter<bdd_policy, Generator>;
+
   //////////////////////////////////////////////////////////////////////////////
   bdd bdd_const(bool value)
   {
@@ -71,12 +74,17 @@ namespace adiar
   bdd bdd_and(const generator<pair<bdd::label_type, bool>> &vars)
   {
     bdd_and_policy p;
-    return internal::build_chain<>(p, vars);
+    bdd_chain_converter<decltype(vars)> vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 
   bdd bdd_and(const generator<int> &vars)
   {
-    return bdd_and(internal::wrap_signed_generator<bdd_policy>(vars));
+    bdd_and_policy p;
+    bdd_chain_converter<decltype(vars)> vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -107,11 +115,16 @@ namespace adiar
   bdd bdd_or(const generator<pair<bdd::label_type, bool>> &vars)
   {
     bdd_or_policy p;
-    return internal::build_chain<>(p, vars);
+    bdd_chain_converter<decltype(vars)> vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 
   bdd bdd_or(const generator<int> &vars)
   {
-    return bdd_or(internal::wrap_signed_generator<bdd_policy>(vars));
+    bdd_or_policy p;
+    bdd_chain_converter<decltype(vars)> vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 }

--- a/src/adiar/bdd/restrict.cpp
+++ b/src/adiar/bdd/restrict.cpp
@@ -84,16 +84,9 @@ namespace adiar
   __bdd bdd_restrict(const exec_policy &ep,
                      const bdd &f, bdd::label_type var, bool val)
   {
-    bool gen_called = false;
-    auto gen = [&gen_called, &var, &val]() -> optional<pair<bdd::label_type, bool>> {
-      if (gen_called) {
-        return make_optional<pair<bdd::label_type, bool>>();
-      }
-      gen_called = true;
-      return make_pair<bdd::label_type, bool>(var, val);
-    };
-
-    return bdd_restrict(ep, f, gen);
+    return bdd_restrict(ep,
+                        f,
+                        make_generator(make_pair<bdd::label_type, bool>(var, val)));
   }
 
   __bdd bdd_restrict(const bdd &f, bdd::label_type var, bool val)

--- a/src/adiar/domain.cpp
+++ b/src/adiar/domain.cpp
@@ -26,8 +26,8 @@ namespace adiar
     { // Garbage collect writer to free write-lock
       internal::file_writer<domain_var> lw(dom);
 
-      domain_var v;
-      while ((v = gen()) <= domain_max) { lw << v; }
+      optional<domain_var> v;
+      while ((v = gen())) { lw << v.value(); }
     }
 
     domain_set(dom);

--- a/src/adiar/functional.h
+++ b/src/adiar/functional.h
@@ -105,7 +105,7 @@ namespace adiar
     static_assert(std::is_integral<RetType>::value);
 
   private:
-    static constexpr RetType max_value = std::numeric_limits<RetType>::max();
+    static constexpr RetType max_value = std::numeric_limits<int>::max();
 
   public:
     using value_type = RetType;

--- a/src/adiar/functional.h
+++ b/src/adiar/functional.h
@@ -111,6 +111,9 @@ namespace adiar
     };
   }
 
+  // TODO: Add make_generator(begin, end) for rvalue iterators; they go out of
+  //       scope at return!
+
   ////////////////////////////////////////////////////////////////////////////
   /// \brief Wrap an `adiar::internal::file_stream` into a generator function.
   ////////////////////////////////////////////////////////////////////////////
@@ -125,6 +128,21 @@ namespace adiar
         return make_optional<value_type>();
       }
       return make_optional<value_type>(s.pull());
+    };
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Wrap a single value into a generator.
+  ////////////////////////////////////////////////////////////////////////////
+  template<typename RetType>
+  inline generator<RetType>
+  make_generator(const RetType &r)
+  {
+    return [=, end = false]() mutable {
+      if (end) { return make_optional<RetType>(); }
+
+      end = true;
+      return make_optional(r);
     };
   }
 

--- a/src/adiar/functional.h
+++ b/src/adiar/functional.h
@@ -2,6 +2,7 @@
 #define ADIAR_FUNCTIONAL_H
 
 #include <functional>
+#include <limits>
 #include <type_traits>
 
 #include <adiar/exception.h>
@@ -101,10 +102,15 @@ namespace adiar
   template <typename RetType>
   struct generator_end
   {
+    static_assert(std::is_integral<RetType>::value);
+
+  private:
+    static constexpr RetType max_value = std::numeric_limits<RetType>::max();
+
+  public:
     using value_type = RetType;
 
-    static_assert(std::is_integral<RetType>::value);
-    static constexpr value_type value = static_cast<value_type>(-1);
+    static constexpr RetType value{max_value};
   };
 
   // TODO: Specialize for DDs (Both BDDs and ZDDs) to return an empty file.

--- a/src/adiar/internal/algorithms/build.h
+++ b/src/adiar/internal/algorithms/build.h
@@ -53,11 +53,11 @@ namespace adiar::internal
     return nf;
   }
 
-  template<typename dd_policy, bool INIT_TERMINAL = false, bool HIGH_VAL = true>
+  template<typename dd_policy, bool InitTerminal = false, bool HighValue = true>
   class chain_low : public dd_policy
   {
   public:
-    static constexpr bool init_terminal = INIT_TERMINAL;
+    static constexpr bool init_terminal = InitTerminal;
 
     constexpr bool
     skip(const typename dd_policy::label_type &) const
@@ -71,15 +71,15 @@ namespace adiar::internal
       return typename dd_policy::node_type(l,
                                            dd_policy::max_id,
                                            r,
-                                           typename dd_policy::pointer_type(HIGH_VAL));
+                                           typename dd_policy::pointer_type(HighValue));
     }
   };
 
-  template<typename dd_policy, bool INIT_TERMINAL = true, bool LOW_VAL = false>
+  template<typename dd_policy, bool InitTerminal = true, bool LowValue = false>
   class chain_high : public dd_policy
   {
   public:
-    static constexpr bool init_terminal = INIT_TERMINAL;
+    static constexpr bool init_terminal = InitTerminal;
 
     constexpr bool
     skip(const typename dd_policy::label_type &) const
@@ -92,16 +92,16 @@ namespace adiar::internal
     {
       return typename dd_policy::node_type(l,
                                            dd_policy::max_id,
-                                           typename dd_policy::pointer_type(LOW_VAL),
+                                           typename dd_policy::pointer_type(LowValue),
                                            r);
     }
   };
 
-  template<typename dd_policy, bool INIT_TERMINAL = true>
+  template<typename dd_policy, bool InitTerminal = true>
   class chain_both : public dd_policy
   {
   public:
-    static constexpr bool init_terminal = INIT_TERMINAL;
+    static constexpr bool init_terminal = InitTerminal;
 
     constexpr bool
     skip(const typename dd_policy::label_type &) const

--- a/src/adiar/internal/algorithms/build.h
+++ b/src/adiar/internal/algorithms/build.h
@@ -13,12 +13,15 @@
 
 namespace adiar::internal
 {
-  template<typename dd_policy>
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Builder for a terminal value
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy>
   inline
-  shared_levelized_file<typename dd_policy::node_type>
+  shared_levelized_file<typename DdPolicy::node_type>
   build_terminal(bool value)
   {
-    using node_type = typename dd_policy::node_type;
+    using node_type = typename DdPolicy::node_type;
     shared_levelized_file<node_type> nf;
     {
       node_writer nw(nf);
@@ -30,12 +33,15 @@ namespace adiar::internal
     return nf;
   }
 
-  template<typename dd_policy>
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Builder for a single-node with children (`false`, `true`).
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy>
   inline
-  shared_levelized_file<typename dd_policy::node_type>
-  build_ithvar(typename dd_policy::label_type label)
+  shared_levelized_file<typename DdPolicy::node_type>
+  build_ithvar(typename DdPolicy::label_type label)
   {
-    using node_type = typename dd_policy::node_type;
+    using node_type = typename DdPolicy::node_type;
     using pointer_type = typename node_type::pointer_type;
 
     if (node_type::max_label < label) {
@@ -53,83 +59,22 @@ namespace adiar::internal
     return nf;
   }
 
-  template<typename dd_policy, bool InitTerminal = false, bool HighValue = true>
-  class chain_low : public dd_policy
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Builds a chain of nodes bottom-up.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename Policy, typename Generator>
+  inline typename Policy::dd_type
+  build_chain(const Policy &policy, const Generator &vars)
   {
-  public:
-    static constexpr bool init_terminal = InitTerminal;
-
-    constexpr bool
-    skip(const typename dd_policy::label_type &) const
-    { return false; }
-
-    inline typename dd_policy::node_type
-    make_node(const typename dd_policy::label_type &l,
-              const typename dd_policy::pointer_type &r,
-              const bool/*negated*/) const
-    {
-      return typename dd_policy::node_type(l,
-                                           dd_policy::max_id,
-                                           r,
-                                           typename dd_policy::pointer_type(HighValue));
-    }
-  };
-
-  template<typename dd_policy, bool InitTerminal = true, bool LowValue = false>
-  class chain_high : public dd_policy
-  {
-  public:
-    static constexpr bool init_terminal = InitTerminal;
-
-    constexpr bool
-    skip(const typename dd_policy::label_type &) const
-    { return false; }
-
-    inline typename dd_policy::node_type
-    make_node(const typename dd_policy::label_type &l,
-              const typename dd_policy::pointer_type &r,
-              const bool/*negated*/) const
-    {
-      return typename dd_policy::node_type(l,
-                                           dd_policy::max_id,
-                                           typename dd_policy::pointer_type(LowValue),
-                                           r);
-    }
-  };
-
-  template<typename dd_policy, bool InitTerminal = true>
-  class chain_both : public dd_policy
-  {
-  public:
-    static constexpr bool init_terminal = InitTerminal;
-
-    constexpr bool
-    skip(const typename dd_policy::label_type &) const
-    { return false; }
-
-    inline typename dd_policy::node_type
-    make_node(const typename dd_policy::label_type &l,
-              const typename dd_policy::pointer_type &r,
-              const bool/*negated*/) const
-    {
-      return typename dd_policy::node_type(l, dd_policy::max_id, r, r);
-    }
-  };
-
-  template<typename chain_policy>
-  inline typename chain_policy::dd_type
-  build_chain(const chain_policy &policy,
-              const generator<pair<typename chain_policy::label_type, bool>> &vars)
-  {
-    using label_type = typename chain_policy::label_type;
+    using label_type = typename Policy::label_type;
 
     optional<pair<label_type, bool>> next = vars();
 
     if (!next) {
-      return build_terminal<chain_policy>(chain_policy::init_terminal);
+      return build_terminal<Policy>(Policy::init_terminal);
     }
 
-    shared_levelized_file<typename chain_policy::node_type> nf;
+    shared_levelized_file<typename Policy::node_type> nf;
     node_writer nw(nf);
 
     size_t max_internal_cut      = 1;
@@ -138,7 +83,7 @@ namespace adiar::internal
     bool   terminal_at_bottom[2] = {false, false};
     size_t terminals[2]          = {0u, 0u};
 
-    typename chain_policy::pointer_type root(chain_policy::init_terminal);
+    typename Policy::pointer_type root(Policy::init_terminal);
     adiar_assert(root.is_terminal());
 
     do {
@@ -165,7 +110,7 @@ namespace adiar::internal
       // TODO: throw exception for too large labels
 
       // Create node on chain.
-      using node_type = typename chain_policy::node_type;
+      using node_type = typename Policy::node_type;
 
       const node_type n = policy.make_node(next_var, root, next_negated);
 
@@ -205,7 +150,7 @@ namespace adiar::internal
 
     // If all values have been skipped by the policy, then collapse to a terminal
     if (nw.size() == 0u) {
-      return build_terminal<chain_policy>(chain_policy::init_terminal);
+      return build_terminal<Policy>(Policy::init_terminal);
     }
 
     // Canonicity (assuming the policies are correct)
@@ -239,21 +184,131 @@ namespace adiar::internal
     return nf;
   }
 
-  template<typename chain_policy>
-  inline typename chain_policy::dd_type
-  build_chain(const chain_policy &policy,
-              const generator<typename chain_policy::label_type> &vars)
-  {
-    using label_type = typename chain_policy::label_type;
+  //////////////////////////////////////////////////////////////////////////////
 
-    return build_chain<chain_policy>(policy, [&vars]() -> optional<pair<label_type, bool>> {
-        optional<label_type> var = vars();
-        if (var) {
-          return make_pair<label_type, bool>(var.value(), false);
-        }
-        return make_optional<pair<label_type, bool>>();
-      });
-  }
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Policy for `build_chain` where the chain goes up the *low* arcs.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy, bool InitTerminal = false, bool HighValue = true>
+  class chain_low : public DdPolicy
+  {
+  public:
+    static constexpr bool init_terminal = InitTerminal;
+
+    constexpr bool
+    skip(const typename DdPolicy::label_type &) const
+    { return false; }
+
+    inline typename DdPolicy::node_type
+    make_node(const typename DdPolicy::label_type &l,
+              const typename DdPolicy::pointer_type &r,
+              const bool/*negated*/) const
+    {
+      return typename DdPolicy::node_type(l,
+                                           DdPolicy::max_id,
+                                           r,
+                                           typename DdPolicy::pointer_type(HighValue));
+    }
+  };
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Policy for `build_chain` where the chain goes up the *high* arcs.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy, bool InitTerminal = true, bool LowValue = false>
+  class chain_high : public DdPolicy
+  {
+  public:
+    static constexpr bool init_terminal = InitTerminal;
+
+    constexpr bool
+    skip(const typename DdPolicy::label_type &) const
+    { return false; }
+
+    inline typename DdPolicy::node_type
+    make_node(const typename DdPolicy::label_type &l,
+              const typename DdPolicy::pointer_type &r,
+              const bool/*negated*/) const
+    {
+      return typename DdPolicy::node_type(l,
+                                           DdPolicy::max_id,
+                                           typename DdPolicy::pointer_type(LowValue),
+                                           r);
+    }
+  };
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Policy for `build_chain` where the chain goes up both the *low* and
+  ///        the *high* arcs.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy, bool InitTerminal = true>
+  class chain_both : public DdPolicy
+  {
+  public:
+    static constexpr bool init_terminal = InitTerminal;
+
+    constexpr bool
+    skip(const typename DdPolicy::label_type &) const
+    { return false; }
+
+    inline typename DdPolicy::node_type
+    make_node(const typename DdPolicy::label_type &l,
+              const typename DdPolicy::pointer_type &r,
+              const bool/*negated*/) const
+    {
+      return typename DdPolicy::node_type(l, DdPolicy::max_id, r, r);
+    }
+  };
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Wrapper for a generator to map its output to fit the `build_chain`
+  ///        algorithm.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy, typename Generator, bool negate = false>
+  class chain_converter
+  {
+  private:
+    const Generator &_gen;
+
+  public:
+    using value_type  = pair<typename DdPolicy::label_type, bool>;
+    using result_type = optional<value_type>;
+
+  private:
+    inline value_type map(const value_type &x) const
+    {
+      return make_pair(x.first, negate ^ x.second);
+    }
+
+    inline value_type map(const typename DdPolicy::label_type &x) const
+    {
+      return make_pair(x, negate);
+    }
+
+    inline value_type map(const int &x) const
+    {
+      return make_pair(std::abs(x), negate ? 0 < x : x < 0);
+    }
+
+  public:
+    chain_converter(const Generator &gen)
+      : _gen(gen)
+    { }
+
+    inline result_type operator()() const
+    {
+      // NOTE: This is similar to a monadic 'bind'/'map'.
+
+      // NOTE: The type of '_gen()' should be 'typename Generator::result_type',
+      //       but declaring it to be exactly this results in an error. Hence,
+      //       we break the style guide with an 'auto'.
+      const auto next_opt = _gen();
+      if (next_opt) {
+        const value_type next_val = this->map(next_opt.value());
+        return make_optional<value_type>(next_val);
+      }
+      return make_optional<value_type>();
+    }
+  };
 }
 
 #endif // ADIAR_INTERNAL_ALGORITHMS_BUILD_H

--- a/src/adiar/internal/algorithms/intercut.h
+++ b/src/adiar/internal/algorithms/intercut.h
@@ -197,8 +197,8 @@ namespace adiar::internal
     shared_file<typename intercut_policy::label_type> hit_levels;
     {
       file_writer<typename intercut_policy::label_type> lw(hit_levels);
-      for (auto x = xs(); x <= intercut_policy::max_label; x = xs()) {
-        lw << x;
+      for (auto x = xs(); x; x = xs()) {
+        lw << x.value();
       }
 
       if (lw.size() == 0) {

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -1081,6 +1081,8 @@ namespace adiar::internal
         if (quantify_policy::quantify_onset) {
           if (!on_level) { return dd; }
 
+          // Quantify all but the last 'on_level'. Hence, look one ahead with
+          // 'next_on_level' to see whether it is the last one.
           optional<typename quantify_policy::label_type> next_on_level = lvls();
           while (next_on_level) {
             dd = quantify<quantify_policy>(ep, dd, on_level.value(), op);

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -1014,7 +1014,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     bool has_sweep(const typename quantify_policy::label_type l)
     {
-      return has_next_level() && l == next_level(l)
+      return l == next_level(l)
         ? quantify_policy::quantify_onset
         : !quantify_policy::quantify_onset;
     }

--- a/src/adiar/internal/util.h
+++ b/src/adiar/internal/util.h
@@ -162,16 +162,17 @@ namespace adiar::internal
   generator<pair<typename DdPolicy::label_type, bool>>
   wrap_signed_generator(const Generator &g)
   {
-    using signed_type = typename Generator::result_type;
     using label_type  = typename DdPolicy::label_type;
 
-    return [&g]() -> pair<label_type, bool> {
-      const signed_type next = g();
+    return [&g]() -> optional<pair<label_type, bool>> {
+      const typename Generator::result_type next_opt = g();
 
-      const label_type x = static_cast<label_type>(std::abs(next));
-      const bool negated = next < 0;
-
-      return pair<label_type, bool>{ x, negated };
+      if (next_opt) {
+        const pair<label_type, bool> ret_value = make_pair(std::abs(next_opt.value()),
+                                                           next_opt.value() < 0);
+        return make_optional(ret_value);
+      }
+      return make_optional<pair<label_type, bool>>();
     };
   }
 }

--- a/src/adiar/internal/util.h
+++ b/src/adiar/internal/util.h
@@ -4,6 +4,7 @@
 #include <type_traits>
 
 #include <adiar/functional.h>
+#include <adiar/types.h>
 
 #include <adiar/internal/assert.h>
 #include <adiar/internal/dd.h>
@@ -151,6 +152,27 @@ namespace adiar::internal
     // Sort internal arcs by their target
     af->sort<arc_target_lt>(file_traits<arc>::idx__internal);
     return af;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Wrap a `generator<int>` into a `generator<pair<label_type, bool>>`
+  ///        where the boolean value is true if the value is negative.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename DdPolicy, typename Generator>
+  generator<pair<typename DdPolicy::label_type, bool>>
+  wrap_signed_generator(const Generator &g)
+  {
+    using signed_type = typename Generator::result_type;
+    using label_type  = typename DdPolicy::label_type;
+
+    return [&g]() -> pair<label_type, bool> {
+      const signed_type next = g();
+
+      const label_type x = static_cast<label_type>(std::abs(next));
+      const bool negated = next < 0;
+
+      return pair<label_type, bool>{ x, negated };
+    };
   }
 }
 

--- a/src/adiar/internal/util.h
+++ b/src/adiar/internal/util.h
@@ -168,9 +168,10 @@ namespace adiar::internal
       const typename Generator::result_type next_opt = g();
 
       if (next_opt) {
-        const pair<label_type, bool> ret_value = make_pair(std::abs(next_opt.value()),
-                                                           next_opt.value() < 0);
-        return make_optional(ret_value);
+        const label_type x = std::abs(next_opt.value());
+        const bool negated = next_opt.value() < 0;
+
+        return make_pair(x, negated);
       }
       return make_optional<pair<label_type, bool>>();
     };

--- a/src/adiar/internal/util.h
+++ b/src/adiar/internal/util.h
@@ -153,29 +153,6 @@ namespace adiar::internal
     af->sort<arc_target_lt>(file_traits<arc>::idx__internal);
     return af;
   }
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// \brief Wrap a `generator<int>` into a `generator<pair<label_type, bool>>`
-  ///        where the boolean value is true if the value is negative.
-  //////////////////////////////////////////////////////////////////////////////
-  template<typename DdPolicy, typename Generator>
-  generator<pair<typename DdPolicy::label_type, bool>>
-  wrap_signed_generator(const Generator &g)
-  {
-    using label_type  = typename DdPolicy::label_type;
-
-    return [&g]() -> optional<pair<label_type, bool>> {
-      const typename Generator::result_type next_opt = g();
-
-      if (next_opt) {
-        const label_type x = std::abs(next_opt.value());
-        const bool negated = next_opt.value() < 0;
-
-        return make_pair(x, negated);
-      }
-      return make_optional<pair<label_type, bool>>();
-    };
-  }
 }
 
 #endif // ADIAR_INTERNAL_UTIL_H

--- a/src/adiar/types.h
+++ b/src/adiar/types.h
@@ -41,14 +41,16 @@ namespace adiar
   { return std::make_pair(std::move(t1), std::move(t2)); }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief A pair of values.
+  /// \brief An optional value, i.e. a possibly existent value.
+  ///
+  /// \details Not having a value is for example used to indicate the end of
+  ///          streams and generators.
   //////////////////////////////////////////////////////////////////////////////
   template<typename T>
   using optional = std::optional<T>;
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Create an `adiar::option`, deducing the target type based on the
-  ///        types of the argument.
+  /// \brief Create an empty `adiar::optional`, i.e. *None*.
   //////////////////////////////////////////////////////////////////////////////
   template<typename T>
   constexpr optional<T>
@@ -56,8 +58,7 @@ namespace adiar
   { return optional<T>(); }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Create an `adiar::option`, deducing the target type based on the
-  ///        types of the argument.
+  /// \brief Create an `adiar::optional` with *Some* value.
   //////////////////////////////////////////////////////////////////////////////
   template<typename T>
   constexpr optional<T>
@@ -65,8 +66,7 @@ namespace adiar
   { return std::make_optional(t); }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Create an `adiar::pair`, deducing the target type based on the
-  ///        types of the arguments.
+  /// \brief Create an `adiar::optional` with *Some* value.
   //////////////////////////////////////////////////////////////////////////////
   template<typename T>
   constexpr optional<T>

--- a/src/adiar/types.h
+++ b/src/adiar/types.h
@@ -31,6 +31,7 @@ namespace adiar
   make_pair(const T1 &t1, const T2 &t2)
   { return std::make_pair(t1, t2); }
 
+  /*
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Create an `adiar::pair`, deducing the target type based on the
   ///        types of the arguments.
@@ -39,6 +40,7 @@ namespace adiar
   constexpr pair<T1, T2>
   make_pair(T1 &&t1, T2 &&t2)
   { return std::make_pair(std::move(t1), std::move(t2)); }
+  */
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief An optional value, i.e. a possibly existent value.
@@ -65,6 +67,7 @@ namespace adiar
   make_optional(const T &t)
   { return std::make_optional(t); }
 
+  /*
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Create an `adiar::optional` with *Some* value.
   //////////////////////////////////////////////////////////////////////////////
@@ -72,6 +75,7 @@ namespace adiar
   constexpr optional<T>
   make_optional(T &&t)
   { return std::make_optional(std::move(t)); }
+  */
 }
 
 #endif // ADIAR_TYPES_H

--- a/src/adiar/types.h
+++ b/src/adiar/types.h
@@ -1,8 +1,8 @@
 #ifndef ADIAR_TYPES_H
 #define ADIAR_TYPES_H
 
+#include <optional>
 #include <utility>
-//#include <adiar/internal/memory.h>
 
 namespace adiar
 {
@@ -39,6 +39,39 @@ namespace adiar
   constexpr pair<T1, T2>
   make_pair(T1 &&t1, T2 &&t2)
   { return std::make_pair(std::move(t1), std::move(t2)); }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief A pair of values.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename T>
+  using optional = std::optional<T>;
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Create an `adiar::option`, deducing the target type based on the
+  ///        types of the argument.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename T>
+  constexpr optional<T>
+  make_optional()
+  { return optional<T>(); }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Create an `adiar::option`, deducing the target type based on the
+  ///        types of the argument.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename T>
+  constexpr optional<T>
+  make_optional(const T &t)
+  { return std::make_optional(t); }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Create an `adiar::pair`, deducing the target type based on the
+  ///        types of the arguments.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename T>
+  constexpr optional<T>
+  make_optional(T &&t)
+  { return std::make_optional(std::move(t)); }
 }
 
 #endif // ADIAR_TYPES_H

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -67,9 +67,8 @@ namespace adiar
   ///
   /// \param var The variable to be forced to true.
   ///
-  /// \param dom Generator function of the domain in \em descending order. When
-  ///            none are left, it must return a value greater than
-  ///            `zdd::max_label`.
+  /// \param dom Generator function of the domain in \em descending order. These
+  ///            variables should be smaller than or equals to `zdd::max_label`.
   ///
   /// \pre       The variable `var` should occur in `dom`.
   ///
@@ -84,7 +83,8 @@ namespace adiar
   /// \param var   The variable to be forced to true.
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em descending order.
+  ///              variables in \em descending order. The variables may not
+  ///              exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -118,9 +118,8 @@ namespace adiar
   ///
   /// \param var The variable to be forced to false.
   ///
-  /// \param dom Generator function of the domain in \em descending order. When
-  ///            none are left, it must return a value greater than
-  ///            `zdd::max_label`.
+  /// \param dom Generator function of the domain in \em descending order. The
+  ///            variables should be smaller than or equals to `zdd::max_label`.
   ///
   /// \pre       The variable `var` should occur in `dom`.
   ///
@@ -135,7 +134,8 @@ namespace adiar
   /// \param var   The variable to be forced to false.
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em descending order.
+  ///              variables in \em descending order. The variables may not
+  ///              exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -166,8 +166,7 @@ namespace adiar
   ///            true child, and false otherwise.
   ///
   /// \param vars Generator function of the variables in \em descending order.
-  ///             When none are left, it must return a value greater than
-  ///             `zdd::max_label`.
+  ///             The variables may not exceed `zdd::max_label`.
   ///
   /// \throws invalid_argument If `vars` are not in \em descending order.
   //////////////////////////////////////////////////////////////////////////////
@@ -177,7 +176,8 @@ namespace adiar
   /// \brief       The family { { 1, 2, ..., k } }.
   ///
   /// \param begin Single-pass forward iterator that provides the variables
-  ///              in \em descending order.
+  ///              in \em descending order. The variables may not exceed
+  ///              `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -208,8 +208,7 @@ namespace adiar
   ///            true child, and false otherwise.
   ///
   /// \param vars Generator function of the variables in \em descending order.
-  ///             When none are left, it must return a value greater than
-  ///             `zdd::max_label`.
+  ///             The variables may not exceed `zdd::max_label`.
   ///
   /// \throws invalid_argument If `vars` are not in \em descending order.
   //////////////////////////////////////////////////////////////////////////////
@@ -219,7 +218,8 @@ namespace adiar
   /// \brief       The family { {1}, {2}, ..., {k} }.
   ///
   /// \param begin Single-pass forward iterator that provides the variables
-  ///              in \em descending order.
+  ///              in \em descending order. The variables may not exceed
+  ///              `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -237,8 +237,7 @@ namespace adiar
   ///            child.
   ///
   /// \param vars Generator function of the variables in \em descending order.
-  ///             When none are left, it must return a value greater than
-  ///             `zdd::max_label`.
+  ///             These values may not exceed `zdd::max_label`.
   ///
   /// \throws invalid_argument If `vars` are not in \em ascending order.
   //////////////////////////////////////////////////////////////////////////////
@@ -248,7 +247,8 @@ namespace adiar
   /// \brief       The powerset of all given variables.
   ///
   /// \param begin Single-pass forward iterator that provides the variables
-  ///              in \em descending order.
+  ///              in \em descending order. The variables may not exceed
+  ///              `zdd::max_label`
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -260,11 +260,10 @@ namespace adiar
   { return zdd_powerset(make_generator(begin, end)); }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief      Bottom of the powerset lattice.
+  /// \brief     Bottom of the powerset lattice.
   ///
   /// \param dom Generator function of the variables in \em descending order.
-  ///            When none are left, it must return a value greater than
-  ///            `zdd::max_label`.
+  ///            These values may not exceed `zdd::max_label`.
   ///
   /// \see zdd_empty
   //////////////////////////////////////////////////////////////////////////////
@@ -274,7 +273,8 @@ namespace adiar
   /// \brief       Bottom of the powerset lattice.
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em descending order.
+  ///              variables in \em descending order. The variables may not
+  ///              exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -294,7 +294,8 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   /// \brief     Top of the powerset lattice.
   ///
-  /// \param dom Generator function of the variables in \em descending order.
+  /// \param dom Generator of the variables in \em descending order. These
+  ///            values may not exceed `zdd::max_label`.
   ///
   /// \see zdd_powerset, zdd_null
   //////////////////////////////////////////////////////////////////////////////
@@ -304,7 +305,8 @@ namespace adiar
   /// \brief       Top of the powerset lattice.
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em descending order.
+  ///              variables in \em descending order. These values may not
+  ///              exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -346,7 +348,7 @@ namespace adiar
   __zdd zdd_binop(const zdd &A, const zdd &B, const bool_op &op);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief     Apply a binary operator between the sets of two families.
+  /// \brief Apply a binary operator between the sets of two families.
   //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_binop(const exec_policy &ep,
                   const zdd &A,
@@ -354,7 +356,7 @@ namespace adiar
                   const bool_op &op);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief   The union of two families of sets.
+  /// \brief The union of two families of sets.
   ///
   /// \returns
   /// \f$ A \cup B \f$
@@ -432,8 +434,7 @@ namespace adiar
   /// \param A    ZDD to apply with the other.
   ///
   /// \param vars Generator function of labels to flip in \em ascending order.
-  ///             When none are left, it must return a value greater than
-  ///             `zdd::max_label`.
+  ///             These values may not exceed `zdd::max_label`.
   ///
   /// \returns
   /// \f$ \{ \mathit{vars} \Delta a \mid a \in A \} \f$
@@ -455,7 +456,8 @@ namespace adiar
   /// \param A    ZDD to apply with the other.
   ///
   /// \param begin Single-pass forward iterator that provides the to-be
-  ///              flipped variables in \em ascending order.
+  ///              flipped variables in \em ascending order. These values may
+  ///              not exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -488,7 +490,6 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   __zdd zdd_complement(const zdd &A, const generator<zdd::label_type> &dom);
 
-
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Complement of A within the given domain.
   //////////////////////////////////////////////////////////////////////////////
@@ -502,7 +503,8 @@ namespace adiar
   /// \param A     family of sets to complement
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em ascending order.
+  ///              variables in \em ascending order. These values may not exceed
+  ///              `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -561,9 +563,8 @@ namespace adiar
   /// \param A    Family of set to expand.
   ///
   /// \param vars Generator function of labels to unproject in \em ascending
-  ///             order. No variables it generates may already exist in `A`.
-  ///             When no more variables are left, it must return a value
-  ///             greater than `zdd::max_label`.
+  ///             order. No variables it generates may already exist in `A` or
+  ///             exceed `zdd::max_label`.
   ///
   /// \returns
   /// \f$ \bigcup_{a \in A, i \in 2^{vars}} (a \cup i) \f$
@@ -588,7 +589,7 @@ namespace adiar
   ///
   /// \param begin Single-pass forward iterator that provides the to-be
   ///              unprojected variables in \em ascending order. These may \em not
-  ///              be present in `A`.
+  ///              be present in `A` or exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -652,8 +653,8 @@ namespace adiar
   /// \param A    Family of set
   ///
   /// \param vars Generator function of the variable labels to filter on in
-  ///             \em ascending order. When none are left, it must return a value
-  ///             greater than `zdd::max_label`.
+  ///             \em ascending order. The values generated should not exceed
+  ///             `zdd::max_label`.
   ///
   /// \returns
   /// \f$ \{ a \in A \mid \forall i \in \mathit{vars} : i \not\in a \} \f$
@@ -673,7 +674,8 @@ namespace adiar
   /// \param A    Family of set
   ///
   /// \param begin Single-pass forward iterator that provides the variables to
-  ///              filter out in \em ascending order.
+  ///              filter out in \em ascending order. These values may not
+  ///              exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -734,8 +736,8 @@ namespace adiar
   /// \param A    Family of set
   ///
   /// \param vars Generator function of the variable labels to filter on in
-  ///             \em ascending order. When none are left, it must return a value
-  ///             greater than `zdd::max_label`.
+  ///             \em ascending order. The values generated may not exceed
+  ///             `zdd::max_label`
   ///
   /// \returns
   /// \f$ \{ a \in A \mid \forall i \in \mathit{vars} : i \in a \} \f$
@@ -755,7 +757,8 @@ namespace adiar
   /// \param A    Family of set
   ///
   /// \param begin Single-pass forward iterator that provides the variables to
-  ///              filter out in \em ascending order.
+  ///              filter out in \em ascending order. These values may not
+  ///              exceed `zdd::max_label`
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -816,8 +819,7 @@ namespace adiar
   /// \param A   Family of sets to project
   ///
   /// \param dom Generator function, that produces the variables of the domain in
-  ///            \em descending order. When none are left to-be quantified, it
-  ///            returns a value larger than `zdd::max_label`, e.g. -1.
+  ///            \em descending order. They should not exceed `zdd::max_label`.
   ///
   /// \returns
   /// \f$ \prod_{\mathit{dom}}(A) = \{ a \setminus \mathit{dom}^c \mid a \in A \} \f$
@@ -851,7 +853,8 @@ namespace adiar
   /// \param A     Family of sets to project
   ///
   /// \param begin Single-pass forward iterator that provides the domain in
-  ///              \em descending order.
+  ///              \em descending order. Its values should not exceed
+  ///              `zdd::max_label`
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -1142,8 +1145,8 @@ namespace adiar
   ///
   /// \param A Set of interest
   ///
-  /// \param a Generator of a bit-vector in \em ascending order. When none are
-  ///          left, it must return a value greater than `zdd::max_label`.
+  /// \param a Generator of a bit-vector in \em ascending order. All variables
+  ///          geneated should be smaller than or equal to `zdd::max_label`.
   ///
   /// \returns Whether \f$ a \in A \f$
   //////////////////////////////////////////////////////////////////////////////
@@ -1155,7 +1158,8 @@ namespace adiar
   /// \param A     Set of interest
   ///
   /// \param begin Single-pass forward iterator of the set of labels in
-  ///              \em ascending order.
+  ///              \em ascending order. All its values should be smaller than
+  ///              or equals to `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///
@@ -1237,8 +1241,8 @@ namespace adiar
   ///
   /// \param f   Boolean function with the given domain
   ///
-  /// \param dom Domain of all variables in \em ascending order. When none are
-  ///            left it must return a value greater than `zdd::max_label`.
+  /// \param dom Domain of all variables in \em ascending order. All generated
+  ///            values should be smaller than or equals to `zdd::max_label`.
   ///
   /// \returns   ZDD that is true for the exact same assignments to variables in
   ///            the given domain.
@@ -1260,7 +1264,8 @@ namespace adiar
   /// \param f     Boolean function with the given domain
   ///
   /// \param begin Single-pass forward iterator that provides the domain's
-  ///              variables in \em ascending order.
+  ///              variables in \em ascending order. None of its values may
+  ///              exceed `zdd::max_label`.
   ///
   /// \param end   Marks the end for `begin`.
   ///

--- a/src/adiar/zdd/build.cpp
+++ b/src/adiar/zdd/build.cpp
@@ -10,6 +10,8 @@
 
 namespace adiar
 {
+  using zdd_chain_converter = internal::chain_converter<zdd_policy, generator<zdd::label_type>>;
+
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_terminal(bool value)
   {
@@ -59,10 +61,12 @@ namespace adiar
   {
     // TODO: Move empty dom edge-case inside of `internal::build_chain<>`?
 
-    zdd_ithvar_policy p(var);
-    const zdd res = internal::build_chain<>(p, dom);
+    const zdd_ithvar_policy p(var);
+    const zdd_chain_converter dom_wrapper(dom);
 
-    return zdd_istrue(res) ? zdd_empty() : res;
+    const zdd res = internal::build_chain<>(p, dom_wrapper);
+
+    return zdd_isnull(res) ? zdd_empty() : res;
   }
 
   zdd zdd_ithvar(const zdd::label_type var)
@@ -99,8 +103,10 @@ namespace adiar
 
   zdd zdd_nithvar(const zdd::label_type var, const generator<zdd::label_type> &dom)
   {
-    zdd_nithvar_policy p(var);
-    return internal::build_chain<>(p, dom);
+    const zdd_nithvar_policy p(var);
+    const zdd_chain_converter dom_wrapper(dom);
+
+    return internal::build_chain<>(p, dom_wrapper);
   }
 
   zdd zdd_nithvar(const zdd::label_type var)
@@ -114,8 +120,10 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_vars(const generator<zdd::label_type> &vars)
   {
-    internal::chain_high<zdd_policy> p;
-    return internal::build_chain<>(p, vars);
+    const internal::chain_high<zdd_policy> p;
+    const zdd_chain_converter vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -128,14 +136,18 @@ namespace adiar
   zdd zdd_singletons(const generator<zdd::label_type> &vars)
   {
     internal::chain_low<zdd_policy> p;
-    return internal::build_chain<>(p, vars);
+    zdd_chain_converter vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 
   //////////////////////////////////////////////////////////////////////////////
   zdd zdd_powerset(const generator<zdd::label_type> &vars)
   {
-    internal::chain_both<zdd_policy> p;
-    return internal::build_chain<>(p, vars);
+    const internal::chain_both<zdd_policy> p;
+    const zdd_chain_converter vars_wrapper(vars);
+
+    return internal::build_chain<>(p, vars_wrapper);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/zdd/build.cpp
+++ b/src/adiar/zdd/build.cpp
@@ -44,7 +44,9 @@ namespace adiar
     { return false; }
 
     inline zdd_policy::node_type
-    make_node(const zdd_policy::label_type &l, const zdd_policy::pointer_type &r) const
+    make_node(const zdd_policy::label_type &l,
+              const zdd_policy::pointer_type &r,
+              const bool/*negated*/) const
     {
       if (l == var) {
         return zdd_policy::node_type(l, zdd_policy::max_id, zdd_policy::pointer_type(false), r);
@@ -89,7 +91,9 @@ namespace adiar
     { return l == var; }
 
     inline zdd_policy::node_type
-    make_node(const zdd_policy::label_type &l, const zdd_policy::pointer_type &r) const
+    make_node(const zdd_policy::label_type &l,
+              const zdd_policy::pointer_type &r,
+              const bool/*negated*/) const
     { return zdd_policy::node_type(l, zdd_policy::max_id, r, r); }
   };
 

--- a/src/adiar/zdd/complement.cpp
+++ b/src/adiar/zdd/complement.cpp
@@ -61,12 +61,20 @@ namespace adiar
       // TODO: remove
       internal::file_stream<zdd::label_type, true> ls(universe);
 
+      const generator<zdd::label_type> universe_generator = make_generator(ls);
+
+      using complement_chain_converter =
+        internal::chain_converter<zdd_policy, generator<zdd::label_type>>;
+
+      const complement_chain_converter wrapped_universe(universe_generator);
+
       if (terminal_value) { // Include everything but Ø
         on_true_terminal_chain_policy p;
-        return internal::build_chain<>(p, make_generator(ls));
+
+        return internal::build_chain<>(p, wrapped_universe);
       } else { // The complement of nothing is everything
         internal::chain_both<zdd_policy> p;
-        return internal::build_chain<>(p, make_generator(ls));
+        return internal::build_chain<>(p, wrapped_universe);
       }
     }
 

--- a/src/adiar/zdd/complement.cpp
+++ b/src/adiar/zdd/complement.cpp
@@ -33,7 +33,9 @@ namespace adiar
 
       inline
       bdd::node_type
-      make_node(const zdd::label_type &l, const zdd::pointer_type &r) const
+      make_node(const zdd::label_type &l,
+                const zdd::pointer_type &r,
+                const bool/*negated*/) const
       {
         if (r.is_terminal()) {
           adiar_assert(r.value() == false, "Root should be Ø");

--- a/src/adiar/zdd/contains.cpp
+++ b/src/adiar/zdd/contains.cpp
@@ -40,12 +40,13 @@ namespace adiar
           return zdd::pointer_type::nil();
         }
 
-        // Obtain the next to-be visited level (if node was in the set)
+        // Forward once (if node was in the set) to hold onto the next to-be
+        // visited level.
         if (l.value() == visited_label) {
           l = gen();
         }
 
-        // Will we the next to-be visited level?
+        // Will we miss the next to-be visited level?
         if (next_ptr.is_node() && l.has_value()
             && visited_label < l.value() && l.value() < next_ptr.label()) {
           return zdd::pointer_type::nil();

--- a/src/adiar/zdd/subset.cpp
+++ b/src/adiar/zdd/subset.cpp
@@ -8,19 +8,6 @@
 
 namespace adiar
 {
-  // TODO: Merge with the generator in `bdd_restrict(f, var, val)`.
-  inline auto make_generator(const zdd::label_type &var, bool &gen_called)
-  {
-    adiar_assert(!gen_called);
-    return [&gen_called, &var]() -> optional<zdd::label_type> {
-      if (gen_called) {
-        return make_optional<zdd::label_type>();
-      }
-      gen_called = true;
-      return var;
-    };
-  }
-
   template<assignment FIX_VALUE>
   class zdd_subset_labels
   {
@@ -152,8 +139,7 @@ namespace adiar
 
   __zdd zdd_offset(const exec_policy &ep, const zdd &A, zdd::label_type var)
   {
-    bool gen_called = false;
-    return zdd_offset(ep, A, make_generator(var, gen_called));
+    return zdd_offset(ep, A, make_generator(var));
   }
 
   __zdd zdd_offset(const zdd &A, zdd::label_type var)
@@ -251,8 +237,7 @@ namespace adiar
 
   __zdd zdd_onset(const exec_policy &ep, const zdd &A, zdd::label_type var)
   {
-    bool gen_called = false;
-    return zdd_onset(ep, A, make_generator(var, gen_called));
+    return zdd_onset(ep, A, make_generator(var));
   }
 
   __zdd zdd_onset(const zdd &A, zdd::label_type var)

--- a/test/adiar/CMakeLists.txt
+++ b/test/adiar/CMakeLists.txt
@@ -2,6 +2,7 @@ add_test(adiar-bool_op     test_bool_op.cpp)
 add_test(adiar-builder     test_builder.cpp)
 add_test(adiar-domain      test_domain.cpp)
 add_test(adiar-exec_policy test_exec_policy.cpp)
+add_test(adiar-functional  test_functional.cpp)
 
 add_subdirectory (bdd)
 add_subdirectory (internal)

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -1076,20 +1076,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(0u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(0u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(0u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(0u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(1u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(0u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(0u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(0u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(1u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(0u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(0u));
       });
 
       it("can create x1", [&]() {
@@ -1121,20 +1121,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(2u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(2u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(1u));
       });
 
       it("can create -x1", [&]() {
@@ -1166,20 +1166,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(2u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(2u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(1u));
       });
 
       // TODO: more tests independent of iterators (and differentiating it from bdd_and)
@@ -1203,20 +1203,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(0u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(0u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(0u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(0u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(1u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(0u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(0u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(0u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(1u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(0u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(0u));
       });
 
       it("can create x1", [&]() {
@@ -1245,20 +1245,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(2u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(2u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(1u));
       });
 
       it("can create -x1", [&]() {
@@ -1287,20 +1287,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(2u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(2u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(2u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(1u));
       });
 
       // TODO: more tests independent of iterators (and differentiating it from bdd_and)
@@ -1345,20 +1345,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(3u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(4u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(3u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(4u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(3u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(4u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(3u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(4u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(3u));
       });
 
       it("can create {} as trivially false", [&]() {
@@ -1376,15 +1376,15 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(0u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(0u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(0u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(0u));
         AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(1u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(0u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(0u));
       });
 
       it("can create {x1, -x3}", [&]() {
@@ -1417,20 +1417,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(3u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(2u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(3u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(3u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(2u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(3u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(2u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(2u));
       });
 
       it("can create {-x2, x4}", [&]() {
@@ -1463,20 +1463,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(3u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(2u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(3u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(3u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(2u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(3u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(2u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(2u));
       });
 
       it("skips duplicates", [&]() {
@@ -1517,20 +1517,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(3u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(4u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(3u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(4u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(3u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(4u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(3u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(4u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(3u));
       });
 
       it("works with ForwardIt::value_type == 'ssize_t'", [&]() {
@@ -1579,20 +1579,20 @@ go_bandit([]() {
 
         AssertThat(res->width, Is().EqualTo(1u));
 
-        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(4u));
-        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(5u));
+        AssertThat(res.max_1level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_1level_cut(cut::Internal_True), Is().EqualTo(4u));
+        AssertThat(res.max_1level_cut(cut::All), Is().EqualTo(5u));
 
-        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(4u));
-        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(5u));
+        AssertThat(res.max_2level_cut(cut::Internal), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_False), Is().EqualTo(1u));
+        AssertThat(res.max_2level_cut(cut::Internal_True), Is().EqualTo(4u));
+        AssertThat(res.max_2level_cut(cut::All), Is().EqualTo(5u));
 
         AssertThat(bdd_iscanonical(res), Is().True());
 
-        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(res->number_of_terminals[true],  Is().EqualTo(4u));
+        AssertThat(res.number_of_terminals(false), Is().EqualTo(1u));
+        AssertThat(res.number_of_terminals(true),  Is().EqualTo(4u));
       });
 
       it("throws exception for non-ascending list", []() {

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -941,6 +941,52 @@ go_bandit([]() {
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
       });
 
+      it("works with ForwardIt::value_type == 'uint64_t'", [&]() {
+        std::vector<uint64_t> vars = { 1, 3 };
+
+        bdd res = bdd_and(vars.rbegin(), vars.rend());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(3, node::max_id,
+                                                terminal_F,
+                                                terminal_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(1, node::max_id,
+                                                terminal_F,
+                                                ptr_uint64(3, ptr_uint64::max_id))));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(level_info(1,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+
+        AssertThat(res->width, Is().EqualTo(1u));
+
+        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(3u));
+
+        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(3u));
+
+        AssertThat(bdd_iscanonical(res), Is().True());
+
+        AssertThat(res->number_of_terminals[false], Is().EqualTo(2u));
+        AssertThat(res->number_of_terminals[true],  Is().EqualTo(1u));
+      });
+
       it("throws exception for non-ascending list", []() {
         std::vector<int> vars = { 3, 2 };
 
@@ -1419,6 +1465,68 @@ go_bandit([]() {
 
         AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
         AssertThat(res->number_of_terminals[true],  Is().EqualTo(3u));
+      });
+
+      it("works with ForwardIt::value_type == 'ssize_t'", [&]() {
+        std::vector<ssize_t> vars = { 1, -2, 3, 5 };
+
+        bdd res = bdd_or(vars.rbegin(), vars.rend());
+        node_test_stream ns(res);
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(5, node::max_id,
+                                                terminal_F,
+                                                terminal_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(3, node::max_id,
+                                                ptr_uint64(5, ptr_uint64::max_id),
+                                                terminal_T)));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(2, node::max_id,
+                                                terminal_T,
+                                                ptr_uint64(3, ptr_uint64::max_id))));
+
+        AssertThat(ns.can_pull(), Is().True());
+        AssertThat(ns.pull(), Is().EqualTo(node(1, node::max_id,
+                                                ptr_uint64(2, ptr_uint64::max_id),
+                                                terminal_T)));
+
+        AssertThat(ns.can_pull(), Is().False());
+
+        level_info_test_stream ms(res);
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(level_info(5,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(level_info(3,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(level_info(2,1u)));
+
+        AssertThat(ms.can_pull(), Is().True());
+        AssertThat(ms.pull(), Is().EqualTo(level_info(1,1u)));
+
+        AssertThat(ms.can_pull(), Is().False());
+
+        AssertThat(res->width, Is().EqualTo(1u));
+
+        AssertThat(res->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+        AssertThat(res->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
+        AssertThat(res->max_1level_cut[cut::Internal_True], Is().EqualTo(4u));
+        AssertThat(res->max_1level_cut[cut::All], Is().EqualTo(5u));
+
+        AssertThat(res->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+        AssertThat(res->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
+        AssertThat(res->max_2level_cut[cut::Internal_True], Is().EqualTo(4u));
+        AssertThat(res->max_2level_cut[cut::All], Is().EqualTo(5u));
+
+        AssertThat(bdd_iscanonical(res), Is().True());
+
+        AssertThat(res->number_of_terminals[false], Is().EqualTo(1u));
+        AssertThat(res->number_of_terminals[true],  Is().EqualTo(4u));
       });
 
       it("throws exception for non-ascending list", []() {

--- a/test/adiar/bdd/test_build.cpp
+++ b/test/adiar/bdd/test_build.cpp
@@ -1533,8 +1533,8 @@ go_bandit([]() {
         AssertThat(res.number_of_terminals(true),  Is().EqualTo(3u));
       });
 
-      it("works with ForwardIt::value_type == 'ssize_t'", [&]() {
-        std::vector<ssize_t> vars = { 1, -2, 3, 5 };
+      it("works with ForwardIt::value_type == 'int64_t'", [&]() {
+        std::vector<int64_t> vars = { 1, -2, 3, 5 };
 
         bdd res = bdd_or(vars.rbegin(), vars.rend());
         node_test_stream ns(res);

--- a/test/adiar/test_domain.cpp
+++ b/test/adiar/test_domain.cpp
@@ -150,7 +150,9 @@ go_bandit([]() {
           x = y;
           y = z;
 
-          return x > 13 ?  domain_max+1 : x;
+          return x > 13
+            ? make_optional<domain_var>()
+            : make_optional<domain_var>(x);
         };
 
         domain_set(gen);

--- a/test/adiar/test_functional.cpp
+++ b/test/adiar/test_functional.cpp
@@ -1,0 +1,325 @@
+#include "../test.h"
+
+go_bandit([]() {
+  describe("adiar/functional.h", []() {
+    describe("make_consumer(ForwardIt&, ForwardIt&)", []() {
+      it("consumes values 0, 1, 42 into std::vector<int>", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        consumer<int> c = make_consumer(begin, end);
+
+        AssertThat(xs.at(0), Is().EqualTo(-1));
+        c(0);
+        AssertThat(xs.at(0), Is().EqualTo(0));
+
+        AssertThat(xs.at(1), Is().EqualTo(-1));
+        c(1);
+        AssertThat(xs.at(1), Is().EqualTo(1));
+
+        AssertThat(xs.at(2), Is().EqualTo(-1));
+        c(42);
+        AssertThat(xs.at(2), Is().EqualTo(42));
+      });
+
+      it("consumes values 4, -2 into std::vector<int>", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        consumer<int> c = make_consumer(begin, end);
+
+        AssertThat(xs.at(0), Is().EqualTo(-1));
+        c(4);
+        AssertThat(xs.at(0), Is().EqualTo(4));
+
+        AssertThat(xs.at(1), Is().EqualTo(-1));
+        c(-2);
+        AssertThat(xs.at(1), Is().EqualTo(-2));
+
+        AssertThat(xs.at(2), Is().EqualTo(-1));
+      });
+
+      it("has side effect on begin iterators", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        consumer<int> c = make_consumer(begin, end);
+
+        AssertThat(begin, Is().EqualTo(xs.begin()));
+        c(0);
+        AssertThat(begin, Is().EqualTo(xs.begin()+1));
+        c(0);
+        AssertThat(begin, Is().EqualTo(xs.begin()+2));
+        c(0);
+        AssertThat(begin, Is().EqualTo(xs.begin()+3));
+        AssertThat(begin, Is().EqualTo(end));
+      });
+
+      it("throws exception when overflowing iterator range", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        consumer<int> c = make_consumer(begin, end);
+
+        c(0);
+        c(0);
+        c(0);
+
+        AssertThrows(out_of_range, c(0));
+      });
+    });
+
+    describe("make_consumer(ForwardIt&&, ForwardIt&&)", []() {
+      it("consumes values 2, 4, 8 into std::vector<int>", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        consumer<int> c = make_consumer(xs.begin(), xs.end());
+
+        AssertThat(xs.at(0), Is().EqualTo(-1));
+        c(2);
+        AssertThat(xs.at(0), Is().EqualTo(2));
+
+        AssertThat(xs.at(1), Is().EqualTo(-1));
+        c(4);
+        AssertThat(xs.at(1), Is().EqualTo(4));
+
+        AssertThat(xs.at(2), Is().EqualTo(-1));
+        c(8);
+        AssertThat(xs.at(2), Is().EqualTo(8));
+      });
+
+      it("consumes values 0, 1 into std::vector<int>", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        consumer<int> c = make_consumer(xs.begin(), xs.end());
+
+        AssertThat(xs.at(0), Is().EqualTo(-1));
+        c(0);
+        AssertThat(xs.at(0), Is().EqualTo(0));
+
+        AssertThat(xs.at(1), Is().EqualTo(-1));
+        c(1);
+        AssertThat(xs.at(1), Is().EqualTo(1));
+
+        AssertThat(xs.at(2), Is().EqualTo(-1));
+      });
+
+      it("throws exception when overflowing iterator range", []() {
+        std::vector<int> xs = { -1, -1, -1 };
+
+        consumer<int> c = make_consumer(xs.begin(), xs.end());
+
+        c(0);
+        c(0);
+        c(0);
+
+        AssertThrows(out_of_range, c(0));
+      });
+    });
+
+    describe("make_generator(ForwardIt&, ForwardIt&)", []() {
+      it("wraps std::vector<int> = { }", []() {
+        const std::vector<int> xs = {};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 0 }", []() {
+        const std::vector<int> xs = {0};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 0, 1 }", []() {
+        const std::vector<int> xs = {0,1};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { -1, 0, 1 }", []() {
+        const std::vector<int> xs = {-1, 0, 1};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(-1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 4, 2, 0 }", []() {
+        const std::vector<int> xs = {4,2,0};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(4)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 2, 2 }", []() {
+        const std::vector<int> xs = {2,2};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 2, -1, 0, 2 }", []() {
+        const std::vector<int> xs = {2,-1,0,2};
+
+        auto begin = xs.begin();
+        auto end   = xs.end();
+
+        generator<int> g = make_generator(begin, end);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(-1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+    });
+
+    describe("make_generator(ForwardIt&&, ForwardIt&&)", []() {
+      it("wraps std::vector<int> = { }", []() {
+        const std::vector<int> xs = {};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 0 }", []() {
+        const std::vector<int> xs = {0};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 0, 1 }", []() {
+        const std::vector<int> xs = {0,1};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { -1, 0, 1 }", []() {
+        const std::vector<int> xs = {-1, 0, 1};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(-1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 4, 2, 0 }", []() {
+        const std::vector<int> xs = {4,2,0};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(4)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 2, 2 }", []() {
+        const std::vector<int> xs = {2,2};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("wraps std::vector<int> = { 2, -1, 0, 2 }", []() {
+        const std::vector<int> xs = {2,-1,0,2};
+
+        generator<int> g = make_generator(xs.begin(), xs.end());
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(-1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>(2)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+    });
+
+    describe("make_generator(const RetType&)", []() {
+      it("Can create -1 generator", []() {
+        generator<int> g = make_generator(-1);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(-1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("Can create 0 generator", []() {
+        generator<int> g = make_generator(0);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(0)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("Can create 1 generator", []() {
+        generator<int> g = make_generator(1);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(1)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+
+      it("Can create 42 generator", []() {
+        generator<int> g = make_generator(42);
+
+        AssertThat(g(), Is().EqualTo(make_optional<int>(42)));
+        AssertThat(g(), Is().EqualTo(make_optional<int>()));
+      });
+    });
+  });
+ });

--- a/test/adiar/zdd/test_build.cpp
+++ b/test/adiar/zdd/test_build.cpp
@@ -1359,7 +1359,7 @@ go_bandit([]() {
 
     describe("zdd_top(...)", [&]() {
       it("is { Ø } with empty generator", [&]() {
-        const auto dom = []() { return -1; };
+        const auto dom = []() { return make_optional<zdd::label_type>(); };
 
         zdd res = zdd_top(dom);
         node_test_stream ns(res);
@@ -1391,7 +1391,10 @@ go_bandit([]() {
 
       it("creates { Ø, {0}, ..., {3}, {0,1}, ..., {2,3}, {0,1,2}, ..., {0,1,2,3} } from generator", [&]() {
         int x = 3;
-        const auto dom = [&x]() { return x--; };
+        const auto dom = [&x]() -> optional<zdd::label_type> {
+          if (x < 0) { return make_optional<zdd::label_type>(); }
+          return x--;
+        };
 
         zdd res = zdd_top(dom);
         node_test_stream ns(res);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -60,6 +60,7 @@ go_bandit([]() {
 #include "adiar/internal/data_types/test_convert.cpp"
 
 #include "adiar/test_exec_policy.cpp"
+#include "adiar/test_functional.cpp"
 
 #include "adiar/internal/io/test_file.cpp"
 #include "adiar/internal/io/test_levelized_file.cpp"


### PR DESCRIPTION
Closes #556 . To do so, I had to change the `generator<...>` to use a `std::optional` to mark the end of the stream. Yet, this makes many things easier such as #458 (as we do not need to introduce an obscure `end()` marker).