### PR TITLE
Remove deprecated 'compute_cofactor'

### DIFF
--- a/src/adiar/bdd/bdd_policy.h
+++ b/src/adiar/bdd/bdd_policy.h
@@ -31,19 +31,6 @@ namespace adiar
   {
     return { child, child };
   }
-
-  // TODO: stop using these in favour of 'reduction_rule_inv' above
-  template<>
-  inline void
-  bdd_policy::compute_cofactor(const bool /*on_level*/,
-                               /*const*/ bdd::pointer_type &,
-                               /*const*/ bdd::pointer_type &)
-  { /* do nothing */ }
-
-  template<>
-  inline bdd_policy::children_type
-  bdd_policy::compute_cofactor(const bool /*on_level*/, const bdd_policy::children_type &children)
-  { return children; }
 }
 
 #endif // ADIAR_BDD_BDD_POLICY_H

--- a/src/adiar/internal/algorithms/pred.cpp
+++ b/src/adiar/internal/algorithms/pred.cpp
@@ -73,35 +73,6 @@ namespace adiar::internal
   };
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Special dd_policy for `isomorphism_policy` to be used within the
-  ///        level merger logic.
-  ///
-  /// \see isomorphism_policy
-  //////////////////////////////////////////////////////////////////////////////
-  // TODO (Decision Diagrams with other kinds of pointers):
-  // template<class dd_policy>
-  class isomorphism_dd_policy : public dd_policy<dd, __dd>
-  {
-  public:
-    // Since we guarantee to be on the same level, then we merely provide a noop
-    // (similar to the bdd_policy) for the cofactor.
-    static inline void compute_cofactor([[maybe_unused]] const bool on_curr_level,
-                                        dd::pointer_type &/*low*/,
-                                        dd::pointer_type &/*high*/)
-    { adiar_assert(on_curr_level, "No request have mixed levels"); }
-
-    // Since we guarantee to be on the same level, then we merely provide a noop
-    // (similar to the bdd_policy) for the cofactor.
-    static inline dd::node_type::children_type
-    compute_cofactor([[maybe_unused]] const bool on_curr_level,
-                     const dd::node_type::children_type &children)
-    {
-      adiar_assert(on_curr_level, "No request have mixed levels");
-      return children;
-    }
-  };
-
-  //////////////////////////////////////////////////////////////////////////////
   /// \brief Policy for isomorphism checking with `comparison_check`.
   ///
   /// \pre To use this operation, the following should be satisfied.
@@ -112,8 +83,7 @@ namespace adiar::internal
   // TODO (Decision Diagrams with other kinds of pointers):
   // template<class dd_policy>
   class isomorphism_policy
-    : public dd_policy<dd, __dd>
-    , public prod2_same_level_merger<isomorphism_dd_policy>
+    : public dd_policy<dd, __dd>, public prod2_same_level_merger<dd_policy<dd, __dd>>
   {
   public:
     using level_check_t = input_bound_levels<false>;

--- a/src/adiar/internal/algorithms/pred.h
+++ b/src/adiar/internal/algorithms/pred.h
@@ -205,10 +205,6 @@ namespace adiar::internal
   /// This 'comp_policy' also should inherit (or provide) the general policy for
   /// the decision_diagram used (i.e. bdd_policy in bdd/bdd.h, zdd_policy in
   /// zdd/zdd.h and so on). This provides the following functions
-  ///
-  /// - compute_cofactor:
-  ///   Used to change the low and high children retrieved from the input during
-  ///   the product construction.
   //////////////////////////////////////////////////////////////////////////////
   template<typename comp_policy>
   bool comparison_check(const exec_policy &ep,

--- a/src/adiar/internal/algorithms/prod2.h
+++ b/src/adiar/internal/algorithms/prod2.h
@@ -621,10 +621,6 @@ namespace adiar::internal
   /// decision_diagram used (i.e. bdd_policy in bdd/bdd.h, zdd_policy in
   /// zdd/zdd.h and so on). This provides the following functions
   ///
-  /// - compute_cofactor:
-  ///   Used to change the low and high children retrieved from the input during
-  ///   the product construction.
-  ///
   /// Other parameters are:
   ///
   /// \param in_i  DAGs to combine into one.

--- a/src/adiar/internal/dd.h
+++ b/src/adiar/internal/dd.h
@@ -568,13 +568,10 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// Function declaration
   public:
-
     //////////////////////////////////////////////////////////////////////////////
-    /// \brief Provides the pointer to the node that is the result of applying
-    ///        the specific reduction rule of this decision diagram.
+    /// \brief Result of applying the suppression rule.
     ///
-    /// \details This function is expected to return a pointer to the given node
-    ///          or one of its children.
+    /// \returns A pointer to the node itself or one of its children.
     //////////////////////////////////////////////////////////////////////////////
     static inline pointer_type
     reduction_rule(const node_type &n);
@@ -582,25 +579,11 @@ namespace adiar::internal
     //////////////////////////////////////////////////////////////////////////////
     /// \brief Provides the children of a node that was suppressed.
     ///
-    /// \details While the label and the .
+    /// \details This is the inverse of `reduction_rule`; to fully reconstruct the
+    ///          node, add the variable label next to these children.
     //////////////////////////////////////////////////////////////////////////////
     static inline children_type
     reduction_rule_inv(const pointer_type &child);
-
-    //////////////////////////////////////////////////////////////////////////////
-    /// Please use `reduction_rule_inv` instead!
-    //////////////////////////////////////////////////////////////////////////////
-    static inline void
-    compute_cofactor(const bool on_curr_level,
-                     pointer_type &low,
-                     pointer_type &high);
-
-    //////////////////////////////////////////////////////////////////////////////
-    /// Please use `reduction_rule_inv` instead!
-    //////////////////////////////////////////////////////////////////////////////
-    static inline children_type
-    compute_cofactor(const bool on_curr_level,
-                     const children_type &children);
   };
   /// \endcond
 }

--- a/src/adiar/zdd/zdd_policy.h
+++ b/src/adiar/zdd/zdd_policy.h
@@ -28,27 +28,6 @@ namespace adiar
   {
     return { child, zdd::pointer_type(false) };
   }
-
-  // TODO: stop using these in favour of 'reduction_rule_inv' above
-  template<>
-  inline void
-  zdd_policy::compute_cofactor(bool on_curr_level,
-                               /*const*/ zdd::pointer_type &,
-                               zdd::pointer_type &high)
-  {
-    if (!on_curr_level) { high = zdd::pointer_type(false); }
-  }
-
-  template<>
-  inline zdd::node_type::children_type
-  zdd_policy::compute_cofactor(const bool on_curr_level,
-                               const zdd::node_type::children_type &children)
-  {
-    if (!on_curr_level) {
-      return zdd::node_type::children_type(children[false], zdd::pointer_type(false));
-    }
-    return children;
-  }
 }
 
 #endif // ADIAR_ZDD_ZDD_POLICY_H


### PR DESCRIPTION
Turns out it already has been fully replaced, just never removed...