### PR TITLE
BDD/Remove Domain `bdd_satmin` and `bdd_satmax`

### DIFF
--- a/docs/example/queens.md
+++ b/docs/example/queens.md
@@ -238,11 +238,11 @@ uint64_t n_queens_list(uint64_t N, uint64_t column,
 
       // Obtain the lexicographically minimal true assignment. Well, only one
       // exists, so we get the only one left.
-      adiar::bdd_satmin(restricted_constraints, [&N, &partial_assignment](adiar::bdd::label_t x, bool v) {
+      adiar::bdd_satmin(restricted_constraints, [&N, &partial_assignment](adiar::pair<adiar::bdd::label_t, bool> xv) {
         // Skip all empty (false) locations
-        if (!v) { return; }
+        if (!xv.second) { return; }
 
-        partial_assignment.at(j_of_label(N, x)) = i_of_label(N, x);
+        partial_assignment.at(j_of_label(N, xv.first)) = i_of_label(N, xv.first);
       });
 
       n_queens_print_solution(partial_assignment);

--- a/example/queens.cpp
+++ b/example/queens.cpp
@@ -268,11 +268,11 @@ uint64_t n_queens_list(uint64_t N, uint64_t column,
 
       // Obtain the lexicographically minimal true assignment. Well, only one
       // exists, so we get the only one left.
-      adiar::bdd_satmin(restricted_constraints, [&N, &partial_assignment](adiar::bdd::label_type x, bool v) {
+      adiar::bdd_satmin(restricted_constraints, [&N, &partial_assignment](adiar::pair<adiar::bdd::label_type, bool> xv) {
         // Skip all empty (false) locations
-        if (!v) { return; }
+        if (!xv.second) { return; }
 
-        partial_assignment.at(j_of_label(N, x)) = i_of_label(N, x);
+        partial_assignment.at(j_of_label(N, xv.first)) = i_of_label(N, xv.first);
       });
 
       n_queens_print_solution(partial_assignment);

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -1219,7 +1219,8 @@ namespace adiar
   void bdd_satmin(const bdd &f, const consumer<bdd::label_type, bool> &cb);
 
   //////////////////////////////////////////////////////////////////////////////
-  // TODO: Iterator-based output
+  // TODO: Iterator-based output (fix: ForwardIt::value_type does not match with
+  //       consumer<...> argument types)
   //
   // template<typename ForwardIt>
   // bdd_satmin(const bdd &f, ForwardIt begin, ForwardIt end)
@@ -1245,7 +1246,8 @@ namespace adiar
   void bdd_satmax(const bdd &f, const consumer<bdd::label_type, bool> &cb);
 
   //////////////////////////////////////////////////////////////////////////////
-  // TODO: Iterator-based output
+  // TODO: Iterator-based output (fix: ForwardIt::value_type does not match with
+  //       consumer<...> argument types)
   //
   // template<typename ForwardIt>
   // bdd_satmax(const bdd &f, ForwardIt begin, ForwardIt end)

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -1199,16 +1199,11 @@ namespace adiar
   bdd::label_type bdd_maxvar(const bdd &f);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief   The lexicographically smallest x such that f(x) is true.
+  /// \brief   The lexicographically smallest cube x such that f(x) is true.
   ///
   /// \details Outputs the trace of the low-most path to the true terminal. The
   ///          resulting assignment is lexicographically smallest, where every
   ///          variable is treated as a digit and \f$ x_0 > x_1 > \dots \f$.
-  ///
-  /// \remark  If `domain_isset() == true` then the assignment is to the
-  ///          domain variables (and the visited bdd variables). If only the
-  ///          variables that exist within `f` is of interest, please unset the
-  ///          domain first.
   ///
   /// \returns A bdd whos only path to the `true` terminal reflects the minimal
   ///          assignment.
@@ -1217,11 +1212,6 @@ namespace adiar
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief   The lexicographically smallest x such that f(x) is true.
-  ///
-  /// \remark  If `domain_isset() == true` then the assignment is to the
-  ///          domain variables (and the visited bdd variables). If only the
-  ///          variables that exist within `f` is of interest, please unset the
-  ///          domain first.
   ///
   /// \param cb Callback function that is called in ascending order of the bdd's
   ///           levels with the (var, value) pairs of the assignment.
@@ -1235,16 +1225,11 @@ namespace adiar
   // bdd_satmin(const bdd &f, ForwardIt begin, ForwardIt end)
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief   The lexicographically largest x such that f(x) is true.
+  /// \brief   The lexicographically largest cube x such that f(x) is true.
   ///
   /// \details Outputs the trace of the high-most path to the true terminal. The
   ///          resulting assignment is lexicographically largest, where every
   ///          variable is treated as a digit and \f$ x_0 > x_1 > \dots \f$.
-  ///
-  /// \remark  If `domain_isset() == true` then the assignment is to the
-  ///          domain variables (and the visited bdd variables). If only the
-  ///          variables that exist within `f` is of interest, please unset the
-  ///          domain first.
   ///
   /// \returns A bdd whos only path to the `true` terminal reflects the maximal
   ///          assignment.
@@ -1253,11 +1238,6 @@ namespace adiar
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief   The lexicographically largest x such that f(x) is true.
-  ///
-  /// \remark  If `domain_isset() == true` then the assignment is to the
-  ///          domain variables (and the visited bdd variables). If only the
-  ///          variables that exist within `f` is of interest, please unset the
-  ///          domain first.
   ///
   /// \param cb Callback function that is called in ascending order of the bdd's
   ///           levels with the (var, value) pairs of the assignment.

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -1219,11 +1219,25 @@ namespace adiar
   void bdd_satmin(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c);
 
   //////////////////////////////////////////////////////////////////////////////
-  // TODO: Iterator-based output (fix: ForwardIt::value_type does not match with
-  //       consumer<...> argument types)
-  //
-  // template<typename ForwardIt>
-  // bdd_satmin(const bdd &f, ForwardIt begin, ForwardIt end)
+  /// \brief   The lexicographically smallest x such that f(x) is true.
+  ///
+  /// \param f     BDD of interest.
+  ///
+  /// \param begin Single-pass forward iterator for where to place the output.
+  ///
+  /// \param end   Marks the end for `begin`.
+  ///
+  /// \returns     An iterator to the first entry that still is left empty.
+  ///
+  /// \throws out_of_range If the distance between `begin` and `end` is not big
+  ///                      enough to contain all variables in `f`.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename ForwardIt>
+  ForwardIt bdd_satmin(const bdd &f, ForwardIt begin, ForwardIt end)
+  {
+    bdd_satmin(f, make_consumer(begin, end));
+    return begin;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief   The lexicographically largest cube x such that f(x) is true.
@@ -1245,12 +1259,27 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   void bdd_satmax(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c);
 
+
   //////////////////////////////////////////////////////////////////////////////
-  // TODO: Iterator-based output (fix: ForwardIt::value_type does not match with
-  //       consumer<...> argument types)
-  //
-  // template<typename ForwardIt>
-  // bdd_satmax(const bdd &f, ForwardIt begin, ForwardIt end)
+  /// \brief   The lexicographically largest x such that f(x) is true.
+  ///
+  /// \param f     BDD of interest.
+  ///
+  /// \param begin Single-pass forward iterator for where to place the output.
+  ///
+  /// \param end   Marks the end for `begin`.
+  ///
+  /// \returns     An iterator to the first entry that still is left empty.
+  ///
+  /// \throws out_of_range If the distance between `begin` and `end` is not big
+  ///                      enough to contain all variables in `f`.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename ForwardIt>
+  ForwardIt bdd_satmax(const bdd &f, ForwardIt begin, ForwardIt end)
+  {
+    bdd_satmax(f, make_consumer(begin, end));
+    return begin;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief    Evaluate a BDD according to an assignment to its variables.

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -1213,10 +1213,10 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   /// \brief   The lexicographically smallest x such that f(x) is true.
   ///
-  /// \param cb Callback function that is called in ascending order of the bdd's
-  ///           levels with the (var, value) pairs of the assignment.
+  /// \param c Consumer that is called in ascending order of the bdd's levels
+  ///          with the (var, value) pairs of the assignment.
   //////////////////////////////////////////////////////////////////////////////
-  void bdd_satmin(const bdd &f, const consumer<bdd::label_type, bool> &cb);
+  void bdd_satmin(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c);
 
   //////////////////////////////////////////////////////////////////////////////
   // TODO: Iterator-based output (fix: ForwardIt::value_type does not match with
@@ -1240,10 +1240,10 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   /// \brief   The lexicographically largest x such that f(x) is true.
   ///
-  /// \param cb Callback function that is called in ascending order of the bdd's
-  ///           levels with the (var, value) pairs of the assignment.
+  /// \param c Consumer that is called in ascending order of the bdd's levels
+  ///          with the (var, value) pairs of the assignment.
   //////////////////////////////////////////////////////////////////////////////
-  void bdd_satmax(const bdd &f, const consumer<bdd::label_type, bool> &cb);
+  void bdd_satmax(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c);
 
   //////////////////////////////////////////////////////////////////////////////
   // TODO: Iterator-based output (fix: ForwardIt::value_type does not match with

--- a/src/adiar/bdd/evaluate.cpp
+++ b/src/adiar/bdd/evaluate.cpp
@@ -3,8 +3,9 @@
 #include <tpie/tpie.h>
 #include <tpie/internal_stack.h>
 
-#include <adiar/domain.h>
 #include <adiar/exception.h>
+#include <adiar/functional.h>
+
 #include <adiar/internal/cut.h>
 #include <adiar/internal/assert.h>
 #include <adiar/internal/util.h>
@@ -131,9 +132,9 @@ namespace adiar
       return next_ptr;
     }
 
-    void visit(const bool s)
+    void visit(const bool t)
     {
-      _visitor.visit(s);
+      _visitor.visit(t);
     }
 
   public:
@@ -172,9 +173,9 @@ namespace adiar
       return next_ptr;
     }
 
-    void visit(const bool s)
+    void visit(const bool t)
     {
-      _visitor.visit(s);
+      _visitor.visit(t);
     }
   };
 

--- a/src/adiar/bdd/evaluate.cpp
+++ b/src/adiar/bdd/evaluate.cpp
@@ -127,9 +127,9 @@ namespace adiar
 
     bdd::pointer_type visit(const bdd::node_type &n)
     {
-      const bdd::pointer_type next_ptr = _visitor.visit(n);
-      _stack.push({n.label(), next_ptr == n.low()});
-      return next_ptr;
+      const bdd::pointer_type next = _visitor.visit(n);
+      _stack.push({n.label(), next == n.low()});
+      return next;
     }
 
     void visit(const bool t)
@@ -159,18 +159,18 @@ namespace adiar
   {
   private:
     Visitor _visitor;
-    const consumer<bdd::label_type, bool> &_consumer;
+    const consumer<pair<bdd::label_type, bool>> &_consumer;
 
   public:
-    bdd_satX__functional(const consumer<bdd::label_type, bool> &c)
+    bdd_satX__functional(const consumer<pair<bdd::label_type, bool>> &c)
       : _consumer(c)
     { }
 
     bdd::pointer_type visit(const bdd::node_type &n)
     {
-      const bdd::pointer_type next_ptr = _visitor.visit(n);
-      _consumer(n.label(), next_ptr == n.high());
-      return next_ptr;
+      const bdd::pointer_type next = _visitor.visit(n);
+      _consumer({n.label(), next == n.high()});
+      return next;
     }
 
     void visit(const bool t)
@@ -191,7 +191,7 @@ namespace adiar
   }
 
   template<typename Visitor>
-  void __bdd_satX(const bdd &f, const consumer<bdd::label_type, bool> &c)
+  void __bdd_satX(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c)
   {
     bdd_satX__functional<Visitor> v(c);
     internal::traverse(f, v);
@@ -202,7 +202,7 @@ namespace adiar
     return __bdd_satX<internal::traverse_satmin_visitor>(f);
   }
 
-  void bdd_satmin(const bdd &f, const consumer<bdd::label_type, bool> &c)
+  void bdd_satmin(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c)
   {
     return __bdd_satX<internal::traverse_satmin_visitor>(f, c);
   }
@@ -212,7 +212,7 @@ namespace adiar
     return __bdd_satX<internal::traverse_satmax_visitor>(f);
   }
 
-  void bdd_satmax(const bdd &f, const consumer<bdd::label_type, bool> &c)
+  void bdd_satmax(const bdd &f, const consumer<pair<bdd::label_type, bool>> &c)
   {
     return __bdd_satX<internal::traverse_satmax_visitor>(f, c);
   }

--- a/src/adiar/functional.h
+++ b/src/adiar/functional.h
@@ -57,8 +57,8 @@ namespace adiar
   /// \tparam Args List of the argument's type in the order, they are supposed
   ///              to be given.
   //////////////////////////////////////////////////////////////////////////////
-  template<typename... Args>
-  using consumer = function<void (Args...)>;
+  template<typename Arg>
+  using consumer = function<void (Arg)>;
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief  Wrap a `begin` and `end` iterator pair into a consumer function.

--- a/src/adiar/internal/algorithms/traverse.h
+++ b/src/adiar/internal/algorithms/traverse.h
@@ -10,13 +10,22 @@
 
 namespace adiar::internal
 {
-  template<typename dd_t, typename traverse_visitor>
-  void traverse(const dd_t &dd, traverse_visitor &visitor)
+  //////////////////////////////////////////////////////////////////////////////
+  //  Traverse Algorithm
+  // ====================
+  //
+  // Traversal of a Decision Diagram together with callbacks for a Visitor to
+  // follow along and pick whereto go.
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename Dd, typename Visitor>
+  void traverse(const Dd &dd, Visitor &visitor)
   {
     node_stream<> in_nodes(dd);
 
-    typename dd_t::node_type n   = in_nodes.pull();
-    typename dd_t::pointer_type  tgt = n.uid();
+    typename Dd::node_type n      = in_nodes.pull();
+    typename Dd::pointer_type tgt = n.uid();
 
     while (!tgt.is_terminal() && !tgt.is_nil()) {
       while (n.uid() < tgt) { n = in_nodes.pull(); }
@@ -27,40 +36,50 @@ namespace adiar::internal
       tgt = visitor.visit(n);
 
       adiar_assert((tgt == n.low()) || (tgt == n.high()) || (tgt.is_nil()),
-                   "Visitor pointer should be within the diagram or nil");
+                   "Visitor pointer should be a child or nil");
     }
     if (!tgt.is_nil()) {
       visitor.visit(tgt.value());
     }
   }
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Implementation of Visitor logic, traversing the lexicographically
+  ///        smallest assignment.
+  ///
+  /// \details Picks the high arc as long as it does not goto `false`.
+  //////////////////////////////////////////////////////////////////////////////
   class traverse_satmin_visitor
   {
   public:
     static constexpr bool default_direction = false;
 
-    inline ptr_uint64 visit(const node &n)
+    inline node::pointer_type visit(const node &n)
     {
-      // Only pick high, if low is the false terminal
       return n.low().is_false() ? n.high() : n.low();
     }
 
-    inline void visit(const bool /*s*/)
+    inline void visit(const bool/*t*/)
     { }
   };
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Implementation of Visitor logic, traversing the lexicographically
+  ///        largest assignment.
+  ///
+  /// \details Picks the low arc as long as it does not goto the `false`.
+  //////////////////////////////////////////////////////////////////////////////
   class traverse_satmax_visitor
   {
   public:
     static constexpr bool default_direction = true;
 
-    inline ptr_uint64 visit(const node &n)
+    inline node::pointer_type visit(const node &n)
     {
-      // Pick high as long it is not the false terminal
-      return n.high().is_node() || n.high().value() ? n.high() : n.low();
+      return n.high().is_false() ? n.low() : n.high();
     }
 
-    inline void visit(const bool /*s*/)
+    inline void visit(const bool/*t*/)
     { }
   };
 }

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -1227,10 +1227,25 @@ namespace adiar
   void zdd_minelem(const zdd &A, const consumer<zdd::label_type> &cb);
 
   //////////////////////////////////////////////////////////////////////////////
-  // TODO: Iterator-based output
-  //
-  // template<typename ForwardIt>
-  // zdd_minelem(const zdd &A, ForwardIt begin, ForwardIt end)
+  /// \brief       Retrieves the lexicographically smallest set a in A.
+  ///
+  /// \param A     Set of sets of interest.
+  ///
+  /// \param begin Single-pass forward iterator for where to place the output.
+  ///
+  /// \param end   Marks the end for `begin`.
+  ///
+  /// \returns     An iterator to the first entry that still is left empty.
+  ///
+  /// \throws out_of_range If the distance between `begin` and `end` is not big
+  ///                      enough to contain all variables in `f`.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename ForwardIt>
+  ForwardIt zdd_minelem(const zdd &A, ForwardIt begin, ForwardIt end)
+  {
+    zdd_minelem(A, make_consumer(begin, end));
+    return begin;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief   Retrieves the lexicographically largest set a in A.
@@ -1256,10 +1271,25 @@ namespace adiar
   void zdd_maxelem(const zdd &A, const consumer<zdd::label_type> &cb);
 
   //////////////////////////////////////////////////////////////////////////////
-  // TODO: Iterator-based output
-  //
-  // template<typename ForwardIt>
-  // zdd_maxelem(const zdd &A, ForwardIt begin, ForwardIt end)
+  /// \brief       Retrieves the lexicographically largest set a in A.
+  ///
+  /// \param A     Set of sets of interest.
+  ///
+  /// \param begin Single-pass forward iterator for where to place the output.
+  ///
+  /// \param end   Marks the end for `begin`.
+  ///
+  /// \returns     An iterator to the first entry that still is left empty.
+  ///
+  /// \throws out_of_range If the distance between `begin` and `end` is not big
+  ///                      enough to contain all variables in `f`.
+  //////////////////////////////////////////////////////////////////////////////
+  template<typename ForwardIt>
+  ForwardIt zdd_maxelem(const zdd &A, ForwardIt begin, ForwardIt end)
+  {
+    zdd_maxelem(A, make_consumer(begin, end));
+    return begin;
+  }
 
   /// \}
   //////////////////////////////////////////////////////////////////////////////

--- a/test/adiar/bdd/test_evaluate.cpp
+++ b/test/adiar/bdd/test_evaluate.cpp
@@ -984,7 +984,7 @@ go_bandit([]() {
       describe("bdd_satmin(f, c)", [&]() {
         it("never calls consumer for true terminal", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type, bool) { calls++; };
+          const auto cb = [&calls](pair<bdd::label_type, bool>) { calls++; };
 
           bdd_satmin(bdd_T, cb);
           AssertThat(calls, Is().EqualTo(0u));
@@ -992,7 +992,7 @@ go_bandit([]() {
 
         it("never calls consumer for false terminal", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type, bool) { calls++; };
+          const auto cb = [&calls](pair<bdd::label_type, bool>) { calls++; };
 
           bdd_satmin(bdd_F, cb);
           AssertThat(calls, Is().EqualTo(0u));
@@ -1000,10 +1000,10 @@ go_bandit([]() {
 
         it("calls consumer once with 'x0 == true' for [0]", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type x, bool v) {
+          const auto cb = [&calls](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().EqualTo(0u));
-            AssertThat(x, Is().EqualTo(0u));
-            AssertThat(v, Is().EqualTo(true));
+            AssertThat(xv.first,  Is().EqualTo(0u));
+            AssertThat(xv.second, Is().EqualTo(true));
 
             calls++;
           };
@@ -1014,10 +1014,10 @@ go_bandit([]() {
 
         it("calls consumer once with 'x0 == false' for [~0]", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type x, bool v) {
+          const auto cb = [&calls](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().EqualTo(0u));
-            AssertThat(x, Is().EqualTo(0u));
-            AssertThat(v, Is().EqualTo(true));
+            AssertThat(xv.first,  Is().EqualTo(0u));
+            AssertThat(xv.second, Is().EqualTo(true));
 
             calls++;
           };
@@ -1031,10 +1031,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, true}, {3, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1047,10 +1047,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, false}, {3, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1063,10 +1063,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, true}, {3, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
 
             calls++;
           };
@@ -1080,10 +1080,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
 
             calls++;
           };
@@ -1097,10 +1097,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {1, false}, {3, false}, {5, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1113,10 +1113,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {1, false}, {3, false}, {5, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1129,10 +1129,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {2, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1145,10 +1145,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {2, true}, {3, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1613,7 +1613,7 @@ go_bandit([]() {
       describe("bdd_satmax(f, c)", [&]() {
         it("never calls consumer for true terminal", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type, bool) { calls++; };
+          const auto cb = [&calls](pair<bdd::label_type, bool>) { calls++; };
 
           bdd_satmax(bdd_T, cb);
           AssertThat(calls, Is().EqualTo(0u));
@@ -1621,7 +1621,7 @@ go_bandit([]() {
 
         it("never calls consumer for false terminal", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type, bool) { calls++; };
+          const auto cb = [&calls](pair<bdd::label_type, bool>) { calls++; };
 
           bdd_satmax(bdd_F, cb);
           AssertThat(calls, Is().EqualTo(0u));
@@ -1629,10 +1629,10 @@ go_bandit([]() {
 
         it("calls consumer once with 'x0 == true' for [0]", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type x, bool v) {
+          const auto cb = [&calls](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().EqualTo(0u));
-            AssertThat(x, Is().EqualTo(0u));
-            AssertThat(v, Is().EqualTo(true));
+            AssertThat(xv.first,  Is().EqualTo(0u));
+            AssertThat(xv.second, Is().EqualTo(true));
 
             calls++;
           };
@@ -1643,10 +1643,10 @@ go_bandit([]() {
 
         it("calls consumer once with 'x0 == false' for [~0]", [&]() {
           size_t calls = 0u;
-          const auto cb = [&calls](bdd::label_type x, bool v) {
+          const auto cb = [&calls](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().EqualTo(0u));
-            AssertThat(x, Is().EqualTo(0u));
-            AssertThat(v, Is().EqualTo(true));
+            AssertThat(xv.first,  Is().EqualTo(0u));
+            AssertThat(xv.second, Is().EqualTo(true));
 
             calls++;
           };
@@ -1660,10 +1660,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {2, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1676,10 +1676,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {2, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1692,10 +1692,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {2, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1708,10 +1708,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {2, false}, {3, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1724,10 +1724,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {1, true}, {5, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1740,10 +1740,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {1, true}, {5, false} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1756,10 +1756,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {1, true}, {2, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 
@@ -1772,10 +1772,10 @@ go_bandit([]() {
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {1, true}, {2, false}, {3, true} };
 
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+          const auto cb = [&calls, &expected](pair<bdd::label_type, bool> xv) {
             AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            AssertThat(xv.first,  Is().EqualTo(expected.at(calls).first));
+            AssertThat(xv.second, Is().EqualTo(expected.at(calls).second));
             calls++;
           };
 

--- a/test/adiar/bdd/test_evaluate.cpp
+++ b/test/adiar/bdd/test_evaluate.cpp
@@ -387,7 +387,7 @@ go_bandit([]() {
       */
       {
         node_writer nw(bdd_0);
-        nw << node(0,0, terminal_F, terminal_T);
+        nw << node(0, bdd::max_id, terminal_F, terminal_T);
       }
 
       shared_levelized_file<bdd::node_type> bdd_1;
@@ -404,11 +404,11 @@ go_bandit([]() {
       */
 
       {
-        node n5 = node(3,0, terminal_F, terminal_T);
-        node n4 = node(2,1, terminal_T, terminal_F);
-        node n3 = node(2,0, terminal_F, n5.uid());
-        node n2 = node(1,0, n3.uid(), n4.uid());
-        node n1 = node(0,0, n2.uid(), n4.uid());
+        node n5 = node(3, bdd::max_id,   terminal_F, terminal_T);
+        node n4 = node(2, bdd::max_id,   terminal_T, terminal_F);
+        node n3 = node(2, bdd::max_id-1, terminal_F, n5.uid());
+        node n2 = node(1, bdd::max_id,   n3.uid(),   n4.uid());
+        node n1 = node(0, bdd::max_id,   n2.uid(),   n4.uid());
 
         node_writer nw(bdd_1);
         nw << n5 << n4 << n3 << n2 << n1;
@@ -430,12 +430,12 @@ go_bandit([]() {
       */
 
       { // Garbage collect writer to free write-lock
-        node n6 = node(3,0, terminal_T, terminal_F);
-        node n5 = node(2,2, n6.uid(), terminal_T);
-        node n4 = node(2,1, terminal_T, terminal_F);
-        node n3 = node(2,0, terminal_F, n6.uid());
-        node n2 = node(1,0, n3.uid(), n4.uid());
-        node n1 = node(0,0, n2.uid(), n5.uid());
+        node n6 = node(3,bdd::max_id,   terminal_T, terminal_F);
+        node n5 = node(2,bdd::max_id,   n6.uid(),   terminal_T);
+        node n4 = node(2,bdd::max_id-1, terminal_T, terminal_F);
+        node n3 = node(2,bdd::max_id-2, terminal_F, n6.uid());
+        node n2 = node(1,bdd::max_id,   n3.uid(),   n4.uid());
+        node n1 = node(0,bdd::max_id,   n2.uid(),   n5.uid());
 
         node_writer nw(bdd_2);
         nw << n6 << n5 << n4 << n3 << n2 << n1;
@@ -453,18 +453,43 @@ go_bandit([]() {
       */
 
       { // Garbage collect writer to free write-lock
-        node n4 = node(5,1, terminal_F, terminal_T);
-        node n3 = node(5,0, terminal_T, terminal_F);
-        node n2 = node(3,0, n3.uid(), n4.uid());
-        node n1 = node(1,0, n2.uid(), n4.uid());
+        node n4 = node(5,bdd::max_id,   terminal_F, terminal_T);
+        node n3 = node(5,bdd::max_id-1, terminal_T, terminal_F);
+        node n2 = node(3,bdd::max_id,   n3.uid(),   n4.uid());
+        node n1 = node(1,bdd::max_id,   n2.uid(),   n4.uid());
 
         node_writer nw(bdd_3);
         nw << n4 << n3 << n2 << n1;
       }
 
-      describe("bdd_satmin(f) [bdd levels]", [&]() {
-        domain_unset();
+      shared_levelized_file<bdd::node_type> bdd_4;
+      /*
+      //               1       ---- x0
+      //              / \
+      //             /   2     ---- x1
+      //            /   / \
+      //           3   4   5   ---- x2
+      //          / \ / \ / \
+      //          T | T F | T  ---- x3
+      //            \__ __/
+      //               6
+      //              / \
+      //              T F
+      */
 
+      { // Garbage collect writer to free write-lock
+        node n6 = node(3,bdd::max_id,   terminal_T, terminal_F);
+        node n5 = node(2,bdd::max_id,   n6.uid(),   terminal_T);
+        node n4 = node(2,bdd::max_id-1, terminal_T, terminal_F);
+        node n3 = node(2,bdd::max_id-2, terminal_T, n6.uid());
+        node n2 = node(1,bdd::max_id,   n4.uid(),   n5.uid());
+        node n1 = node(0,bdd::max_id,   n3.uid(),   n2.uid());
+
+        node_writer nw(bdd_4);
+        nw << n6 << n5 << n4 << n3 << n2 << n1;
+      }
+
+      describe("bdd_satmin(f)", [&]() {
         it("returns same file for true terminal", [&]() {
           bdd out = bdd_satmin(bdd_T);
           AssertThat(out.file_ptr(), Is().EqualTo(bdd_T));
@@ -475,7 +500,7 @@ go_bandit([]() {
           AssertThat(out.file_ptr(), Is().EqualTo(bdd_F));
         });
 
-        it("should retrieve evaluation [0]", [&]() {
+        it("returns minimal BDD cube [0]", [&]() {
           bdd out = bdd_satmin(bdd_0);
 
           // Check it looks all right
@@ -509,7 +534,41 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve evaluation [1]", [&]() {
+        it("returns minimal BDD cube [~0]", [&]() {
+          bdd out = bdd_satmin(bdd_not(bdd_0));
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(2u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns minimal BDD cube [1]", [&]() {
           bdd out = bdd_satmin(bdd_1);
 
           // Check it looks all right
@@ -567,20 +626,15 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve evaluation [~1]", [&]() {
+        it("returns minimal BDD cube [~1]", [&]() {
           bdd out  = bdd_satmin(bdd_not(bdd_1));
 
           // Check it looks all right
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         terminal_T,
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         bdd::pointer_type(3, bdd::max_id),
+                                                         terminal_T,
                                                          terminal_F)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
@@ -598,9 +652,6 @@ go_bandit([]() {
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
@@ -612,20 +663,20 @@ go_bandit([]() {
           AssertThat(out_meta.can_pull(), Is().False());
 
           AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(3u));
           AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(4u));
 
           AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(3u));
           AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(4u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(4u));
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve evaluation [2]", [&]() {
+        it("returns minimal BDD cube [2]", [&]() {
           bdd out = bdd_satmin(bdd_2);
 
           // Check it looks all right
@@ -683,7 +734,57 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve evaluation [3]", [&]() {
+        it("returns minimal BDD cube [~2]", [&]() {
+          bdd out = bdd_satmin(bdd_not(bdd_2));
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
+                                                         bdd::pointer_type(2, bdd::max_id),
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
+                                                         bdd::pointer_type(1, bdd::max_id),
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(3u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(4u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(3u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns minimal BDD cube [3]", [&]() {
           bdd out = bdd_satmin(bdd_3);
 
 
@@ -733,12 +834,61 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
-      });
 
-      describe("bdd_satmin(f) [domain]", [&]() {
-        it("should retrieve evaluation [0] in domain { 0,1,2 }", [&]() {
-          domain_set(3);
-          bdd out = bdd_satmin(bdd_0);
+        it("returns minimal BDD cube [~3]", [&]() {
+          bdd out = bdd_satmin(bdd_not(bdd_3));
+
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, bdd::max_id,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
+                                                         bdd::pointer_type(5, bdd::max_id),
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
+                                                         bdd::pointer_type(3, bdd::max_id),
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(3u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(4u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(3u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(4u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns minimal BDD cube [4]", [&]() {
+          bdd out = bdd_satmin(bdd_4);
+
 
           // Check it looks all right
           node_test_stream out_nodes(out);
@@ -749,14 +899,9 @@ go_bandit([]() {
                                                          terminal_F)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
                                                          bdd::pointer_type(2, bdd::max_id),
                                                          terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(1, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -766,7 +911,55 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns minimal BDD cube [~4]", [&]() {
+          bdd out = bdd_satmin(bdd_not(bdd_4));
+
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
+                                                         terminal_F,
+                                                         bdd::pointer_type(3, bdd::max_id))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
+                                                         bdd::pointer_type(2, bdd::max_id),
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
@@ -786,83 +979,10 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
-
-        it("should retrieve evaluation [2] in domain { 0,2,4 }", [&]() {
-          std::vector<domain_var> dom = { 0,2,4 };
-          domain_set(dom.begin(), dom.end());
-
-          bdd out = bdd_satmin(bdd_2);
-
-          // Check it looks all right
-          node_test_stream out_nodes(out);
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, bdd::max_id,
-                                                         terminal_T,
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         bdd::pointer_type(4, bdd::max_id),
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(3, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
-                                                         bdd::pointer_type(2, bdd::max_id),
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
-                                                         bdd::pointer_type(1, bdd::max_id),
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().False());
-
-          level_info_test_stream out_meta(out);
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().False());
-
-          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(5u));
-          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(6u));
-
-          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(5u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(6u));
-
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(5u));
-          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-        });
-
-        domain_unset();
       });
 
-      describe("bdd_satmin(f, cb) [bdd levels]", [&]() {
-        domain_unset();
-
-        it("is never called for true terminal", [&]() {
+      describe("bdd_satmin(f, c)", [&]() {
+        it("never calls consumer for true terminal", [&]() {
           size_t calls = 0u;
           const auto cb = [&calls](bdd::label_type, bool) { calls++; };
 
@@ -870,7 +990,7 @@ go_bandit([]() {
           AssertThat(calls, Is().EqualTo(0u));
         });
 
-        it("is never called for false terminal", [&]() {
+        it("never calls consumer for false terminal", [&]() {
           size_t calls = 0u;
           const auto cb = [&calls](bdd::label_type, bool) { calls++; };
 
@@ -878,7 +998,7 @@ go_bandit([]() {
           AssertThat(calls, Is().EqualTo(0u));
         });
 
-        it("is called once for [0]", [&]() {
+        it("calls consumer once with 'x0 == true' for [0]", [&]() {
           size_t calls = 0u;
           const auto cb = [&calls](bdd::label_type x, bool v) {
             AssertThat(calls, Is().EqualTo(0u));
@@ -892,7 +1012,21 @@ go_bandit([]() {
           AssertThat(calls, Is().EqualTo(1u));
         });
 
-        it("is called with expected evaluation [1]", [&]() {
+        it("calls consumer once with 'x0 == false' for [~0]", [&]() {
+          size_t calls = 0u;
+          const auto cb = [&calls](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().EqualTo(0u));
+            AssertThat(x, Is().EqualTo(0u));
+            AssertThat(v, Is().EqualTo(true));
+
+            calls++;
+          };
+
+          bdd_satmin(bdd_0, cb);
+          AssertThat(calls, Is().EqualTo(1u));
+        });
+
+        it("calls consumer with minimal truth assignment [1]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, true}, {3, true} };
@@ -908,7 +1042,7 @@ go_bandit([]() {
           AssertThat(calls, Is().EqualTo(4u));
         });
 
-        it("is called with expected evaluation [~1]", [&]() {
+        it("calls consumer with minimal truth assignment [~1]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, false}, {3, false} };
@@ -921,10 +1055,10 @@ go_bandit([]() {
           };
 
           bdd_satmin(bdd_not(bdd_1), cb);
-          AssertThat(calls, Is().EqualTo(4u));
+          AssertThat(calls, Is().EqualTo(3u));
         });
 
-        it("is called with expected evaluation [2]", [&]() {
+        it("calls consumer with minimal truth assignment [2]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, false}, {1, false}, {2, true}, {3, false} };
@@ -941,7 +1075,24 @@ go_bandit([]() {
           AssertThat(calls, Is().EqualTo(4u));
         });
 
-        it("is called with expected evaluation [3]", [&]() {
+        it("calls consumer with minimal truth assignment [~2]", [&]() {
+          size_t calls = 0;
+          std::vector<std::pair<bdd::label_type, bool>> expected =
+            { {0, false}, {1, false}, {2, false} };
+
+          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().LessThan(expected.size()));
+            AssertThat(x, Is().EqualTo(expected.at(calls).first));
+            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+
+            calls++;
+          };
+
+          bdd_satmin(bdd_not(bdd_2), cb);
+          AssertThat(calls, Is().EqualTo(3u));
+        });
+
+        it("calls consumer with minimal truth assignment [3]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {1, false}, {3, false}, {5, false} };
@@ -956,100 +1107,161 @@ go_bandit([]() {
           bdd_satmin(bdd_3, cb);
           AssertThat(calls, Is().EqualTo(3u));
         });
-      });
 
-      describe("bdd_satmin(f, cb) [bdd levels]", [&]() {
-        it("is called with full domain for [0]", [&]() {
-          domain_set(2);
-
+        it("calls consumer with minimal truth assignment [~3]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {1, false} };
+            { {1, false}, {3, false}, {5, true} };
 
           const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
             AssertThat(calls, Is().LessThan(expected.size()));
             AssertThat(x, Is().EqualTo(expected.at(calls).first));
             AssertThat(v, Is().EqualTo(expected.at(calls).second));
-
             calls++;
           };
 
-          bdd_satmin(bdd_0, cb);
+          bdd_satmin(bdd_not(bdd_3), cb);
+          AssertThat(calls, Is().EqualTo(3u));
+        });
+
+        it("calls consumer with minimal truth assignment [4]", [&]() {
+          size_t calls = 0;
+          std::vector<std::pair<bdd::label_type, bool>> expected =
+            { {0, false}, {2, false} };
+
+          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().LessThan(expected.size()));
+            AssertThat(x, Is().EqualTo(expected.at(calls).first));
+            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            calls++;
+          };
+
+          bdd_satmin(bdd_4, cb);
           AssertThat(calls, Is().EqualTo(2u));
         });
 
-        it("is called with expected evaluation [2]", [&]() {
-          std::vector<bdd::label_type> dom = { 0,2,4 };
-          domain_set(dom.begin(), dom.end());
-
+        it("calls consumer with minimal truth assignment [~4]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, false}, {1, false}, {2, true}, {3, false}, {4, false} };
+            { {0, false}, {2, true}, {3, true} };
 
           const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
             AssertThat(calls, Is().LessThan(expected.size()));
             AssertThat(x, Is().EqualTo(expected.at(calls).first));
             AssertThat(v, Is().EqualTo(expected.at(calls).second));
-
             calls++;
           };
 
-          bdd_satmin(bdd_2, cb);
-          AssertThat(calls, Is().EqualTo(5u));
+          bdd_satmin(bdd_not(bdd_4), cb);
+          AssertThat(calls, Is().EqualTo(3u));
         });
       });
 
-      describe("bdd_satmin(f, begin, end) [bdd levels]", [&]() {
-        domain_unset();
-
+      describe("bdd_satmin(f, begin, end)", [&]() {
         // TODO
       });
 
-      describe("bdd_satmin(f, begin, end) [domain]", [&]() {
-        // TODO
-      });
+      describe("bdd_satmax(f)", [&]() {
+        it("returns same file for true terminal", [&]() {
+          bdd out = bdd_satmax(bdd_T);
+          AssertThat(out.file_ptr(), Is().EqualTo(bdd_T));
+        });
 
-      describe("bdd_satmax(f) [bdd levels]", [&]() {
-        domain_unset();
+        it("returns same file for false terminal", [&]() {
+          bdd out = bdd_satmax(bdd_F);
+          AssertThat(out.file_ptr(), Is().EqualTo(bdd_F));
+        });
 
-        it("should retrieve maximal evaluation [1]", [&]() {
+        it("returns maximal BDD cube [0]", [&]() {
+          bdd out = bdd_satmax(bdd_0);
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(2u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns maximal BDD cube [~0]", [&]() {
+          bdd out = bdd_satmax(bdd_not(bdd_0));
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
+                                                         terminal_T,
+                                                         terminal_F)));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(2u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(2u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns maximal BDD cube [1]", [&]() {
           bdd out = bdd_satmax(bdd_1);
 
           // Check it looks all right
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         terminal_F,
-                                                         terminal_T)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         bdd::pointer_type(3, bdd::max_id),
+                                                         terminal_T,
                                                          terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(2, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(1, bdd::max_id))));
+                                                         bdd::pointer_type(2, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
@@ -1057,57 +1269,41 @@ go_bandit([]() {
           AssertThat(out_meta.can_pull(), Is().False());
 
           AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
           AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(4u));
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve maximal evaluation [~1]", [&]() {
+        it("returns maximal BDD cube [~1]", [&]() {
           bdd out = bdd_satmax(bdd_not(bdd_1));
 
           // Check it looks all right
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
                                                          terminal_F,
                                                          terminal_T)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(3, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(2, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(1, bdd::max_id))));
+                                                         bdd::pointer_type(2, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
@@ -1115,57 +1311,41 @@ go_bandit([]() {
           AssertThat(out_meta.can_pull(), Is().False());
 
           AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
           AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(4u));
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve maximal evaluation [2]", [&]() {
+        it("returns maximal BDD cube [2]", [&]() {
           bdd out = bdd_satmax(bdd_2);
 
           // Check it looks all right
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
                                                          terminal_F,
                                                          terminal_T)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(3, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(2, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(1, bdd::max_id))));
+                                                         bdd::pointer_type(2, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
@@ -1173,20 +1353,20 @@ go_bandit([]() {
           AssertThat(out_meta.can_pull(), Is().False());
 
           AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
           AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(4u));
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve maximal evaluation [~2]", [&]() {
+        it("returns maximal BDD cube [~2]", [&]() {
           bdd out = bdd_satmax(bdd_not(bdd_2));
 
           // Check it looks all right
@@ -1203,14 +1383,9 @@ go_bandit([]() {
                                                          terminal_F)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(2, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(1, bdd::max_id))));
+                                                         bdd::pointer_type(2, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1223,28 +1398,25 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
           AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(3u));
           AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(4u));
 
           AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(4u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(3u));
           AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(4u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(4u));
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve maximal evaluation [3]", [&]() {
+        it("returns maximal BDD cube [3]", [&]() {
           bdd out = bdd_satmax(bdd_3);
 
           // Check it looks all right
@@ -1256,14 +1428,9 @@ go_bandit([]() {
                                                          terminal_T)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(5, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(3, bdd::max_id))));
+                                                         bdd::pointer_type(5, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1273,28 +1440,25 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(5,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
           AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(3u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(4u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
           AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(3u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
           AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(4u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
 
-        it("should retrieve maximal evaluation [~3]", [&]() {
+        it("returns maximal BDD cube [~3]", [&]() {
           bdd out = bdd_satmax(bdd_not(bdd_3));
 
           // Check it looks all right
@@ -1306,14 +1470,9 @@ go_bandit([]() {
                                                          terminal_F)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(5, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(3, bdd::max_id))));
+                                                         bdd::pointer_type(5, bdd::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
@@ -1323,10 +1482,57 @@ go_bandit([]() {
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(5,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().False());
+
+          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
+
+          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
+          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
+
+          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
+        });
+
+        it("returns maximal BDD cube [4]", [&]() {
+          bdd out = bdd_satmax(bdd_4);
+
+          // Check it looks all right
+          node_test_stream out_nodes(out);
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
+                                                         terminal_F,
+                                                         terminal_T)));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
+                                                         terminal_F,
+                                                         bdd::pointer_type(2, bdd::max_id))));
+
+          AssertThat(out_nodes.can_pull(), Is().True());
+          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
+                                                         terminal_F,
+                                                         bdd::pointer_type(1, bdd::max_id))));
+
+          AssertThat(out_nodes.can_pull(), Is().False());
+
+          level_info_test_stream out_meta(out);
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
+
+          AssertThat(out_meta.can_pull(), Is().True());
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -1343,30 +1549,18 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[false], Is().EqualTo(3u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
-      });
 
-      describe("bdd_satmax(f) [domain]", [&]() {
-        it("should retrieve maximal evaluation [~1] in domain { 0, 1, ..., 5 }", [&]() {
-          domain_set(6);
-          bdd out = bdd_satmax(bdd_1);
+        it("returns maximal BDD cube [~4]", [&]() {
+          bdd out = bdd_satmax(bdd_not(bdd_4));
+
 
           // Check it looks all right
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, bdd::max_id,
-                                                         terminal_F,
-                                                         terminal_T)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(5, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
                                                          terminal_F,
-                                                         bdd::pointer_type(4, bdd::max_id))));
+                                                         terminal_T)));
 
           AssertThat(out_nodes.can_pull(), Is().True());
           AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
@@ -1388,12 +1582,6 @@ go_bandit([]() {
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
@@ -1401,136 +1589,6 @@ go_bandit([]() {
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().False());
-
-          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(6u));
-          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(7u));
-
-          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(6u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(7u));
-
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(6u));
-          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-        });
-
-        it("should retrieve maximal evaluation [~2] in domain { 0, 1, ..., 5 }", [&]() {
-          domain_set(5);
-
-          bdd out = bdd_satmax(bdd_not(bdd_2));
-
-          // Check it looks all right
-          node_test_stream out_nodes(out);
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, bdd::max_id,
-                                                         terminal_F,
-                                                         terminal_T)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(4, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         bdd::pointer_type(3, bdd::max_id),
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(2, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(1, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().False());
-
-          level_info_test_stream out_meta(out);
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().False());
-
-          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(5u));
-          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(6u));
-
-          AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(5u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(6u));
-
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(5u));
-          AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
-        });
-
-        it("should retrieve maximal evaluation [~2] in domain { 0, 2, 4 }", [&]() {
-          std::vector<bdd::label_type> dom = { 0,2,4 };
-          domain_set(dom.begin(), dom.end());
-
-          bdd out = bdd_satmax(bdd_not(bdd_2));
-
-          // Check it looks all right
-          node_test_stream out_nodes(out);
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, bdd::max_id,
-                                                         terminal_F,
-                                                         terminal_T)));
-
-          // Notice, this variable is outside the domain but on the traversed path!
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(4, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, bdd::max_id,
-                                                         bdd::pointer_type(3, bdd::max_id),
-                                                         terminal_F)));
-
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, bdd::max_id,
-                                                         terminal_F,
-                                                         bdd::pointer_type(2, bdd::max_id))));
-
-          AssertThat(out_nodes.can_pull(), Is().False());
-
-          level_info_test_stream out_meta(out);
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
           AssertThat(out_meta.pull(), Is().EqualTo(level_info(0,1u)));
@@ -1550,17 +1608,57 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[false], Is().EqualTo(4u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(1u));
         });
-
-        domain_unset();
       });
 
-      describe("bdd_satmax(f, cb) [bdd levels]", [&]() {
-        domain_unset();
+      describe("bdd_satmax(f, c)", [&]() {
+        it("never calls consumer for true terminal", [&]() {
+          size_t calls = 0u;
+          const auto cb = [&calls](bdd::label_type, bool) { calls++; };
 
-        it("should retrieve maximal evaluation [1]", [&]() {
+          bdd_satmax(bdd_T, cb);
+          AssertThat(calls, Is().EqualTo(0u));
+        });
+
+        it("never calls consumer for false terminal", [&]() {
+          size_t calls = 0u;
+          const auto cb = [&calls](bdd::label_type, bool) { calls++; };
+
+          bdd_satmax(bdd_F, cb);
+          AssertThat(calls, Is().EqualTo(0u));
+        });
+
+        it("calls consumer once with 'x0 == true' for [0]", [&]() {
+          size_t calls = 0u;
+          const auto cb = [&calls](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().EqualTo(0u));
+            AssertThat(x, Is().EqualTo(0u));
+            AssertThat(v, Is().EqualTo(true));
+
+            calls++;
+          };
+
+          bdd_satmax(bdd_0, cb);
+          AssertThat(calls, Is().EqualTo(1u));
+        });
+
+        it("calls consumer once with 'x0 == false' for [~0]", [&]() {
+          size_t calls = 0u;
+          const auto cb = [&calls](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().EqualTo(0u));
+            AssertThat(x, Is().EqualTo(0u));
+            AssertThat(v, Is().EqualTo(true));
+
+            calls++;
+          };
+
+          bdd_satmax(bdd_0, cb);
+          AssertThat(calls, Is().EqualTo(1u));
+        });
+
+        it("calls consumer with maximal truth assignment [1]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {1, true}, {2, false}, {3, true} };
+            { {0, true}, {2, false} };
 
           const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
             AssertThat(calls, Is().LessThan(expected.size()));
@@ -1570,13 +1668,13 @@ go_bandit([]() {
           };
 
           bdd_satmax(bdd_1, cb);
-          AssertThat(calls, Is().EqualTo(4u));
+          AssertThat(calls, Is().EqualTo(2u));
         });
 
-        it("should retrieve maximal evaluation [~1]", [&]() {
+        it("calls consumer with maximal truth assignment [~1]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {1, true}, {2, true}, {3, true} };
+            { {0, true}, {2, true} };
 
           const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
             AssertThat(calls, Is().LessThan(expected.size()));
@@ -1586,13 +1684,13 @@ go_bandit([]() {
           };
 
           bdd_satmax(bdd_not(bdd_1), cb);
-          AssertThat(calls, Is().EqualTo(4u));
+          AssertThat(calls, Is().EqualTo(2u));
         });
 
-        it("should retrieve maximal evaluation [2]", [&]() {
+        it("calls consumer with maximal truth assignment [2]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {1, true}, {2, true}, {3, true} };
+            { {0, true}, {2, true} };
 
           const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
             AssertThat(calls, Is().LessThan(expected.size()));
@@ -1602,10 +1700,74 @@ go_bandit([]() {
           };
 
           bdd_satmax(bdd_2, cb);
-          AssertThat(calls, Is().EqualTo(4u));
+          AssertThat(calls, Is().EqualTo(2u));
         });
 
-        it("should retrieve maximal evaluation [~2]", [&]() {
+        it("calls consumer with maximal truth assignment [~2]", [&]() {
+          size_t calls = 0;
+          std::vector<std::pair<bdd::label_type, bool>> expected =
+            { {0, true}, {2, false}, {3, true} };
+
+          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().LessThan(expected.size()));
+            AssertThat(x, Is().EqualTo(expected.at(calls).first));
+            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            calls++;
+          };
+
+          bdd_satmax(bdd_not(bdd_2), cb);
+          AssertThat(calls, Is().EqualTo(3u));
+        });
+
+        it("calls consumer with maximal truth assignment [3]", [&]() {
+          size_t calls = 0;
+          std::vector<std::pair<bdd::label_type, bool>> expected =
+            { {1, true}, {5, true} };
+
+          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().LessThan(expected.size()));
+            AssertThat(x, Is().EqualTo(expected.at(calls).first));
+            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            calls++;
+          };
+
+          bdd_satmax(bdd_3, cb);
+          AssertThat(calls, Is().EqualTo(2u));
+        });
+
+        it("calls consumer with maximal truth assignment [~3]", [&]() {
+          size_t calls = 0;
+          std::vector<std::pair<bdd::label_type, bool>> expected =
+            { {1, true}, {5, false} };
+
+          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().LessThan(expected.size()));
+            AssertThat(x, Is().EqualTo(expected.at(calls).first));
+            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            calls++;
+          };
+
+          bdd_satmax(bdd_not(bdd_3), cb);
+          AssertThat(calls, Is().EqualTo(2u));
+        });
+
+        it("calls consumer with maximal truth assignment [4]", [&]() {
+          size_t calls = 0;
+          std::vector<std::pair<bdd::label_type, bool>> expected =
+            { {0, true}, {1, true}, {2, true} };
+
+          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
+            AssertThat(calls, Is().LessThan(expected.size()));
+            AssertThat(x, Is().EqualTo(expected.at(calls).first));
+            AssertThat(v, Is().EqualTo(expected.at(calls).second));
+            calls++;
+          };
+
+          bdd_satmax(bdd_4, cb);
+          AssertThat(calls, Is().EqualTo(3u));
+        });
+
+        it("calls consumer with maximal truth assignment [~4]", [&]() {
           size_t calls = 0;
           std::vector<std::pair<bdd::label_type, bool>> expected =
             { {0, true}, {1, true}, {2, false}, {3, true} };
@@ -1617,114 +1779,14 @@ go_bandit([]() {
             calls++;
           };
 
-          bdd_satmax(bdd_not(bdd_2), cb);
+          bdd_satmax(bdd_not(bdd_4), cb);
           AssertThat(calls, Is().EqualTo(4u));
         });
-
-        it("should retrieve maximal evaluation [3]", [&]() {
-          size_t calls = 0;
-          std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {1, true}, {3, true}, {5, true} };
-
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
-            AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
-            calls++;
-          };
-
-          bdd_satmax(bdd_3, cb);
-          AssertThat(calls, Is().EqualTo(3u));
-        });
-
-        it("should retrieve maximal evaluation [~3]", [&]() {
-          size_t calls = 0;
-          std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {1, true}, {3, true}, {5, false} };
-
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
-            AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
-            calls++;
-          };
-
-          bdd_satmax(bdd_not(bdd_3), cb);
-          AssertThat(calls, Is().EqualTo(3u));
-        });
       });
 
-      describe("bdd_satmax(f, cb) [domain]", [&]() {
-        it("should retrieve maximal evaluation [~1] in domain { 0, 1, ..., 5 }", [&]() {
-          domain_set(6);
-
-          size_t calls = 0;
-          std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {1, true}, {2, false}, {3, true}, {4, true}, {5, true} };
-
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
-            AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
-            calls++;
-          };
-
-          bdd_satmax(bdd_1, cb);
-          AssertThat(calls, Is().EqualTo(6u));
-        });
-
-        it("should retrieve maximal evaluation [~2] in domain { 0, 1, ..., 5 }", [&]() {
-          domain_set(5);
-
-          size_t calls = 0;
-          std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {1, true}, {2, false}, {3, true}, {4, true} };
-
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
-            AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
-            calls++;
-          };
-
-          bdd_satmax(bdd_not(bdd_2), cb);
-          AssertThat(calls, Is().EqualTo(5u));
-        });
-
-        it("should retrieve maximal evaluation [~2] in domain { 0, 2, 4 }", [&]() {
-          std::vector<bdd::label_type> dom = { 0,2,4 };
-          domain_set(dom.begin(), dom.end());
-
-          bdd out = bdd_satmax(bdd_not(bdd_2));
-
-          size_t calls = 0;
-          std::vector<std::pair<bdd::label_type, bool>> expected =
-            { {0, true}, {2, false}, {3, true}, {4, true} };
-
-          const auto cb = [&calls, &expected](bdd::label_type x, bool v) {
-            AssertThat(calls, Is().LessThan(expected.size()));
-            AssertThat(x, Is().EqualTo(expected.at(calls).first));
-            AssertThat(v, Is().EqualTo(expected.at(calls).second));
-            calls++;
-          };
-
-          bdd_satmax(bdd_not(bdd_2), cb);
-          AssertThat(calls, Is().EqualTo(3u + 1u));
-        });
-
-        domain_unset();
-      });
-
-      describe("bdd_satmax(f, begin, end) [bdd levels]", [&]() {
-        domain_unset();
-
+      describe("bdd_satmax(f, begin, end)", [&]() {
         // TODO
       });
-
-      describe("bdd_satmax(f, begin, end) [domain]", [&]() {
-        // TODO
-      });
-
     } // bdd_satmin, bdd_satmax
   });
  });

--- a/test/adiar/zdd/test_elem.cpp
+++ b/test/adiar/zdd/test_elem.cpp
@@ -291,14 +291,14 @@ go_bandit([]() {
       });
     });
 
-    describe("zdd_minelem(A, cb)", [&]() {
+    describe("zdd_minelem(A, c)", [&]() {
       it("makes no calls for { Ø } on { Ø }", [&]() {
         size_t calls = 0u;
-        const auto cb = [&calls](zdd::label_type) {
+        const auto c = [&calls](zdd::label_type) {
           calls++;
         };
 
-        zdd_minelem(zdd_T, cb);
+        zdd_minelem(zdd_T, c);
         AssertThat(calls, Is().EqualTo(0u));
       });
 
@@ -306,22 +306,22 @@ go_bandit([]() {
         size_t calls = 0u;
         std::vector<zdd::label_type> expected { 1 };
 
-        const auto cb = [&calls, &expected](zdd::label_type x) {
+        const auto c = [&calls, &expected](zdd::label_type x) {
           AssertThat(x, Is().EqualTo(expected.at(calls)));
           calls++;
         };
 
-        zdd_minelem(zdd_1, cb);
+        zdd_minelem(zdd_1, c);
         AssertThat(calls, Is().EqualTo(1u));
       });
 
       it("makes no calls for { Ø } on [2]", [&]() {
         size_t calls = 0u;
-        const auto cb = [&calls](zdd::label_type) {
+        const auto c = [&calls](zdd::label_type) {
           calls++;
         };
 
-        zdd_minelem(zdd_2, cb);
+        zdd_minelem(zdd_2, c);
         AssertThat(calls, Is().EqualTo(0u));
       });
 
@@ -329,12 +329,12 @@ go_bandit([]() {
         size_t calls = 0u;
         std::vector<zdd::label_type> expected { 2,4 };
 
-        const auto cb = [&calls, &expected](zdd::label_type x) {
+        const auto c = [&calls, &expected](zdd::label_type x) {
           AssertThat(x, Is().EqualTo(expected.at(calls)));
           calls++;
         };
 
-        zdd_minelem(zdd_3, cb);
+        zdd_minelem(zdd_3, c);
         AssertThat(calls, Is().EqualTo(2u));
       });
 
@@ -342,13 +342,104 @@ go_bandit([]() {
         size_t calls = 0u;
         std::vector<zdd::label_type> expected { 1 };
 
-        const auto cb = [&calls, &expected](zdd::label_type x) {
+        const auto c = [&calls, &expected](zdd::label_type x) {
           AssertThat(x, Is().EqualTo(expected.at(calls)));
           calls++;
         };
 
-        zdd_minelem(zdd_4, cb);
+        zdd_minelem(zdd_4, c);
         AssertThat(calls, Is().EqualTo(1u));
+      });
+    });
+
+    describe("zdd_minelem(A, begin, end)", [&]() {
+      using buffer_type = std::vector<zdd::label_type>;
+
+      const buffer_type::value_type buffer_default(zdd::max_label+1);
+      const size_t buffer_size = 4;
+
+      it("outputs { } in buffer for { Ø }", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_minelem(zdd_T, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+0));
+
+        buffer_type expected(buffer_size, buffer_default);
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("outputs { 1 } in buffer for [1]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_minelem(zdd_1, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+1));
+
+        buffer_type expected(buffer_size, buffer_default);
+        expected.at(0) = 1;
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("throws 'out_of_range' if buffer is too small [1]", [&]() {
+        buffer_type buffer(0, buffer_default);
+        AssertThrows(out_of_range, zdd_minelem(zdd_1, buffer.begin(), buffer.end()));
+      });
+
+      it("outputs { } in buffer for [2]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_minelem(zdd_2, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+0));
+
+        buffer_type expected(buffer_size, buffer_default);
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("outputs { 2,4 } in buffer for [3]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_minelem(zdd_3, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+2));
+
+        buffer_type expected(buffer_size, buffer_default);
+        expected.at(0) = 2;
+        expected.at(1) = 4;
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("throws 'out_of_range' if buffer is too small [3]", [&]() {
+        buffer_type buffer(1, buffer_default);
+        AssertThrows(out_of_range, zdd_minelem(zdd_3, buffer.begin(), buffer.end()));
+      });
+
+      it("outputs { 1 } in buffer for [4]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_minelem(zdd_4, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+1));
+
+        buffer_type expected(buffer_size, buffer_default);
+        expected.at(0) = 1;
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
       });
     });
 
@@ -528,15 +619,14 @@ go_bandit([]() {
       });
     });
 
-
-    describe("zdd_maxelem(A, cb)", [&]() {
+    describe("zdd_maxelem(A, c)", [&]() {
       it("makes no calls for { Ø } on { Ø }", [&]() {
         size_t calls = 0u;
-        const auto cb = [&calls](zdd::label_type) {
+        const auto c = [&calls](zdd::label_type) {
           calls++;
         };
 
-        zdd_maxelem(zdd_T, cb);
+        zdd_maxelem(zdd_T, c);
         AssertThat(calls, Is().EqualTo(0u));
 
         zdd out = zdd_maxelem(zdd_T);
@@ -546,12 +636,12 @@ go_bandit([]() {
         size_t calls = 0u;
         std::vector<zdd::label_type> expected { 0,2 };
 
-        const auto cb = [&calls, &expected](zdd::label_type x) {
+        const auto c = [&calls, &expected](zdd::label_type x) {
           AssertThat(x, Is().EqualTo(expected.at(calls)));
           calls++;
         };
 
-        zdd_maxelem(zdd_1, cb);
+        zdd_maxelem(zdd_1, c);
         AssertThat(calls, Is().EqualTo(2u));
       });
 
@@ -559,12 +649,12 @@ go_bandit([]() {
         size_t calls = 0u;
         std::vector<zdd::label_type> expected { 1 };
 
-        const auto cb = [&calls, &expected](zdd::label_type x) {
+        const auto c = [&calls, &expected](zdd::label_type x) {
           AssertThat(x, Is().EqualTo(expected.at(calls)));
           calls++;
         };
 
-        zdd_maxelem(zdd_2, cb);
+        zdd_maxelem(zdd_2, c);
         AssertThat(calls, Is().EqualTo(1u));
       });
 
@@ -572,13 +662,96 @@ go_bandit([]() {
         size_t calls = 0u;
         std::vector<zdd::label_type> expected { 0,1 };
 
-        const auto cb = [&calls, &expected](zdd::label_type x) {
+        const auto c = [&calls, &expected](zdd::label_type x) {
           AssertThat(x, Is().EqualTo(expected.at(calls)));
           calls++;
         };
 
-        zdd_maxelem(zdd_4, cb);
+        zdd_maxelem(zdd_4, c);
         AssertThat(calls, Is().EqualTo(2u));
+      });
+    });
+
+    describe("zdd_maxelem(A, begin, end)", [&]() {
+      using buffer_type = std::vector<zdd::label_type>;
+
+      const buffer_type::value_type buffer_default(zdd::max_label+1);
+      const size_t buffer_size = 4;
+
+      it("outputs { } in buffer for { Ø }", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_maxelem(zdd_T, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+0));
+
+        buffer_type expected(buffer_size, buffer_default);
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("outputs { 0,2 } in buffer for [1]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_maxelem(zdd_1, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+2));
+
+        buffer_type expected(buffer_size, buffer_default);
+        expected.at(0) = 0;
+        expected.at(1) = 2;
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("throws 'out_of_range' if buffer is too small [1]", [&]() {
+        buffer_type buffer(1, buffer_default);
+        AssertThrows(out_of_range, zdd_maxelem(zdd_1, buffer.begin(), buffer.end()));
+      });
+
+      it("outputs { 1 } in buffer for [2]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_maxelem(zdd_2, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+1));
+
+        buffer_type expected(buffer_size, buffer_default);
+        expected.at(0) = 1;
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("throws 'out_of_range' if buffer is too small [2]", [&]() {
+        buffer_type buffer(0, buffer_default);
+        AssertThrows(out_of_range, zdd_maxelem(zdd_2, buffer.begin(), buffer.end()));
+      });
+
+      it("outputs { 0,1 } in buffer for [4]", [&]() {
+        buffer_type buffer(buffer_size, buffer_default);
+
+        auto ret = zdd_maxelem(zdd_4, buffer.begin(), buffer.end());
+
+        AssertThat(ret, Is().EqualTo(buffer.begin()+2));
+
+        buffer_type expected(buffer_size, buffer_default);
+        expected.at(0) = 0;
+        expected.at(1) = 1;
+
+        for (size_t i = 0; i < buffer_size; ++i) {
+          AssertThat(buffer.at(i), Is().EqualTo(expected.at(i)));
+        }
+      });
+
+      it("throws 'out_of_range' if buffer is too small [4]", [&]() {
+        buffer_type buffer(1, buffer_default);
+        AssertThrows(out_of_range, zdd_maxelem(zdd_4, buffer.begin(), buffer.end()));
       });
     });
   });


### PR DESCRIPTION
**Tasks**

- [x] Reverts #504 . Furthermore, does also ignores skipped levels of the BDD. This not only simplifies the code, but makes `bdd_satmin` and `bdd_satmax` closer to other BDD packages (e.g. BuDDy).
- [x] Makes `bdd_mincube` and `bdd_maxcube` redudant, as `bdd_satmin` and `bdd_satmax` already is this exact thing ( closes #454 ).
- [x] Add iterator overloads for `bdd_satmin` and `bdd_satmax` ( closes #225 )
- [x] Add iterator overloads for `zdd_minelem` and `zdd_maxelem`

Also various code cleanup for anything traversal related... This makes *src/bdd/evaluate.cpp* and *src/zdd/elem.cpp* eerily similar. But, I have to think a bit more on how truly to merge the common pieces of code.