### PR TITLE
Fix MacOS test actions consistently inconsistently breaks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,11 +76,8 @@ jobs:
     - name: Build tests
       working-directory: ${{runner.workspace}}
       run: |
-        export CC=${{env.cc}}
-        if [ "${{ matrix.cc.cc }}" != "gcc" ] ;
-        then
-          export CXX=${{env.cxx}}
-        fi
+        export CC=${{ env.cc }}
+        export CXX=${{ env.cxx }}
 
         cmake -E make_directory ${{github.workspace}}/build
         cd ${{github.workspace}}/build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,7 +106,7 @@ jobs:
           - { cc: gcc,   v: 12, cxx: g++ } # newest
 
           # Clang Compiler
-          - { cc: clang, v: 11, cxx: clang++ } # oldest possible
+          - { cc: clang, v: 12, cxx: clang++ } # oldest possible
           - { cc: clang, v: 14, cxx: clang++ } # default
           - { cc: clang, v: 15, cxx: clang++ } # newst possible
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -67,8 +67,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        if ["${{matrix.cc.cc}}" == "gcc"];
-        then
+        if [ "${{matrix.cc.cc}}" = "gcc" ]; then
           echo "================================"
           echo "Compiler"
           brew install ${{matrix.cc.cc}}@${{matrix.cc.v}}
@@ -86,8 +85,7 @@ jobs:
     - name: Build tests
       working-directory: ${{runner.workspace}}
       run: |
-        if [ "${{ matrix.cc.cc }}" == "gcc" ] ;
-        then
+        if [ "${{ matrix.cc.cc }}" = "gcc" ]; then
           export CC=/usr/bin/${{matrix.cc.cc}}
           export CXX=/usr/bin/${{matrix.cc.cxx}}
         else

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -54,6 +54,12 @@ jobs:
         submodules: 'recursive'
 
     # Install dependencies
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+      with:
+        cask: false # remove this if you need `brew install --cask`
+        test-bot: false # remove this if you need `brew test-bot`
+
     - name: Install xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -61,8 +67,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew update
-
         if ["${{matrix.cc.cc}}" == "gcc"];
         then
           echo "================================"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -86,11 +86,11 @@ jobs:
       working-directory: ${{runner.workspace}}
       run: |
         if [ "${{ matrix.cc.cc }}" = "gcc" ]; then
-          export CC=/usr/bin/${{matrix.cc.cc}}
-          export CXX=/usr/bin/${{matrix.cc.cxx}}
+          export CC=${{ matrix.cc.cc }}-${{ matrix.cc.v }}
+          export CXX=${{ matrix.cc.cxx }}-${{ matrix.cc.v }}
         else
-          export CC=${{matrix.cc.cc}}
-          export CXX=${{matrix.cc.cxx}}
+          export CC=${{ matrix.cc.cc }}
+          export CXX=${{ matrix.cc.cxx }}
         fi
 
         cmake -E make_directory ${{github.workspace}}/build


### PR DESCRIPTION
As suggested on the Homebrew repository (Issue 15621). Furthermore, fixed that the Mac (and Linux) build with GCC do not actually use the requested compiler (or version).

This exposes quite a few warnings that should be addressed in the future in some *other* PR.