### PR TITLE
Internal/nested sweeping/exec policy settings

### DIFF
--- a/src/adiar/bdd/if_then_else.cpp
+++ b/src/adiar/bdd/if_then_else.cpp
@@ -595,8 +595,8 @@ namespace adiar
     const size_t pq_3_memory_fits =
       ite_priority_queue_3_t<internal::memory_mode::Internal>::memory_fits(pq_3_internal_memory);
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_1_bound = std::min({__ite_ilevel_upper_bound<internal::get_2level_cut, 2u>(f, g, h),
                                         __ite_ilevel_upper_bound(f, g, h)});

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -149,7 +149,7 @@ namespace adiar
     /// \details To safe on space, the value is stored in a char. Hence, the
     ///          precision is only 1/254 for values in the interval [-1,1].
     ////////////////////////////////////////////////////////////////////////////
-    signed char _nested_reduce_epsilon = 6; // <-- 4.7%
+    signed char _nested_reduce_epsilon = -1; // TODO: set to positive value
 
   public:
     ////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -114,8 +114,15 @@ namespace adiar
       };
 
       //////////////////////////////////////////////////////////////////////////
-      /// \brief Epsilon value for maximal growth a BDD may grow during repeated
-      ///        transpostion before switching to Nested Sweeping.
+      /// \brief Multiplicative value for the maximal growth of a BDD may during
+      ///        repeated transpostion before switching to Nested Sweeping.
+      ///
+      /// \details A value of `1.0` is equivalent to the original input size.
+      ///          Larger Values reflect an acceptable increase in size. A value
+      ///          between `0.0` and `1.0` requires the BDD to shrink to
+      ///          continue repeating transposition.
+      ///
+      /// \details A negative value will result in undefined behaviour.
       //////////////////////////////////////////////////////////////////////////
       class transposition_growth
       {
@@ -124,7 +131,7 @@ namespace adiar
         static constexpr transposition_growth
         min()
         {
-          return -1.0;
+          return 0.0;
         }
 
         /// \brief Maximal value
@@ -283,7 +290,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Maximal growth during repeated transposition of `quantify`.
     ////////////////////////////////////////////////////////////////////////////
-    quantify::transposition_growth _quantify__transposition_growth = 0.5;
+    quantify::transposition_growth _quantify__transposition_growth = 1.5f;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Maximal number of repeated transpositions in `quantify`.
@@ -295,7 +302,7 @@ namespace adiar
     ///        expensive node merging computations (if applicable).
     ////////////////////////////////////////////////////////////////////////////
     // TODO: set to ~5%
-    nested::fast_reduce _nested__fast_reduce = -1.0;
+    nested::fast_reduce _nested__fast_reduce = -1.0f;
 
   public:
     ////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -46,7 +46,7 @@ namespace adiar
     ///
     /// \see bdd_apply zdd_binop
     ////////////////////////////////////////////////////////////////////////////
-    enum class access
+    enum class access : char
     {
       /** Pick \em Random Access when an input is narrow enough. */
       Auto,
@@ -74,7 +74,7 @@ namespace adiar
     /// \warning Using `Internal` may lead to crashes if an input or output is
     ///          too large!
     ////////////////////////////////////////////////////////////////////////////
-    enum class memory
+    enum class memory : char
     {
       /** Pick \em internal memory as long as it is safe to do so. */
       Auto,
@@ -99,7 +99,7 @@ namespace adiar
     ///
     /// \see bdd_exists bdd_forall zdd_project
     ////////////////////////////////////////////////////////////////////////////
-    enum class quantify
+    enum class quantify : char
     {
       /** Automatically decide what approach to use (may switch half-way). */
       Auto,

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -126,12 +126,15 @@ namespace adiar
       //////////////////////////////////////////////////////////////////////////
       class transposition_growth
       {
+      private:
+        static constexpr float min_val = 0.0f;
+
       public:
         /// \brief Minimal value
         static constexpr transposition_growth
         min()
         {
-          return 0.0f;
+          return min_val;
         }
 
         /// \brief Maximal value
@@ -144,6 +147,14 @@ namespace adiar
       private:
         float _value;
 
+        /// \brief Convert into a `signed char`
+        static constexpr float
+        from_float(float f)
+        {
+          // Truncate `f` to be in the interval [0.0f, ...)
+          return f < min_val ? min_val : f;
+        }
+
       public:
         constexpr transposition_growth()
           : _value(1.5f)
@@ -151,7 +162,7 @@ namespace adiar
 
         /// \brief Wrap a `float`.
         constexpr transposition_growth(float value)
-          : _value(value)
+          : _value(from_float(value))
         {}
 
         /// \brief Reobtain the wrapped `float`

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -115,6 +115,68 @@ namespace adiar
 
     // TODO: Move Nested Sweeping constants/strategies in here too...
 
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Settings for Nested Sweeping framework
+    ////////////////////////////////////////////////////////////////////////////
+    class nested
+    {
+    public:
+      //////////////////////////////////////////////////////////////////////////
+      /// \brief Chosen epsilon value for Nested Sweeping to start skipping the
+      ///        expensive node merging computations (if applicable).
+      ///
+      /// \details During Nested Sweeping, if a later sweep will touch a level
+      ///          again, one can postpone merging duplicate nodes. This does
+      ///          no apply to the last Reduce sweep up. So, the final diagram
+      ///          is still canonical.
+      ///
+      /// \details Setting this value to *1.0* is equivalent to always using the
+      ///          fast reduce. On the other hand, setting it to a negative
+      ///          value turns this optimisation of.
+      ///
+      /// \details To safe on space, the value is stored in a char. Hence, this
+      ///          option can only be set in increments of ~1%.
+      //////////////////////////////////////////////////////////////////////////
+      class fast_reduce
+      {
+      private:
+        signed char _value;
+
+        /// \brief Number of ticks in the interval [0,1] and [-1,0]
+        static constexpr float ticks = std::numeric_limits<signed char>::max();
+
+        /// \brief Convert into a `signed char`
+        static constexpr signed char from_float(float f)
+        {
+          // Truncate `f` to be in the interval [-1,1]
+          if (1.0 < f) { f = 1.0; } else if (f < -1.0) { f = -1.0; }
+
+          // Multiply by 'ticks' to extend the interval *[-1,1]* into
+          // *[-ticks,ticks]*. Then, convert to an integral value. This
+          // introduces a loss of precision.
+          return static_cast<signed char>(f * ticks);
+        }
+
+      public:
+        /// \brief Conversion constructor from `float`.
+        constexpr fast_reduce(float f)
+          : _value{from_float(f)}
+        { }
+
+        /// \brief Reobtain this value as a `float`.
+        operator float() const
+        {
+          return static_cast<double>(this->_value) / ticks;
+        }
+
+        bool
+        operator== (const fast_reduce &other) const
+        {
+          return this->_value == other._value;
+        }
+      };
+    };
+
   private:
     // TODO: Merge all enums into a single 64 bit integer to safe on space?
 
@@ -136,20 +198,9 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen epsilon value for Nested Sweeping to start skipping the
     ///        expensive node merging computations (if applicable).
-    ///
-    /// \details During Nested Sweeping, if a later sweep will touch a level
-    ///          again, one can postpone dealing with merging duplicate nodes.
-    ///          This does not apply to the last Reduce sweep up, so the final
-    ///          diagram is still canonical.
-    ///
-    /// \details Setting this value to 0 is equivalent to always using the fast
-    ///          reduce. On the other hand, setting it to a negative value turns
-    ///          this optimisation of.
-    ///
-    /// \details To safe on space, the value is stored in a char. Hence, the
-    ///          precision is only 1/254 for values in the interval [-1,1].
     ////////////////////////////////////////////////////////////////////////////
-    signed char _nested_reduce_epsilon = -1; // TODO: set to positive value
+    // TODO: set to positive value
+    nested::fast_reduce _nested__fast_reduce = -1.0;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -188,6 +239,13 @@ namespace adiar
       : _quantify(qm)
     { }
 
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Conversion construction from `quantify` enum.
+    ////////////////////////////////////////////////////////////////////////////
+    exec_policy(const nested::fast_reduce &fr)
+      : _nested__fast_reduce(fr)
+    { }
+
     // TODO: constructor with defaults for a specific 'version number'?
 
   public:
@@ -208,16 +266,6 @@ namespace adiar
     template <typename T>
     const T& get() const;
 
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief Chosen \f$ \epsilon \f$ threshold to trigger the fast Reduce
-    ///        within Nested Sweeping.
-    ////////////////////////////////////////////////////////////////////////////
-    float nested_reduce_epsilon() const
-    {
-      constexpr double tick_distance = std::numeric_limits<signed char>::max();
-      return static_cast<double>(this->_nested_reduce_epsilon) / tick_distance;
-    }
-
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Check for equality of settings.
@@ -228,6 +276,7 @@ namespace adiar
       return this->_memory  == ep._memory
           && this->_access  == ep._access
           && this->_quantify == ep._quantify
+          && this->_nested__fast_reduce == ep._nested__fast_reduce
         ;
     }
 
@@ -293,6 +342,24 @@ namespace adiar
       exec_policy ep = *this;
       return ep.set(qs);
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Set the quantify strategy.
+    ////////////////////////////////////////////////////////////////////////////
+    exec_policy& set(const nested::fast_reduce& fr)
+    {
+      this->_nested__fast_reduce = fr;
+      return *this;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Create a copy with the quantify strategy changed.
+    ////////////////////////////////////////////////////////////////////////////
+    exec_policy operator &(const nested::fast_reduce& fr) const
+    {
+      exec_policy ep = *this;
+      return ep.set(fr);
+    }
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -319,50 +386,104 @@ namespace adiar
   exec_policy::get<exec_policy::quantify>() const
   { return this->_quantify; }
 
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Chosen Nested Sweeping fast reduce epsilon value.
+  ////////////////////////////////////////////////////////////////////////////
+  template <>
+  inline const exec_policy::nested::fast_reduce&
+  exec_policy::get<exec_policy::nested::fast_reduce>() const
+  { return this->_nested__fast_reduce; }
+
   /// \}
   //////////////////////////////////////////////////////////////////////////////
 
+  /// \cond
+
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Operator overload to support lifting enum values to `exec_policy`.
+  /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
   inline exec_policy operator &(const exec_policy::access &am,
                                 const exec_policy::memory &mm)
   { return exec_policy(am) & mm; }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Operator overload to support lifting enum values to `exec_policy`.
+  /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
   inline exec_policy operator &(const exec_policy::memory &mm,
                                 const exec_policy::access &am)
   { return exec_policy(mm) & am; }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Operator overload to support lifting enum values to `exec_policy`.
+  /// \brief Lift enum values to `exec_policy`.
+  //////////////////////////////////////////////////////////////////////////////
+  inline exec_policy operator &(const exec_policy::access &am,
+                                const exec_policy::nested::fast_reduce &fr)
+  { return exec_policy(am) & fr; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Lift enum values to `exec_policy`.
+  //////////////////////////////////////////////////////////////////////////////
+  inline exec_policy operator &(const exec_policy::nested::fast_reduce &fr,
+                                const exec_policy::access &am)
+  { return exec_policy(fr) & am; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
   inline exec_policy operator &(const exec_policy::access &am,
                                 const exec_policy::quantify &qs)
   { return exec_policy(am) & qs; }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Operator overload to support lifting enum values to `exec_policy`.
+  /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
   inline exec_policy operator &(const exec_policy::quantify &qs,
                                 const exec_policy::access &am)
   { return exec_policy(qs) & am; }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Operator overload to support lifting enum values to `exec_policy`.
+  /// \brief Lift enum values to `exec_policy`.
+  //////////////////////////////////////////////////////////////////////////////
+  inline exec_policy operator &(const exec_policy::memory &mm,
+                                const exec_policy::nested::fast_reduce &fr)
+  { return exec_policy(mm) & fr; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Lift enum values to `exec_policy`.
+  //////////////////////////////////////////////////////////////////////////////
+  inline exec_policy operator &(const exec_policy::nested::fast_reduce &fr,
+                                const exec_policy::memory &mm)
+  { return exec_policy(fr) & mm; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
   inline exec_policy operator &(const exec_policy::memory &mm,
                                 const exec_policy::quantify &qs)
   { return exec_policy(mm) & qs; }
 
   //////////////////////////////////////////////////////////////////////////////
-  /// \brief Operator overload to support lifting enum values to `exec_policy`.
+  /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
   inline exec_policy operator &(const exec_policy::quantify &qs,
                                 const exec_policy::memory &mm)
   { return exec_policy(qs) & mm; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Lift enum values to `exec_policy`.
+  //////////////////////////////////////////////////////////////////////////////
+  inline exec_policy operator &(const exec_policy::quantify &qs,
+                                const exec_policy::nested::fast_reduce &fr)
+  { return exec_policy(qs) & fr; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief Lift enum values to `exec_policy`.
+  //////////////////////////////////////////////////////////////////////////////
+  inline exec_policy operator &(const exec_policy::nested::fast_reduce &fr,
+                                const exec_policy::quantify &qs)
+  { return exec_policy(fr) & qs; }
+
+  /// \endcond
 }
 
 #endif // ADIAR_EXEC_POLICY_H

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -1,6 +1,8 @@
 #ifndef ADIAR_EXEC_POLICY_H
 #define ADIAR_EXEC_POLICY_H
 
+#include <limits>
+
 namespace adiar
 {
   //////////////////////////////////////////////////////////////////////////////
@@ -131,6 +133,24 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     quantify _quantify_alg = quantify::Auto;
 
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Chosen epsilon value for Nested Sweeping to start skipping the
+    ///        expensive node merging computations (if applicable).
+    ///
+    /// \details During Nested Sweeping, if a later sweep will touch a level
+    ///          again, one can postpone dealing with merging duplicate nodes.
+    ///          This does not apply to the last Reduce sweep up, so the final
+    ///          diagram is still canonical.
+    ///
+    /// \details Setting this value to 0 is equivalent to always using the fast
+    ///          reduce. On the other hand, setting it to a negative value turns
+    ///          this optimisation of.
+    ///
+    /// \details To safe on space, the value is stored in a char. Hence, the
+    ///          precision is only 1/254 for values in the interval [-1,1].
+    ////////////////////////////////////////////////////////////////////////////
+    signed char _nested_reduce_epsilon = 6; // <-- 4.7%
+
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Default constructor with all options set to their default value.
@@ -186,19 +206,29 @@ namespace adiar
     /// \brief Chosen access mode.
     ////////////////////////////////////////////////////////////////////////////
     const access& access_mode() const
-    { return _access_mode; }
+    { return this->_access_mode; }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen memory type.
     ////////////////////////////////////////////////////////////////////////////
     const memory& memory_mode() const
-    { return _memory_mode; }
+    { return this->_memory_mode; }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen quantification strategy.
     ////////////////////////////////////////////////////////////////////////////
     const quantify& quantify_alg() const
-    { return _quantify_alg; }
+    { return this->_quantify_alg; }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Chosen \f$ \epsilon \f$ threshold to trigger the fast Reduce
+    ///        within Nested Sweeping.
+    ////////////////////////////////////////////////////////////////////////////
+    float nested_reduce_epsilon() const
+    {
+      constexpr double tick_distance = std::numeric_limits<signed char>::max();
+      return static_cast<double>(this->_nested_reduce_epsilon) / tick_distance;
+    }
 
   public:
     ////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -121,17 +121,17 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen `access` (default `Auto`).
     ////////////////////////////////////////////////////////////////////////////
-    access _access_mode = access::Auto;
+    access _access = access::Auto;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen `memory`  (default `Auto`).
     ////////////////////////////////////////////////////////////////////////////
-    memory _memory_mode = memory::Auto;
+    memory _memory = memory::Auto;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen `quantify` (default `Auto`).
     ////////////////////////////////////////////////////////////////////////////
-    quantify _quantify_alg = quantify::Auto;
+    quantify _quantify = quantify::Auto;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen epsilon value for Nested Sweeping to start skipping the
@@ -171,21 +171,21 @@ namespace adiar
     /// \brief Conversion construction from `access` enum.
     ////////////////////////////////////////////////////////////////////////////
     exec_policy(const access &am)
-      : _access_mode(am)
+      : _access(am)
     { }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Conversion construction from `memory` enum.
     ////////////////////////////////////////////////////////////////////////////
     exec_policy(const memory &mm)
-      : _memory_mode(mm)
+      : _memory(mm)
     { }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Conversion construction from `quantify` enum.
     ////////////////////////////////////////////////////////////////////////////
     exec_policy(const quantify &qm)
-      : _quantify_alg(qm)
+      : _quantify(qm)
     { }
 
     // TODO: constructor with defaults for a specific 'version number'?
@@ -206,8 +206,7 @@ namespace adiar
     /// \brief Obtain a value
     ////////////////////////////////////////////////////////////////////////////
     template <typename T>
-    const T& get() const
-    { static_assert(false, "Type 'T' not stored in execution policy"); }
+    const T& get() const;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen \f$ \epsilon \f$ threshold to trigger the fast Reduce
@@ -226,9 +225,9 @@ namespace adiar
     bool operator ==(const exec_policy& ep) const
     {
       // Order based from the most generic to the most specific setting.
-      return this->_memory_mode  == ep._memory_mode
-          && this->_access_mode  == ep._access_mode
-          && this->_quantify_alg == ep._quantify_alg
+      return this->_memory  == ep._memory
+          && this->_access  == ep._access
+          && this->_quantify == ep._quantify
         ;
     }
 
@@ -246,7 +245,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     exec_policy& set(const access &am)
     {
-      this->_access_mode = am;
+      this->_access = am;
       return *this;
     }
 
@@ -264,7 +263,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     exec_policy& set(const memory &mm)
     {
-      this->_memory_mode = mm;
+      this->_memory = mm;
       return *this;
     }
 
@@ -282,7 +281,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     exec_policy& set(const quantify &qs)
     {
-      this->_quantify_alg = qs;
+      this->_quantify = qs;
       return *this;
     }
 
@@ -302,7 +301,7 @@ namespace adiar
   template <>
   inline const exec_policy::access&
   exec_policy::get<exec_policy::access>() const
-  { return this->_access_mode; }
+  { return this->_access; }
 
   ////////////////////////////////////////////////////////////////////////////
   /// \brief Chosen memory type.
@@ -310,7 +309,7 @@ namespace adiar
   template <>
   inline const exec_policy::memory&
   exec_policy::get<exec_policy::memory>() const
-  { return this->_memory_mode; }
+  { return this->_memory; }
 
   ////////////////////////////////////////////////////////////////////////////
   /// \brief Chosen quantification strategy.
@@ -318,7 +317,7 @@ namespace adiar
   template <>
   inline const exec_policy::quantify&
   exec_policy::get<exec_policy::quantify>() const
-  { return this->_quantify_alg; }
+  { return this->_quantify; }
 
   /// \}
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -1,7 +1,9 @@
 #ifndef ADIAR_EXEC_POLICY_H
 #define ADIAR_EXEC_POLICY_H
 
+#include <algorithm>
 #include <limits>
+#include <type_traits>
 
 namespace adiar
 {
@@ -146,10 +148,15 @@ namespace adiar
         static constexpr float ticks = std::numeric_limits<signed char>::max();
 
         /// \brief Convert into a `signed char`
-        static constexpr signed char from_float(float f)
+        static constexpr signed char
+        from_float(float f)
         {
           // Truncate `f` to be in the interval [-1,1]
-          if (1.0 < f) { f = 1.0; } else if (f < -1.0) { f = -1.0; }
+          if (1.0 < f) {
+            f = 1.0;
+          } else if (f < -1.0) {
+            f = -1.0;
+          }
 
           // Multiply by 'ticks' to extend the interval *[-1,1]* into
           // *[-ticks,ticks]*. Then, convert to an integral value. This
@@ -160,17 +167,14 @@ namespace adiar
       public:
         /// \brief Conversion constructor from `float`.
         constexpr fast_reduce(float f)
-          : _value{from_float(f)}
-        { }
+          : _value{ from_float(f) }
+        {}
 
         /// \brief Reobtain this value as a `float`.
-        operator float() const
-        {
-          return static_cast<double>(this->_value) / ticks;
-        }
+        operator float() const { return static_cast<double>(this->_value) / ticks; }
 
         bool
-        operator== (const fast_reduce &other) const
+        operator==(const fast_reduce& other) const
         {
           return this->_value == other._value;
         }
@@ -221,30 +225,30 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Conversion construction from `access` enum.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy(const access &am)
+    exec_policy(const access& am)
       : _access(am)
-    { }
+    {}
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Conversion construction from `memory` enum.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy(const memory &mm)
+    exec_policy(const memory& mm)
       : _memory(mm)
-    { }
+    {}
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Conversion construction from `quantify` enum.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy(const quantify &qm)
+    exec_policy(const quantify& qm)
       : _quantify(qm)
-    { }
+    {}
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Conversion construction from `quantify` enum.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy(const nested::fast_reduce &fr)
+    exec_policy(const nested::fast_reduce& fr)
       : _nested__fast_reduce(fr)
-    { }
+    {}
 
     // TODO: constructor with defaults for a specific 'version number'?
 
@@ -252,38 +256,40 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Copy assignment
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy& operator =(const exec_policy &) = default;
+    exec_policy&
+    operator=(const exec_policy&) = default;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Move assignment
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy& operator =(exec_policy &&) = default;
+    exec_policy&
+    operator=(exec_policy&&) = default;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Obtain a value
     ////////////////////////////////////////////////////////////////////////////
     template <typename T>
-    const T& get() const;
+    const T&
+    get() const;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Check for equality of settings.
     ////////////////////////////////////////////////////////////////////////////
-    bool operator ==(const exec_policy& ep) const
+    bool
+    operator==(const exec_policy& ep) const
     {
       // Order based from the most generic to the most specific setting.
-      return this->_memory  == ep._memory
-          && this->_access  == ep._access
-          && this->_quantify == ep._quantify
-          && this->_nested__fast_reduce == ep._nested__fast_reduce
-        ;
+      return this->_memory == ep._memory && this->_access == ep._access
+        && this->_quantify == ep._quantify && this->_nested__fast_reduce == ep._nested__fast_reduce;
     }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Check for at least one mismatch in the settings.
     ////////////////////////////////////////////////////////////////////////////
-    bool operator !=(const exec_policy& ep) const
+    bool
+    operator!=(const exec_policy& ep) const
     {
       return !(*this == ep);
     }
@@ -292,7 +298,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Set the access mode.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy& set(const access &am)
+    exec_policy&
+    set(const access& am)
     {
       this->_access = am;
       return *this;
@@ -301,7 +308,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the access mode changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const access& am) const
+    exec_policy
+    operator&(const access& am) const
     {
       exec_policy ep = *this;
       return ep.set(am);
@@ -310,7 +318,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Set the memory mode.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy& set(const memory &mm)
+    exec_policy&
+    set(const memory& mm)
     {
       this->_memory = mm;
       return *this;
@@ -319,7 +328,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the memory mode changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const memory& mm) const
+    exec_policy
+    operator&(const memory& mm) const
     {
       exec_policy ep = *this;
       return ep.set(mm);
@@ -328,7 +338,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Set the quantify strategy.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy& set(const quantify &qs)
+    exec_policy&
+    set(const quantify& qs)
     {
       this->_quantify = qs;
       return *this;
@@ -337,7 +348,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the quantify strategy changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const quantify& qs) const
+    exec_policy
+    operator&(const quantify& qs) const
     {
       exec_policy ep = *this;
       return ep.set(qs);
@@ -346,7 +358,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Set the quantify strategy.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy& set(const nested::fast_reduce& fr)
+    exec_policy&
+    set(const nested::fast_reduce& fr)
     {
       this->_nested__fast_reduce = fr;
       return *this;
@@ -355,7 +368,8 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the quantify strategy changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const nested::fast_reduce& fr) const
+    exec_policy
+    operator&(const nested::fast_reduce& fr) const
     {
       exec_policy ep = *this;
       return ep.set(fr);
@@ -368,7 +382,9 @@ namespace adiar
   template <>
   inline const exec_policy::access&
   exec_policy::get<exec_policy::access>() const
-  { return this->_access; }
+  {
+    return this->_access;
+  }
 
   ////////////////////////////////////////////////////////////////////////////
   /// \brief Chosen memory type.
@@ -376,7 +392,9 @@ namespace adiar
   template <>
   inline const exec_policy::memory&
   exec_policy::get<exec_policy::memory>() const
-  { return this->_memory; }
+  {
+    return this->_memory;
+  }
 
   ////////////////////////////////////////////////////////////////////////////
   /// \brief Chosen quantification strategy.
@@ -384,7 +402,9 @@ namespace adiar
   template <>
   inline const exec_policy::quantify&
   exec_policy::get<exec_policy::quantify>() const
-  { return this->_quantify; }
+  {
+    return this->_quantify;
+  }
 
   ////////////////////////////////////////////////////////////////////////////
   /// \brief Chosen Nested Sweeping fast reduce epsilon value.
@@ -392,7 +412,9 @@ namespace adiar
   template <>
   inline const exec_policy::nested::fast_reduce&
   exec_policy::get<exec_policy::nested::fast_reduce>() const
-  { return this->_nested__fast_reduce; }
+  {
+    return this->_nested__fast_reduce;
+  }
 
   /// \}
   //////////////////////////////////////////////////////////////////////////////
@@ -402,86 +424,110 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::access &am,
-                                const exec_policy::memory &mm)
-  { return exec_policy(am) & mm; }
+  inline exec_policy
+  operator&(const exec_policy::access& am, const exec_policy::memory& mm)
+  {
+    return exec_policy(am) & mm;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::memory &mm,
-                                const exec_policy::access &am)
-  { return exec_policy(mm) & am; }
+  inline exec_policy
+  operator&(const exec_policy::memory& mm, const exec_policy::access& am)
+  {
+    return exec_policy(mm) & am;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::access &am,
-                                const exec_policy::nested::fast_reduce &fr)
-  { return exec_policy(am) & fr; }
+  inline exec_policy
+  operator&(const exec_policy::access& am, const exec_policy::nested::fast_reduce& fr)
+  {
+    return exec_policy(am) & fr;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::nested::fast_reduce &fr,
-                                const exec_policy::access &am)
-  { return exec_policy(fr) & am; }
+  inline exec_policy
+  operator&(const exec_policy::nested::fast_reduce& fr, const exec_policy::access& am)
+  {
+    return exec_policy(fr) & am;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::access &am,
-                                const exec_policy::quantify &qs)
-  { return exec_policy(am) & qs; }
+  inline exec_policy
+  operator&(const exec_policy::access& am, const exec_policy::quantify& qs)
+  {
+    return exec_policy(am) & qs;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::quantify &qs,
-                                const exec_policy::access &am)
-  { return exec_policy(qs) & am; }
+  inline exec_policy
+  operator&(const exec_policy::quantify& qs, const exec_policy::access& am)
+  {
+    return exec_policy(qs) & am;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::memory &mm,
-                                const exec_policy::nested::fast_reduce &fr)
-  { return exec_policy(mm) & fr; }
+  inline exec_policy
+  operator&(const exec_policy::memory& mm, const exec_policy::nested::fast_reduce& fr)
+  {
+    return exec_policy(mm) & fr;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::nested::fast_reduce &fr,
-                                const exec_policy::memory &mm)
-  { return exec_policy(fr) & mm; }
+  inline exec_policy
+  operator&(const exec_policy::nested::fast_reduce& fr, const exec_policy::memory& mm)
+  {
+    return exec_policy(fr) & mm;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::memory &mm,
-                                const exec_policy::quantify &qs)
-  { return exec_policy(mm) & qs; }
+  inline exec_policy
+  operator&(const exec_policy::memory& mm, const exec_policy::quantify& qs)
+  {
+    return exec_policy(mm) & qs;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::quantify &qs,
-                                const exec_policy::memory &mm)
-  { return exec_policy(qs) & mm; }
+  inline exec_policy
+  operator&(const exec_policy::quantify& qs, const exec_policy::memory& mm)
+  {
+    return exec_policy(qs) & mm;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::quantify &qs,
-                                const exec_policy::nested::fast_reduce &fr)
-  { return exec_policy(qs) & fr; }
+  inline exec_policy
+  operator&(const exec_policy::quantify& qs, const exec_policy::nested::fast_reduce& fr)
+  {
+    return exec_policy(qs) & fr;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \brief Lift enum values to `exec_policy`.
   //////////////////////////////////////////////////////////////////////////////
-  inline exec_policy operator &(const exec_policy::nested::fast_reduce &fr,
-                                const exec_policy::quantify &qs)
-  { return exec_policy(fr) & qs; }
+  inline exec_policy
+  operator&(const exec_policy::nested::fast_reduce& fr, const exec_policy::quantify& qs)
+  {
+    return exec_policy(fr) & qs;
+  }
 
   /// \endcond
 }

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -131,7 +131,7 @@ namespace adiar
         static constexpr transposition_growth
         min()
         {
-          return 0.0;
+          return 0.0f;
         }
 
         /// \brief Maximal value
@@ -145,6 +145,10 @@ namespace adiar
         float _value;
 
       public:
+        constexpr transposition_growth()
+          : _value(1.5f)
+        { }
+
         /// \brief Wrap a `float`.
         constexpr transposition_growth(float value)
           : _value(value)
@@ -180,6 +184,11 @@ namespace adiar
         unsigned char _value;
 
       public:
+        /// \brief Default value construction.
+        constexpr transposition_max()
+          : _value(1u)
+        {}
+
         /// \brief Wrap an `unsigned char`
         constexpr transposition_max(unsigned char value)
           : _value(value)
@@ -219,14 +228,14 @@ namespace adiar
         static constexpr fast_reduce
         min()
         {
-          return -1.0;
+          return -1.0f;
         }
 
         /// \brief Maximal value
         static constexpr fast_reduce
         max()
         {
-          return 1.0;
+          return 1.0f;
         }
 
       private:
@@ -240,10 +249,10 @@ namespace adiar
         from_float(float f)
         {
           // Truncate `f` to be in the interval [-1,1]
-          if (1.0 < f) {
-            f = 1.0;
-          } else if (f < -1.0) {
-            f = -1.0;
+          if (1.0f < f) {
+            f = 1.0f;
+          } else if (f < -1.0f) {
+            f = -1.0f;
           }
 
           // Multiply by 'ticks' to extend the interval *[-1,1]* into
@@ -253,6 +262,11 @@ namespace adiar
         }
 
       public:
+        /// \brief Default value construction.
+        constexpr fast_reduce()
+          : _value(0.05f)
+        { }
+
         /// \brief Conversion constructor from `float`.
         constexpr fast_reduce(float f)
           : _value{ from_float(f) }
@@ -290,19 +304,19 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Maximal growth during repeated transposition of `quantify`.
     ////////////////////////////////////////////////////////////////////////////
-    quantify::transposition_growth _quantify__transposition_growth = 1.5f;
+    quantify::transposition_growth _quantify__transposition_growth /*default*/;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Maximal number of repeated transpositions in `quantify`.
     ////////////////////////////////////////////////////////////////////////////
-    quantify::transposition_max _quantify__transposition_max = 1;
+    quantify::transposition_max _quantify__transposition_max /*default*/;
+      ;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen epsilon value for Nested Sweeping to start skipping the
     ///        expensive node merging computations (if applicable).
     ////////////////////////////////////////////////////////////////////////////
-    // TODO: set to ~5%
-    nested::fast_reduce _nested__fast_reduce = -1.0f;
+    nested::fast_reduce _nested__fast_reduce /*default*/;
 
   public:
     ////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -203,22 +203,11 @@ namespace adiar
 
   public:
     ////////////////////////////////////////////////////////////////////////////
-    /// \brief Chosen access mode.
+    /// \brief Obtain a value
     ////////////////////////////////////////////////////////////////////////////
-    const access& access_mode() const
-    { return this->_access_mode; }
-
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief Chosen memory type.
-    ////////////////////////////////////////////////////////////////////////////
-    const memory& memory_mode() const
-    { return this->_memory_mode; }
-
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief Chosen quantification strategy.
-    ////////////////////////////////////////////////////////////////////////////
-    const quantify& quantify_alg() const
-    { return this->_quantify_alg; }
+    template <typename T>
+    const T& get() const
+    { static_assert(false, "Type 'T' not stored in execution policy"); }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Chosen \f$ \epsilon \f$ threshold to trigger the fast Reduce
@@ -237,9 +226,9 @@ namespace adiar
     bool operator ==(const exec_policy& ep) const
     {
       // Order based from the most generic to the most specific setting.
-      return this->memory_mode()  == ep.memory_mode()
-          && this->access_mode()  == ep.access_mode()
-          && this->quantify_alg() == ep.quantify_alg()
+      return this->_memory_mode  == ep._memory_mode
+          && this->_access_mode  == ep._access_mode
+          && this->_quantify_alg == ep._quantify_alg
         ;
     }
 
@@ -306,6 +295,30 @@ namespace adiar
       return ep.set(qs);
     }
   };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Chosen access mode.
+  ////////////////////////////////////////////////////////////////////////////
+  template <>
+  inline const exec_policy::access&
+  exec_policy::get<exec_policy::access>() const
+  { return this->_access_mode; }
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Chosen memory type.
+  ////////////////////////////////////////////////////////////////////////////
+  template <>
+  inline const exec_policy::memory&
+  exec_policy::get<exec_policy::memory>() const
+  { return this->_memory_mode; }
+
+  ////////////////////////////////////////////////////////////////////////////
+  /// \brief Chosen quantification strategy.
+  ////////////////////////////////////////////////////////////////////////////
+  template <>
+  inline const exec_policy::quantify&
+  exec_policy::get<exec_policy::quantify>() const
+  { return this->_quantify_alg; }
 
   /// \}
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -252,7 +252,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the access mode changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const access& am)
+    exec_policy operator &(const access& am) const
     {
       exec_policy ep = *this;
       return ep.set(am);
@@ -270,7 +270,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the memory mode changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const memory& mm)
+    exec_policy operator &(const memory& mm) const
     {
       exec_policy ep = *this;
       return ep.set(mm);
@@ -288,7 +288,7 @@ namespace adiar
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Create a copy with the quantify strategy changed.
     ////////////////////////////////////////////////////////////////////////////
-    exec_policy operator &(const quantify& qs)
+    exec_policy operator &(const quantify& qs) const
     {
       exec_policy ep = *this;
       return ep.set(qs);

--- a/src/adiar/internal/algorithms/count.h
+++ b/src/adiar/internal/algorithms/count.h
@@ -188,8 +188,8 @@ namespace adiar::internal
     const size_t pq_memory_fits =
       count_priority_queue_t<typename Policy::data_type, ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>::memory_fits(aux_available_memory);
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_bound = dd.max_2level_cut(cut::Internal);
 

--- a/src/adiar/internal/algorithms/intercut.h
+++ b/src/adiar/internal/algorithms/intercut.h
@@ -353,8 +353,8 @@ namespace adiar::internal
     const size_t pq_memory_fits =
       intercut_priority_queue_t<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>::memory_fits(pq_memory);
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_bound = __intercut_2level_upper_bound<intercut_policy>(dd);
 

--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -1573,7 +1573,7 @@ namespace adiar::internal
           //  Strategy: Use the fast reduce from the next level (until next
           // inner sweep) if this level did not change considerably in size.
           if constexpr (nesting_policy::reduce_strategy == nested_sweeping::Auto) {
-            const double threshold = 0.05;
+            const double threshold = ep.nested_reduce_epsilon();
 
             const double prior = static_cast<double>(unreduced_width);
             const double delta = static_cast<double>(unreduced_width - reduced_width);

--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -864,7 +864,7 @@ namespace adiar::internal
 
         // ---------------------------------------------------------------------
         // Case: Run Inner Sweep (with random access)
-        adiar_assert(ep.access_mode() != exec_policy::access::Random_Access);
+        adiar_assert(ep.template get<exec_policy::access>() != exec_policy::access::Random_Access);
 
         // ---------------------------------------------------------------------
         // Case: Run Inner Sweep (with priority queues)
@@ -880,9 +880,9 @@ namespace adiar::internal
 
         const size_t inner_pq_bound = policy_impl.pq_bound(outer_file, outer_roots.size());
 
-        const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+        const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
-        const size_t inner_pq_max_size = ep.memory_mode() == exec_policy::memory::Internal
+        const size_t inner_pq_max_size = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal
           ? std::min(inner_pq_fits, inner_pq_bound)
           : inner_pq_bound;
 
@@ -1345,11 +1345,11 @@ namespace adiar::internal
         //   Resolve `inner_arcs_file->max_1level_cut == 0` in a separate while-loop.
         const size_t inner_pq_bound = std::max<size_t>(inner_arcs_file->max_1level_cut, 1);
 
-        const size_t inner_pq_max_size = ep.memory_mode() == exec_policy::memory::Internal
+        const size_t inner_pq_max_size = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal
           ? std::min(inner_pq_memory_fits, inner_pq_bound)
           : inner_pq_bound;
 
-        const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+        const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
         if (!external_only && inner_pq_max_size <= no_lookahead_bound(1)) {
 #ifdef ADIAR_STATS
           stats.inner_up.lpq.unbucketed += 1u;
@@ -1907,11 +1907,11 @@ namespace adiar::internal
 
     const size_t pq_roots_bound = dag->max_1level_cut;
 
-    const size_t outer_pq_roots_max = ep.memory_mode() == exec_policy::memory::Internal
+    const size_t outer_pq_roots_max = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal
       ? std::min({outer_pq_memory_fits, outer_roots_memory_fits, pq_roots_bound})
       : pq_roots_bound;
 
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
     if (!external_only && outer_pq_roots_max <= no_lookahead_bound(1)) {
 #ifdef ADIAR_STATS
       nested_sweeping::stats.outer_up.lpq.unbucketed += 1u;

--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -1290,10 +1290,11 @@ namespace adiar::internal
             }
 
             if constexpr (nesting_policy::final_canonical) {
-              const double prior = static_cast<double>(unreduced_width);
-              const double delta = static_cast<double>(unreduced_width - reduced_width);
+              const float  epsilon = ep.template get<exec_policy::nested::fast_reduce>();
+              const double prior   = static_cast<double>(unreduced_width);
+              const double delta   = static_cast<double>(unreduced_width - reduced_width);
 
-              auto_fast_reduce |= (delta / prior) < ep.nested_reduce_epsilon();
+              auto_fast_reduce |= (delta / prior) < epsilon;
             }
           }
         }
@@ -1571,10 +1572,11 @@ namespace adiar::internal
           // Strategy: Use the fast reduce from the next level (until next inner sweep) if this
           // level did not change considerably in size.
           if constexpr (nesting_policy::final_canonical) {
-            const double prior = static_cast<double>(unreduced_width);
-            const double delta = static_cast<double>(unreduced_width - reduced_width);
+            const float  epsilon = ep.template get<exec_policy::nested::fast_reduce>();
+            const double prior   = static_cast<double>(unreduced_width);
+            const double delta   = static_cast<double>(unreduced_width - reduced_width);
 
-            auto_fast_reduce |= (delta / prior) < ep.nested_reduce_epsilon();
+            auto_fast_reduce |= (delta / prior) < epsilon;
           }
         }
 

--- a/src/adiar/internal/algorithms/pred.h
+++ b/src/adiar/internal/algorithms/pred.h
@@ -242,8 +242,8 @@ namespace adiar::internal
     const size_t pq_2_memory_fits =
       comparison_priority_queue_2_t<memory_mode::Internal>::memory_fits(pq_2_internal_memory);
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_1_bound = comp_policy::level_check_t::pq1_upper_bound(f0, f1);
 

--- a/src/adiar/internal/algorithms/prod2.h
+++ b/src/adiar/internal/algorithms/prod2.h
@@ -680,8 +680,8 @@ namespace adiar::internal
   {
     adiar_assert(in_0->canonical || in_1->canonical, "At least one input must be canonical");
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_bound = std::min({__prod2_ilevel_upper_bound<Policy, get_2level_cut, 2u>(in_0, in_1, op),
                                       __prod2_2level_upper_bound<Policy>(in_0, in_1, op),
@@ -749,8 +749,8 @@ namespace adiar::internal
              const typename Policy::dd_type &in_1,
              const bool_op &op)
   {
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_1_bound = std::min({__prod2_ilevel_upper_bound<Policy, get_2level_cut, 2u>(in_0, in_1, op),
         __prod2_2level_upper_bound<Policy>(in_0, in_1, op),
@@ -889,9 +889,9 @@ namespace adiar::internal
     const size_t min_width = std::min(width_0, width_1);
 
     if (// Use `__prod2_ra` if user has forced Random Access
-        ep.access_mode() == exec_policy::access::Random_Access
+        ep.template get<exec_policy::access>() == exec_policy::access::Random_Access
         || (// Heuristically, if the narrowest canonical fits
-            ep.access_mode() == exec_policy::access::Auto && (min_width <= ra_threshold))) {
+            ep.template get<exec_policy::access>() == exec_policy::access::Auto && (min_width <= ra_threshold))) {
 #ifdef ADIAR_STATS
       stats_prod2.ra.runs += 1u;
 #endif

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -734,8 +734,7 @@ namespace adiar::internal
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    static constexpr internal::nested_sweeping::reduce_strategy reduce_strategy =
-      internal::nested_sweeping::Auto;
+    static constexpr bool final_canonical = true;
   };
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -911,7 +911,7 @@ namespace adiar::internal
       //   1. ... it stays smaller than 1+epsilon% of the input size.
       const size_t transposition__size_threshold = static_cast<size_t>(
         std::min<double>(std::numeric_limits<size_t>::max(),
-                         (1.0 + ep.template get<exec_policy::quantify::transposition_growth>())
+                         ep.template get<exec_policy::quantify::transposition_growth>()
                            * static_cast<double>(dd_size)));
 
       //   2. ... it has not run more than the maximum number of iterations.

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -480,8 +480,8 @@ namespace adiar::internal
     const size_t pq_2_memory_fits =
       quantify_priority_queue_2_t<memory_mode::Internal>::memory_fits(pq_2_internal_memory);
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_1_bound = std::min({__quantify_ilevel_upper_bound<quantify_policy, get_2level_cut, 2u>(in,op),
                                         __quantify_ilevel_upper_bound(in)});
@@ -672,11 +672,11 @@ namespace adiar::internal
         // Add crossing arcs
         + (inner_pq_1.size());
 
-      const size_t max_pq_2_size = ep.memory_mode() == exec_policy::memory::Internal
+      const size_t max_pq_2_size = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal
         ? std::min(pq_2_memory_fits, pq_2_bound)
         : pq_2_bound;
 
-      if(ep.memory_mode() != exec_policy::memory::External && max_pq_2_size <= pq_2_memory_fits) {
+      if(ep.template get<exec_policy::memory>() != exec_policy::memory::External && max_pq_2_size <= pq_2_memory_fits) {
         using inner_pq_2_t = quantify_priority_queue_2_t<memory_mode::Internal>;
         inner_pq_2_t inner_pq_2(inner_remaining_memory, max_pq_2_size);
 
@@ -868,7 +868,7 @@ namespace adiar::internal
       return dd;
     }
 
-    switch (ep.quantify_alg()) {
+    switch (ep.template get<exec_policy::quantify>()) {
     case exec_policy::quantify::Partial:
       { // ---------------------------------------------------------------------
         // Case: Repeated partial quantification
@@ -1100,9 +1100,8 @@ namespace adiar::internal
   {
     adiar_assert(is_commutative(op), "Operator must be commutative");
 
-    // NOTE: read-once access with 'gen' makes partial quantification not
-    //       possible.
-    switch (ep.quantify_alg()) {
+    // NOTE: read-once access with 'gen' makes partial quantification not possible.
+    switch (ep.template get<exec_policy::quantify>()) {
     case exec_policy::quantify::Partial:
     case exec_policy::quantify::Singleton:
       { // -------------------------------------------------------------------

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -7,23 +7,23 @@
 #include <adiar/exec_policy.h>
 #include <adiar/functional.h>
 
-#include <adiar/internal/assert.h>
-#include <adiar/internal/bool_op.h>
-#include <adiar/internal/block_size.h>
-#include <adiar/internal/cut.h>
-#include <adiar/internal/cnl.h>
-#include <adiar/internal/unreachable.h>
 #include <adiar/internal/algorithms/nested_sweeping.h>
+#include <adiar/internal/assert.h>
+#include <adiar/internal/block_size.h>
+#include <adiar/internal/bool_op.h>
+#include <adiar/internal/cnl.h>
+#include <adiar/internal/cut.h>
 #include <adiar/internal/data_structures/levelized_priority_queue.h>
-#include <adiar/internal/data_types/tuple.h>
 #include <adiar/internal/data_types/request.h>
+#include <adiar/internal/data_types/tuple.h>
 #include <adiar/internal/io/arc_file.h>
 #include <adiar/internal/io/arc_writer.h>
 #include <adiar/internal/io/file.h>
 #include <adiar/internal/io/file_stream.h>
-#include <adiar/internal/io/shared_file_ptr.h>
-#include <adiar/internal/io/node_stream.h>
 #include <adiar/internal/io/node_arc_stream.h>
+#include <adiar/internal/io/node_stream.h>
+#include <adiar/internal/io/shared_file_ptr.h>
+#include <adiar/internal/unreachable.h>
 #include <adiar/internal/util.h>
 
 namespace adiar::internal
@@ -34,13 +34,13 @@ namespace adiar::internal
 
   //////////////////////////////////////////////////////////////////////////////
   // Data structures
-  template<uint8_t nodes_carried>
+  template <uint8_t nodes_carried>
   using quantify_request = request_data<2, with_parent, nodes_carried, 1>;
 
   //////////////////////////////////////////////////////////////////////////////
   // Priority queue functions
 
-  template<size_t look_ahead, memory_mode mem_mode>
+  template <size_t look_ahead, memory_mode mem_mode>
   using quantify_priority_queue_1_node_t =
     levelized_node_priority_queue<quantify_request<0>,
                                   request_data_first_lt<quantify_request<0>>,
@@ -49,7 +49,7 @@ namespace adiar::internal
                                   1,
                                   0>;
 
-  template<size_t look_ahead, memory_mode mem_mode>
+  template <size_t look_ahead, memory_mode mem_mode>
   using quantify_priority_queue_1_arc_t =
     levelized_node_arc_priority_queue<quantify_request<0>,
                                       request_data_first_lt<quantify_request<0>>,
@@ -58,42 +58,40 @@ namespace adiar::internal
                                       1,
                                       0>;
 
-  template<memory_mode mem_mode>
+  template <memory_mode mem_mode>
   using quantify_priority_queue_2_t =
     priority_queue<mem_mode, quantify_request<1>, request_data_second_lt<quantify_request<1>>>;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper functions
-  template<typename quantify_policy, typename pq_1_t>
-  inline void __quantify_forward_request(pq_1_t &quantify_pq_1,
-                                         arc_writer &aw,
-                                         const typename quantify_policy::pointer_type source,
-                                         const quantify_request<0>::target_t &target)
+  template <typename quantify_policy, typename pq_1_t>
+  inline void
+  __quantify_forward_request(pq_1_t& quantify_pq_1,
+                             arc_writer& aw,
+                             const typename quantify_policy::pointer_type source,
+                             const quantify_request<0>::target_t& target)
   {
     adiar_assert(!target.first().is_nil(),
                  "pointer_type::nil() should only ever end up being placed in target[1]");
 
     if (target.first().is_terminal()) {
-      adiar_assert(target.second().is_nil(),
-                   "Operator should already be resolved at this point");
-      aw.push({source, target.first()});
+      adiar_assert(target.second().is_nil(), "Operator should already be resolved at this point");
+      aw.push({ source, target.first() });
     } else {
-      quantify_pq_1.push({target, {}, {source}});
+      quantify_pq_1.push({ target, {}, { source } });
     }
   }
 
-  template<typename pq_1_t, typename pq_2_t>
+  template <typename pq_1_t, typename pq_2_t>
   inline bool
-  __quantify_update_source_or_break(pq_1_t &quantify_pq_1,
-                                    pq_2_t &quantify_pq_2,
-                                    ptr_uint64 &source,
-                                    const quantify_request<0>::target_t &target)
+  __quantify_update_source_or_break(pq_1_t& quantify_pq_1,
+                                    pq_2_t& quantify_pq_2,
+                                    ptr_uint64& source,
+                                    const quantify_request<0>::target_t& target)
   {
-    if (quantify_pq_1.can_pull()
-        && quantify_pq_1.top().target == target) {
+    if (quantify_pq_1.can_pull() && quantify_pq_1.top().target == target) {
       source = quantify_pq_1.pull().data.source;
-    } else if (!quantify_pq_2.empty()
-               && quantify_pq_2.top().target == target) {
+    } else if (!quantify_pq_2.empty() && quantify_pq_2.top().target == target) {
       source = quantify_pq_2.top().data.source;
       quantify_pq_2.pop();
     } else {
@@ -102,9 +100,9 @@ namespace adiar::internal
     return false;
   }
 
-  template<typename quantify_policy, size_t targets>
+  template <typename quantify_policy, size_t targets>
   inline tuple<typename quantify_policy::pointer_type, targets, true>
-  __quantify_resolve_request(const bool_op &op,
+  __quantify_resolve_request(const bool_op& op,
                              std::array<typename quantify_policy::pointer_type, targets> ts)
   {
     { // Sort array with pointers
@@ -115,19 +113,19 @@ namespace adiar::internal
     // Remove duplicate pointers from array (abusing sorting). The policy may
     // also prune some terminals.
     size_t ts_max_idx = 0;
-    for (size_t i = ts_max_idx+1; i < ts.size(); ++i) {
+    for (size_t i = ts_max_idx + 1; i < ts.size(); ++i) {
       adiar_assert(ts_max_idx < i, "i is always ahead of 'ts_max_idx'");
 
       // Stop early at maximum value of 'nil'
       if (ts[i] == quantify_policy::pointer_type::nil()) { break; }
 
       // Move new unique element at next spot for 'ts_max_idx'
-      if (ts[ts_max_idx] != ts[i] &&
-          (!ts[i].is_terminal() || quantify_policy::keep_terminal(op, ts[i]))) {
+      if (ts[ts_max_idx] != ts[i]
+          && (!ts[i].is_terminal() || quantify_policy::keep_terminal(op, ts[i]))) {
         ts[++ts_max_idx] = ts[i];
       }
     }
-    for (size_t i = ts_max_idx+1; i < ts.size(); ++i) {
+    for (size_t i = ts_max_idx + 1; i < ts.size(); ++i) {
       ts[i] = quantify_policy::pointer_type::nil();
     }
 
@@ -136,31 +134,32 @@ namespace adiar::internal
       ts[ts_max_idx].is_terminal() && quantify_policy::collapse_to_terminal(op, ts[ts_max_idx]);
 
     // Are there only terminals left (should be combined)
-    const bool only_terminals =
-      ts[0].is_terminal() /* sorted => ts[1].is_terminal() */;
+    const bool only_terminals = ts[0].is_terminal() /* sorted => ts[1].is_terminal() */;
 
     // If there are more than two targets but one of the two apply, then prune
     // it all the way down to a single target.
     if (1 <= ts_max_idx && (max_shortcuts || only_terminals)) {
       adiar_assert(!ts[1].is_nil(), "Cannot be nil at i <= ts_max_elem");
       ts[0] = max_shortcuts ? ts[ts_max_idx] : op(ts[0], ts[1]);
-      for (size_t i = 1u; i <= ts_max_idx; ++i) {
-        ts[i] = quantify_policy::pointer_type::nil();
-      }
+      for (size_t i = 1u; i <= ts_max_idx; ++i) { ts[i] = quantify_policy::pointer_type::nil(); }
     }
 
     // Return final (sorted and pruned) set of targets.
     return ts;
   }
 
-  template<typename node_stream_t, typename pq_1_t, typename pq_2_t, typename quantify_policy, typename in_t>
+  template <typename node_stream_t,
+            typename pq_1_t,
+            typename pq_2_t,
+            typename quantify_policy,
+            typename in_t>
   typename quantify_policy::__dd_type
-  __quantify(const exec_policy &ep,
-             const in_t &in,
-             quantify_policy &policy_impl,
-             const bool_op &op,
-             pq_1_t &quantify_pq_1,
-             pq_2_t &quantify_pq_2)
+  __quantify(const exec_policy& ep,
+             const in_t& in,
+             quantify_policy& policy_impl,
+             const bool_op& op,
+             pq_1_t& quantify_pq_1,
+             pq_2_t& quantify_pq_2)
   {
     // TODO (optimisation):
     //   Merge 'op' into 'policy_impl'.
@@ -178,14 +177,14 @@ namespace adiar::internal
     arc_writer aw(out_arcs);
 
     // Process requests in topological order of both BDDs
-    while(!quantify_pq_1.empty()) {
+    while (!quantify_pq_1.empty()) {
       adiar_assert(quantify_pq_2.empty(),
                    "Secondary priority queue is only non-empty while processing each level");
 
       // Set up level
       quantify_pq_1.setup_next_level();
       const typename quantify_policy::label_type out_label = quantify_pq_1.current_level();
-      typename quantify_policy::id_type out_id = 0;
+      typename quantify_policy::id_type out_id             = 0;
 
       const bool should_quantify = policy_impl.should_quantify(out_label);
 
@@ -194,9 +193,10 @@ namespace adiar::internal
         quantify_request<1> req;
 
         if (quantify_pq_1.can_pull()
-            && (quantify_pq_2.empty() || quantify_pq_1.top().target.first() < quantify_pq_2.top().target.second())) {
+            && (quantify_pq_2.empty()
+                || quantify_pq_1.top().target.first() < quantify_pq_2.top().target.second())) {
           req = { quantify_pq_1.top().target,
-                  {{ { node::pointer_type::nil(), node::pointer_type::nil() } }},
+                  { { { node::pointer_type::nil(), node::pointer_type::nil() } } },
                   quantify_pq_1.top().data };
           quantify_pq_1.pop();
         } else {
@@ -207,21 +207,18 @@ namespace adiar::internal
         // Seek element from request in stream
         const ptr_uint64 t_seek = req.empty_carry() ? req.target.first() : req.target.second();
 
-        while (v.uid() < t_seek) {
-          v = in_nodes.pull();
-        }
+        while (v.uid() < t_seek) { v = in_nodes.pull(); }
 
         // Forward information of node t1 across the level if needed
-        if (req.empty_carry()
-            && req.target.second().is_node()
+        if (req.empty_carry() && req.target.second().is_node()
             && req.target.first().label() == req.target.second().label()) {
           adiar_assert(!req.target.second().is_nil(),
                        "req.target.second().is_node() ==> !req.target.second().is_nil()");
 
-          quantify_pq_2.push({ req.target, {v.children()}, req.data });
+          quantify_pq_2.push({ req.target, { v.children() }, req.data });
 
           while (quantify_pq_1.can_pull() && (quantify_pq_1.top().target == req.target)) {
-            quantify_pq_2.push({ req.target, {v.children()}, quantify_pq_1.pull().data });
+            quantify_pq_2.push({ req.target, { v.children() }, quantify_pq_1.pull().data });
           }
 
           continue;
@@ -231,14 +228,14 @@ namespace adiar::internal
                      "Level of requests always ought to match the one currently processed");
 
 #ifdef ADIAR_STATS
-        const int arity_idx = req.targets()-1;
+        const int arity_idx = req.targets() - 1;
         stats_quantify.requests_unique[arity_idx] += 1;
 #endif
 
         // ---------------------------------------------------------------------
         // CASE: Quantification of Singleton f into (f[0], f[1]).
-        if (should_quantify &&
-            (!quantify_policy::partial_quantification || req.target.second().is_nil())) {
+        if (should_quantify
+            && (!quantify_policy::partial_quantification || req.target.second().is_nil())) {
           quantify_request<0>::target_t rec =
             __quantify_resolve_request<quantify_policy, 2>(op, v.children().data());
 
@@ -247,20 +244,17 @@ namespace adiar::internal
             stats_quantify.requests[arity_idx] += 1;
 #endif
             __quantify_forward_request<quantify_policy>(quantify_pq_1, aw, req.data.source, rec);
-          } while (!__quantify_update_source_or_break(quantify_pq_1, quantify_pq_2,
-                                                      req.data.source,
-                                                      req.target));
+          } while (!__quantify_update_source_or_break(
+            quantify_pq_1, quantify_pq_2, req.data.source, req.target));
 
           continue;
         }
 
         // Recreate children of the two targeted nodes (or possibly the
         // suppressed node for target.second()).
-        const node::children_type children0 =
-          req.empty_carry() ? v.children() : req.node_carry[0];
+        const node::children_type children0 = req.empty_carry() ? v.children() : req.node_carry[0];
 
-        const node::children_type children1 =
-          req.target.second().level() == out_label
+        const node::children_type children1 = req.target.second().level() == out_label
           ? v.children()
           : quantify_policy::reduction_rule_inv(req.target.second());
 
@@ -271,8 +265,8 @@ namespace adiar::internal
         if constexpr (quantify_policy::partial_quantification) {
           if (should_quantify) {
             const tuple<typename quantify_policy::pointer_type, 4, true> rec_all =
-              __quantify_resolve_request<quantify_policy, 4>(op, {children0[false], children0[true],
-                                                                  children1[false], children1[true]});
+              __quantify_resolve_request<quantify_policy, 4>(
+                op, { children0[false], children0[true], children1[false], children1[true] });
 
             if (rec_all[2] == quantify_policy::pointer_type::nil()) {
               // Collapsed to a terminal?
@@ -290,10 +284,10 @@ namespace adiar::internal
 #ifdef ADIAR_STATS
                 stats_quantify.requests[arity_idx] += 1;
 #endif
-                __quantify_forward_request<quantify_policy>(quantify_pq_1, aw, req.data.source, rec);
-              } while (!__quantify_update_source_or_break(quantify_pq_1, quantify_pq_2,
-                                                          req.data.source,
-                                                          req.target));
+                __quantify_forward_request<quantify_policy>(
+                  quantify_pq_1, aw, req.data.source, rec);
+              } while (!__quantify_update_source_or_break(
+                quantify_pq_1, quantify_pq_2, req.data.source, req.target));
             } else {
               // Store for later, that a node is yet to be done.
               policy_impl.remaining_nodes++;
@@ -303,11 +297,13 @@ namespace adiar::internal
 
               quantify_request<0>::target_t rec0(rec_all[0], rec_all[1]);
 
-              __quantify_forward_request<quantify_policy>(quantify_pq_1, aw, out_uid.as_ptr(false), rec0);
+              __quantify_forward_request<quantify_policy>(
+                quantify_pq_1, aw, out_uid.as_ptr(false), rec0);
 
               quantify_request<0>::target_t rec1(rec_all[2], rec_all[3]);
 
-              __quantify_forward_request<quantify_policy>(quantify_pq_1, aw, out_uid.as_ptr(true), rec1);
+              __quantify_forward_request<quantify_policy>(
+                quantify_pq_1, aw, out_uid.as_ptr(true), rec1);
 
               if (!req.data.source.is_nil()) {
                 do {
@@ -315,9 +311,8 @@ namespace adiar::internal
                   stats_quantify.requests[arity_idx] += 1;
 #endif
                   aw.push_internal(arc(req.data.source, out_uid));
-                } while (!__quantify_update_source_or_break(quantify_pq_1, quantify_pq_2,
-                                                            req.data.source,
-                                                            req.target));
+                } while (!__quantify_update_source_or_break(
+                  quantify_pq_1, quantify_pq_2, req.data.source, req.target));
               }
             }
             continue;
@@ -334,13 +329,13 @@ namespace adiar::internal
 
         const node::uid_type out_uid(out_label, out_id++);
 
-        quantify_request<0>::target_t rec0 =
-          __quantify_resolve_request<quantify_policy, 2>(op, {children0[false], children1[false]});
+        quantify_request<0>::target_t rec0 = __quantify_resolve_request<quantify_policy, 2>(
+          op, { children0[false], children1[false] });
 
         __quantify_forward_request<quantify_policy>(quantify_pq_1, aw, out_uid.as_ptr(false), rec0);
 
         quantify_request<0>::target_t rec1 =
-          __quantify_resolve_request<quantify_policy, 2>(op, {children0[true], children1[true]});
+          __quantify_resolve_request<quantify_policy, 2>(op, { children0[true], children1[true] });
         __quantify_forward_request<quantify_policy>(quantify_pq_1, aw, out_uid.as_ptr(true), rec1);
 
         if (!req.data.source.is_nil()) {
@@ -349,16 +344,13 @@ namespace adiar::internal
             stats_quantify.requests[arity_idx] += 1;
 #endif
             aw.push_internal(arc(req.data.source, out_uid));
-          } while (!__quantify_update_source_or_break(quantify_pq_1, quantify_pq_2,
-                                                      req.data.source,
-                                                      req.target));
+          } while (!__quantify_update_source_or_break(
+            quantify_pq_1, quantify_pq_2, req.data.source, req.target));
         }
       }
 
       // Update meta information
-      if (out_id > 0) {
-        aw.push(level_info(out_label, out_id));
-      }
+      if (out_id > 0) { aw.push(level_info(out_label, out_id)); }
 
       out_arcs->max_1level_cut = std::max(out_arcs->max_1level_cut, quantify_pq_1.size());
     }
@@ -366,7 +358,7 @@ namespace adiar::internal
     // Ensure the edge case, where the in-going edge from nil to the root pair
     // does not dominate the max_1level_cut
     out_arcs->max_1level_cut = std::min(aw.size() - out_arcs->number_of_terminals[false]
-                                                  - out_arcs->number_of_terminals[true],
+                                          - out_arcs->number_of_terminals[true],
                                         out_arcs->max_1level_cut);
 
     return typename quantify_policy::__dd_type(out_arcs, ep);
@@ -376,9 +368,9 @@ namespace adiar::internal
   /// Derives an upper bound on the output's maximum i-level cut given its
   /// maximum i-level cut.
   //////////////////////////////////////////////////////////////////////////////
-  template<typename quantify_policy, typename cut, size_t const_size_inc, typename in_t>
-  size_t __quantify_ilevel_upper_bound(const in_t &in,
-                                       const bool_op &op)
+  template <typename quantify_policy, typename cut, size_t const_size_inc, typename in_t>
+  size_t
+  __quantify_ilevel_upper_bound(const in_t& in, const bool_op& op)
   {
     const typename cut::type ct_internal  = cut::type::Internal;
     const typename cut::type ct_terminals = quantify_policy::cut_with_terminals(op);
@@ -392,22 +384,29 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////
   /// Derives an upper bound on the output's maximum i-level cut given its size.
   //////////////////////////////////////////////////////////////////////////////
-  template<typename in_t>
-  size_t __quantify_ilevel_upper_bound(const in_t &in)
+  template <typename in_t>
+  size_t
+  __quantify_ilevel_upper_bound(const in_t& in)
   {
     const safe_size_t in_size = in.size();
     return to_size(in_size * in_size + 1u + 2u);
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  template<typename node_stream_t, typename pq_1_t, typename pq_2_t, typename quantify_policy, typename in_t>
+  template <typename node_stream_t,
+            typename pq_1_t,
+            typename pq_2_t,
+            typename quantify_policy,
+            typename in_t>
   typename quantify_policy::__dd_type
-  __quantify(const exec_policy &ep,
-             const in_t &in,
-             quantify_policy &policy_impl,
-             const bool_op &op,
-             const size_t pq_1_memory, const size_t max_pq_1_size,
-             const size_t pq_2_memory, const size_t max_pq_2_size)
+  __quantify(const exec_policy& ep,
+             const in_t& in,
+             quantify_policy& policy_impl,
+             const bool_op& op,
+             const size_t pq_1_memory,
+             const size_t max_pq_1_size,
+             const size_t pq_2_memory,
+             const size_t max_pq_2_size)
   {
     // Check for trivial terminal-only return on shortcutting the root
     typename quantify_policy::node_type root;
@@ -416,7 +415,8 @@ namespace adiar::internal
       node_stream_t in_nodes(in);
       root = in_nodes.pull();
 
-      if (policy_impl.should_quantify(root.label()) && (root.low().is_terminal() || root.high().is_terminal())) {
+      if (policy_impl.should_quantify(root.label())
+          && (root.low().is_terminal() || root.high().is_terminal())) {
         typename quantify_policy::pointer_type result = quantify_policy::resolve_root(root, op);
 
         if (result != root.uid() && result.is_terminal()) {
@@ -428,25 +428,24 @@ namespace adiar::internal
     // TODO: use 'result' above rather than 'root.uid()' for root request
 
     // Set up cross-level priority queue
-    pq_1_t quantify_pq_1({in}, pq_1_memory, max_pq_1_size, stats_quantify.lpq);
-    quantify_pq_1.push({ { root.uid(), ptr_uint64::nil() }, {}, {ptr_uint64::nil()} });
+    pq_1_t quantify_pq_1({ in }, pq_1_memory, max_pq_1_size, stats_quantify.lpq);
+    quantify_pq_1.push({ { root.uid(), ptr_uint64::nil() }, {}, { ptr_uint64::nil() } });
 
     // Set up per-level priority queue
     pq_2_t quantify_pq_2(pq_2_memory, max_pq_2_size);
 
-    return __quantify<node_stream_t, pq_1_t, pq_2_t>
-      (ep, in, policy_impl, op, quantify_pq_1, quantify_pq_2);
+    return __quantify<node_stream_t, pq_1_t, pq_2_t>(
+      ep, in, policy_impl, op, quantify_pq_1, quantify_pq_2);
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  template<typename node_stream_t,
-           template<size_t, memory_mode> typename pq_1_template,
-           typename quantify_policy, typename in_t>
+  template <typename node_stream_t,
+            template <size_t, memory_mode>
+            typename pq_1_template,
+            typename quantify_policy,
+            typename in_t>
   typename quantify_policy::__dd_type
-  __quantify(const exec_policy &ep,
-             const in_t &in,
-             quantify_policy &policy_impl,
-             const bool_op &op)
+  __quantify(const exec_policy& ep, const in_t& in, quantify_policy& policy_impl, const bool_op& op)
   {
     adiar_assert(is_commutative(op), "A commutative operator must be used");
 
@@ -469,46 +468,64 @@ namespace adiar::internal
       quantify_priority_queue_2_t<memory_mode::Internal>::data_structures;
 
     const size_t pq_1_internal_memory =
-      (aux_available_memory / (data_structures_in_pq_1 + data_structures_in_pq_2)) * data_structures_in_pq_1;
+      (aux_available_memory / (data_structures_in_pq_1 + data_structures_in_pq_2))
+      * data_structures_in_pq_1;
 
     const size_t pq_1_memory_fits =
       pq_1_template<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>::memory_fits(pq_1_internal_memory);
 
-    const size_t pq_2_internal_memory =
-      aux_available_memory - pq_1_internal_memory;
+    const size_t pq_2_internal_memory = aux_available_memory - pq_1_internal_memory;
 
     const size_t pq_2_memory_fits =
       quantify_priority_queue_2_t<memory_mode::Internal>::memory_fits(pq_2_internal_memory);
 
-    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
-    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
+    const bool internal_only =
+      ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only =
+      ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
-    const size_t pq_1_bound = std::min({__quantify_ilevel_upper_bound<quantify_policy, get_2level_cut, 2u>(in,op),
-                                        __quantify_ilevel_upper_bound(in)});
+    const size_t pq_1_bound =
+      std::min({ __quantify_ilevel_upper_bound<quantify_policy, get_2level_cut, 2u>(in, op),
+                 __quantify_ilevel_upper_bound(in) });
 
-    const size_t max_pq_1_size = internal_only ? std::min(pq_1_memory_fits, pq_1_bound) : pq_1_bound;
+    const size_t max_pq_1_size =
+      internal_only ? std::min(pq_1_memory_fits, pq_1_bound) : pq_1_bound;
 
-    const size_t pq_2_bound = __quantify_ilevel_upper_bound<quantify_policy, get_1level_cut, 0u>(in,op);
+    const size_t pq_2_bound =
+      __quantify_ilevel_upper_bound<quantify_policy, get_1level_cut, 0u>(in, op);
 
-    const size_t max_pq_2_size = internal_only ? std::min(pq_2_memory_fits, pq_2_bound) : pq_2_bound;
+    const size_t max_pq_2_size =
+      internal_only ? std::min(pq_2_memory_fits, pq_2_bound) : pq_2_bound;
 
-    if(!external_only && max_pq_1_size <= no_lookahead_bound(2)) {
+    if (!external_only && max_pq_1_size <= no_lookahead_bound(2)) {
 #ifdef ADIAR_STATS
       stats_quantify.lpq.unbucketed += 1u;
 #endif
       return __quantify<node_stream_t,
                         pq_1_template<0, memory_mode::Internal>,
-                        quantify_priority_queue_2_t<memory_mode::Internal>>
-        (ep, in, policy_impl, op, pq_1_internal_memory, max_pq_1_size, pq_2_internal_memory, max_pq_2_size);
-    } else if(!external_only && max_pq_1_size <= pq_1_memory_fits
-                             && max_pq_2_size <= pq_2_memory_fits) {
+                        quantify_priority_queue_2_t<memory_mode::Internal>>(ep,
+                                                                            in,
+                                                                            policy_impl,
+                                                                            op,
+                                                                            pq_1_internal_memory,
+                                                                            max_pq_1_size,
+                                                                            pq_2_internal_memory,
+                                                                            max_pq_2_size);
+    } else if (!external_only && max_pq_1_size <= pq_1_memory_fits
+               && max_pq_2_size <= pq_2_memory_fits) {
 #ifdef ADIAR_STATS
       stats_quantify.lpq.internal += 1u;
 #endif
       return __quantify<node_stream_t,
                         pq_1_template<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>,
-                        quantify_priority_queue_2_t<memory_mode::Internal>>
-        (ep, in, policy_impl, op, pq_1_internal_memory, max_pq_1_size, pq_2_internal_memory, max_pq_2_size);
+                        quantify_priority_queue_2_t<memory_mode::Internal>>(ep,
+                                                                            in,
+                                                                            policy_impl,
+                                                                            op,
+                                                                            pq_1_internal_memory,
+                                                                            max_pq_1_size,
+                                                                            pq_2_internal_memory,
+                                                                            max_pq_2_size);
     } else {
 #ifdef ADIAR_STATS
       stats_quantify.lpq.external += 1u;
@@ -518,35 +535,35 @@ namespace adiar::internal
 
       return __quantify<node_stream_t,
                         pq_1_template<ADIAR_LPQ_LOOKAHEAD, memory_mode::External>,
-                        quantify_priority_queue_2_t<memory_mode::External>>
-        (ep, in, policy_impl, op, pq_1_memory, max_pq_1_size, pq_2_memory, max_pq_2_size);
+                        quantify_priority_queue_2_t<memory_mode::External>>(
+        ep, in, policy_impl, op, pq_1_memory, max_pq_1_size, pq_2_memory, max_pq_2_size);
     }
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   typename quantify_policy::__dd_type
-  __quantify(const exec_policy &ep,
-             const typename quantify_policy::dd_type &in,
-             quantify_policy &policy_impl,
-             const bool_op &op)
+  __quantify(const exec_policy& ep,
+             const typename quantify_policy::dd_type& in,
+             quantify_policy& policy_impl,
+             const bool_op& op)
   {
     return __quantify<node_stream<>, quantify_priority_queue_1_node_t>(ep, in, policy_impl, op);
   }
 
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   typename quantify_policy::__dd_type
-  __quantify(const exec_policy &ep,
-             const typename quantify_policy::__dd_type &in,
-             quantify_policy &policy_impl,
-             const bool_op &op)
+  __quantify(const exec_policy& ep,
+             const typename quantify_policy::__dd_type& in,
+             quantify_policy& policy_impl,
+             const bool_op& op)
   {
     return __quantify<node_arc_stream<>, quantify_priority_queue_1_arc_t>(ep, in, policy_impl, op);
   }
 
   //////////////////////////////////////////////////////////////////////////////
   // Single-variable
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   class single_quantify_policy : public quantify_policy
   {
   private:
@@ -556,30 +573,32 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     single_quantify_policy(typename quantify_policy::label_type level)
       : _level(level)
-    { }
+    {}
 
     ////////////////////////////////////////////////////////////////////////////
     inline bool
     should_quantify(typename quantify_policy::label_type level) const
-    { return _level == level; }
+    {
+      return _level == level;
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     static constexpr bool partial_quantification = false;
   };
 
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   typename quantify_policy::__dd_type
-  quantify(const exec_policy &ep,
-           const typename quantify_policy::dd_type &in,
+  quantify(const exec_policy& ep,
+           const typename quantify_policy::dd_type& in,
            const typename quantify_policy::label_type label,
-           const bool_op &op)
+           const bool_op& op)
   {
     // Trivial cases, where there is no need to do any computation
     if (dd_isterminal(in) || !has_level(in, label)) {
 #ifdef ADIAR_STATS
       stats_quantify.skipped += 1u;
 #endif
-     return in;
+      return in;
     }
 
 #ifdef ADIAR_STATS
@@ -593,49 +612,57 @@ namespace adiar::internal
 
   //////////////////////////////////////////////////////////////////////////////
   // Multi-variable (common)
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   class multi_quantify_policy : public quantify_policy
   {
   private:
-    const bool_op &_op;
+    const bool_op& _op;
 
   public:
-    using request_t = quantify_request<0>;
+    using request_t      = quantify_request<0>;
     using request_pred_t = request_data_first_lt<request_t>;
 
-    template<size_t look_ahead, memory_mode mem_mode>
+    template <size_t look_ahead, memory_mode mem_mode>
     using pq_t = quantify_priority_queue_1_node_t<look_ahead, mem_mode>;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
-    static size_t stream_memory()
-    { return node_stream<>::memory_usage() + arc_writer::memory_usage(); }
+    static size_t
+    stream_memory()
+    {
+      return node_stream<>::memory_usage() + arc_writer::memory_usage();
+    }
 
     ////////////////////////////////////////////////////////////////////////////
-    static size_t pq_memory(const size_t inner_memory)
+    static size_t
+    pq_memory(const size_t inner_memory)
     {
       constexpr size_t data_structures_in_pq_1 =
-        quantify_priority_queue_1_node_t<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>::data_structures;
+        quantify_priority_queue_1_node_t<ADIAR_LPQ_LOOKAHEAD,
+                                         memory_mode::Internal>::data_structures;
 
       constexpr size_t data_structures_in_pq_2 =
         quantify_priority_queue_2_t<memory_mode::Internal>::data_structures;
 
-      return  (inner_memory / (data_structures_in_pq_1 + data_structures_in_pq_2)) * data_structures_in_pq_1;
+      return (inner_memory / (data_structures_in_pq_1 + data_structures_in_pq_2))
+        * data_structures_in_pq_1;
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    size_t pq_bound(const typename quantify_policy::shared_node_file_type &outer_file,
-                    const size_t /*outer_roots*/) const
+    size_t
+    pq_bound(const typename quantify_policy::shared_node_file_type& outer_file,
+             const size_t /*outer_roots*/) const
     {
       const typename quantify_policy::dd_type outer_wrapper(outer_file);
-      return std::min(__quantify_ilevel_upper_bound<quantify_policy, get_2level_cut, 2u>(outer_wrapper, _op),
-                      __quantify_ilevel_upper_bound(outer_wrapper));
+      return std::min(
+        __quantify_ilevel_upper_bound<quantify_policy, get_2level_cut, 2u>(outer_wrapper, _op),
+        __quantify_ilevel_upper_bound(outer_wrapper));
     }
 
   public:
-    multi_quantify_policy(const bool_op &op)
+    multi_quantify_policy(const bool_op& op)
       : _op(op)
-    { }
+    {}
 
   public:
     //////////////////////////////////////////////////////////////////////////////
@@ -643,9 +670,10 @@ namespace adiar::internal
     /// deepest yet to-be quantified level. Hence, we can provide an
     /// always-false predicate that is immediate to the compiler.
     //////////////////////////////////////////////////////////////////////////////
-    constexpr bool
-    should_quantify(typename quantify_policy::label_type /*level*/) const
-    { return false; }
+    constexpr bool should_quantify(typename quantify_policy::label_type /*level*/) const
+    {
+      return false;
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     static constexpr bool partial_quantification = false;
@@ -655,11 +683,11 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Run Sweep with given priority queue.
     ////////////////////////////////////////////////////////////////////////////
-    template<typename inner_pq_1_t>
+    template <typename inner_pq_1_t>
     typename quantify_policy::__dd_type
-    sweep_pq(const exec_policy &ep,
-             const shared_levelized_file<node> &outer_file,
-             inner_pq_1_t &inner_pq_1,
+    sweep_pq(const exec_policy& ep,
+             const shared_levelized_file<node>& outer_file,
+             inner_pq_1_t& inner_pq_1,
              const size_t inner_remaining_memory) const
     {
       const size_t pq_2_memory_fits =
@@ -667,54 +695,55 @@ namespace adiar::internal
 
       const size_t pq_2_bound =
         // Obtain 1-level cut from subset
-        __quantify_ilevel_upper_bound<quantify_policy, get_1level_cut, 0u>
-          (typename quantify_policy::dd_type(outer_file), _op)
+        __quantify_ilevel_upper_bound<quantify_policy, get_1level_cut, 0u>(
+          typename quantify_policy::dd_type(outer_file), _op)
         // Add crossing arcs
         + (inner_pq_1.size());
 
-      const size_t max_pq_2_size = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal
+      const size_t max_pq_2_size =
+        ep.template get<exec_policy::memory>() == exec_policy::memory::Internal
         ? std::min(pq_2_memory_fits, pq_2_bound)
         : pq_2_bound;
 
-      if(ep.template get<exec_policy::memory>() != exec_policy::memory::External && max_pq_2_size <= pq_2_memory_fits) {
+      if (ep.template get<exec_policy::memory>() != exec_policy::memory::External
+          && max_pq_2_size <= pq_2_memory_fits) {
         using inner_pq_2_t = quantify_priority_queue_2_t<memory_mode::Internal>;
         inner_pq_2_t inner_pq_2(inner_remaining_memory, max_pq_2_size);
 
-        return __quantify<node_stream<>, inner_pq_1_t, inner_pq_2_t>
-          (ep, outer_file, *this, _op, inner_pq_1, inner_pq_2);
+        return __quantify<node_stream<>, inner_pq_1_t, inner_pq_2_t>(
+          ep, outer_file, *this, _op, inner_pq_1, inner_pq_2);
       } else {
         using inner_pq_2_t = quantify_priority_queue_2_t<memory_mode::External>;
         inner_pq_2_t inner_pq_2(inner_remaining_memory, max_pq_2_size);
 
-        return __quantify<node_stream<>, inner_pq_1_t, inner_pq_2_t>
-          (ep, outer_file, *this, _op, inner_pq_1, inner_pq_2);
+        return __quantify<node_stream<>, inner_pq_1_t, inner_pq_2_t>(
+          ep, outer_file, *this, _op, inner_pq_1, inner_pq_2);
       }
     }
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Pick PQ type and Run Sweep.
     ////////////////////////////////////////////////////////////////////////////
-    template<typename outer_roots_t>
+    template <typename outer_roots_t>
     typename quantify_policy::__dd_type
-    sweep(const exec_policy &ep,
-          const shared_levelized_file<node> &outer_file,
-          outer_roots_t &outer_roots,
+    sweep(const exec_policy& ep,
+          const shared_levelized_file<node>& outer_file,
+          outer_roots_t& outer_roots,
           const size_t inner_memory) const
     {
-      return nested_sweeping::inner::down__sweep_switch
-        (ep, *this, outer_file, outer_roots, inner_memory, stats_quantify.lpq);
+      return nested_sweeping::inner::down__sweep_switch(
+        ep, *this, outer_file, outer_roots, inner_memory, stats_quantify.lpq);
     }
 
     //////////////////////////////////////////////////////////////////////////////
     /// \brief Create request
     //////////////////////////////////////////////////////////////////////////////
     inline request_t
-    request_from_node(const typename quantify_policy::node_type &n,
-                      const typename quantify_policy::pointer_type &parent) const
+    request_from_node(const typename quantify_policy::node_type& n,
+                      const typename quantify_policy::pointer_type& parent) const
     {
       // Shortcutting or Irrelevant terminal?
-      const typename quantify_policy::pointer_type result =
-        quantify_policy::resolve_root(n, _op);
+      const typename quantify_policy::pointer_type result = quantify_policy::resolve_root(n, _op);
 
       const bool shortcut = result != n.uid();
 
@@ -725,12 +754,13 @@ namespace adiar::internal
         : request_t::target_t{ first(n.low(), n.high()), second(n.low(), n.high()) };
 
 #ifdef ADIAR_STATS
-      stats_quantify.nested_policy.shortcut_terminal += static_cast<int>(shortcut && result.is_terminal());
-      stats_quantify.nested_policy.shortcut_node     += static_cast<int>(shortcut && result.is_node());
-      stats_quantify.nested_policy.products          += static_cast<int>(!shortcut);
+      stats_quantify.nested_policy.shortcut_terminal +=
+        static_cast<int>(shortcut && result.is_terminal());
+      stats_quantify.nested_policy.shortcut_node += static_cast<int>(shortcut && result.is_node());
+      stats_quantify.nested_policy.products += static_cast<int>(!shortcut);
 #endif
 
-      return request_t(tgt, {}, {parent});
+      return request_t(tgt, {}, { parent });
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -739,9 +769,8 @@ namespace adiar::internal
 
   //////////////////////////////////////////////////////////////////////////////
   // Multi-variable (predicate)
-  template<typename quantify_policy>
-  class partial_quantify_policy
-    : public quantify_policy
+  template <typename quantify_policy>
+  class partial_quantify_policy : public quantify_policy
   {
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -753,7 +782,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Predicate for whether a level should be swept on (or not).
     ////////////////////////////////////////////////////////////////////////////
-    const pred_t &_pred;
+    const pred_t& _pred;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -763,17 +792,20 @@ namespace adiar::internal
 
   public:
     ////////////////////////////////////////////////////////////////////////////
-    partial_quantify_policy(const pred_t &pred)
+    partial_quantify_policy(const pred_t& pred)
       : _pred(pred)
-    { }
+    {}
 
     ////////////////////////////////////////////////////////////////////////////
     inline bool
     should_quantify(typename quantify_policy::label_type level) const
-    { return _pred(level) == quantify_policy::quantify_onset; }
+    {
+      return _pred(level) == quantify_policy::quantify_onset;
+    }
 
     ////////////////////////////////////////////////////////////////////////////
-    void reset()
+    void
+    reset()
     {
       remaining_nodes = 0;
     }
@@ -782,9 +814,8 @@ namespace adiar::internal
     static constexpr bool partial_quantification = true;
   };
 
-  template<typename quantify_policy>
-  class multi_quantify_policy__pred
-    : public multi_quantify_policy<quantify_policy>
+  template <typename quantify_policy>
+  class multi_quantify_policy__pred : public multi_quantify_policy<quantify_policy>
   {
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -796,19 +827,21 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Predicate for whether a level should be swept on (or not).
     ////////////////////////////////////////////////////////////////////////////
-    const pred_t &_pred;
+    const pred_t& _pred;
 
   public:
     ////////////////////////////////////////////////////////////////////////////
-    multi_quantify_policy__pred(const bool_op &op, const pred_t &pred)
-      : multi_quantify_policy<quantify_policy>(op), _pred(pred)
-    { }
+    multi_quantify_policy__pred(const bool_op& op, const pred_t& pred)
+      : multi_quantify_policy<quantify_policy>(op)
+      , _pred(pred)
+    {}
 
   public:
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Whether the generator wants to sweep on the given level.
     ////////////////////////////////////////////////////////////////////////////
-    bool has_sweep(node::pointer_type::label_type l)
+    bool
+    has_sweep(node::pointer_type::label_type l)
     {
       return _pred(l) == quantify_policy::quantify_onset;
     }
@@ -818,10 +851,10 @@ namespace adiar::internal
   //       - initial cheap check on is_terminal.
   //       - initial 'quantify__get_deepest' should not terminate early but
   //         determine whether any variable may "survive".
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   inline typename quantify_policy::label_type
-  quantify__get_deepest(const typename quantify_policy::dd_type &dd,
-                        const predicate<typename quantify_policy::label_type> &pred)
+  quantify__get_deepest(const typename quantify_policy::dd_type& dd,
+                        const predicate<typename quantify_policy::label_type>& pred)
   {
     level_info_stream<true /* bottom-up */> lis(dd);
 
@@ -829,17 +862,17 @@ namespace adiar::internal
       const typename quantify_policy::label_type l = lis.pull().label();
       if (pred(l) == quantify_policy::quantify_onset) { return l; }
     }
-    return quantify_policy::max_label+1;
+    return quantify_policy::max_label + 1;
   }
 
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   inline typename quantify_policy::label_type
-  quantify__count_above_widest(const typename quantify_policy::dd_type &dd,
-                               const predicate<typename quantify_policy::label_type> &pred)
+  quantify__count_above_widest(const typename quantify_policy::dd_type& dd,
+                               const predicate<typename quantify_policy::label_type>& pred)
   {
     level_info_stream<true /* bottom-up */> lis(dd);
 
-    size_t acc = 0u;
+    size_t acc       = 0u;
     bool start_count = false;
     while (lis.can_pull()) {
       const level_info li = lis.pull();
@@ -849,12 +882,12 @@ namespace adiar::internal
     return acc;
   }
 
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   typename quantify_policy::__dd_type
-  quantify(const exec_policy &ep,
+  quantify(const exec_policy& ep,
            typename quantify_policy::dd_type dd,
-           const predicate<typename quantify_policy::label_type> &pred,
-           const bool_op &op)
+           const predicate<typename quantify_policy::label_type>& pred,
+           const bool_op& op)
   {
     using unreduced_t = typename quantify_policy::__dd_type;
     // TODO: check for missing std::move(...)
@@ -869,135 +902,129 @@ namespace adiar::internal
     }
 
     switch (ep.template get<exec_policy::quantify>()) {
-    case exec_policy::quantify::Partial:
-      { // ---------------------------------------------------------------------
-        // Case: Repeated partial quantification
+    case exec_policy::quantify::
+      Partial: { // ---------------------------------------------------------------------
+                 // Case: Repeated partial quantification
+#ifdef ADIAR_STATS
+      stats_quantify.partial_sweeps += 1u;
+#endif
+      partial_quantify_policy<quantify_policy> partial_impl(pred);
+      unreduced_t res = __quantify(ep, std::move(dd), partial_impl, op);
+
+      while (partial_impl.remaining_nodes > 0) {
+#ifdef ADIAR_STATS
+        stats_quantify.partial_sweeps += 1u;
+#endif
+        partial_impl.reset();
+        res = __quantify(ep, res, partial_impl, op);
+      }
+      return res;
+    }
+
+    case exec_policy::quantify::
+      Singleton: { // ---------------------------------------------------------------------
+                   // Case: Repeated single variable quantification
+#ifdef ADIAR_STATS
+      stats_quantify.singleton_sweeps += 1u;
+#endif
+      while (label <= quantify_policy::max_label) {
+        dd = quantify<quantify_policy>(ep, dd, label, op);
+        if (dd_isterminal(dd)) { return std::move(dd); }
+
+        label = quantify__get_deepest<quantify_policy>(dd, pred);
+      }
+      return dd;
+    }
+
+    case exec_policy::quantify::
+      Nested: { // ---------------------------------------------------------------------
+                // Case: Nested Sweeping
+#ifdef ADIAR_STATS
+      stats_quantify.nested_sweeps += 1u;
+#endif
+      multi_quantify_policy__pred<quantify_policy> inner_impl(op, pred);
+      return nested_sweep<>(
+        ep, quantify<quantify_policy>(ep, std::move(dd), label, op), inner_impl);
+    }
+    case exec_policy::quantify::
+      Auto: { // ---------------------------------------------------------------------
+      // Case: Partial/Singleton Quantification + Nested Sweeping
+      const size_t dd_size = dd.size();
+
+      const size_t nodes_per_block = get_block_size() / sizeof(typename quantify_policy::node_type);
+
+      // Do Partial Quantification as long as...
+      //   1. ... it stays smaller than 150% of the input size.
+      const size_t partial__size_threshold = 3u * (dd_size / 2u);
+
+      //   2. ... the number of terminals stays above 2% of the input.
+      //      (abusing rounding errors, this only has an effect if the
+      //      decision diagram is larger than a single block).
+      const size_t partial__terminal_threshold =
+        (nodes_per_block / (100u / 2u)) * (dd_size / nodes_per_block);
+
+      //   3. ... there (most likely) are still shallow to-be quantified
+      //      variables left for this iteration ('shallow' is in this context
+      //      variables above the deepest level with maximum width).
+      //
+      //      TODO: compute in the same iteration as 'label' above.
+      const size_t partial__max_iterations =
+        quantify__count_above_widest<quantify_policy>(dd, pred);
+
+      unreduced_t transposed;
+
+      // If 2. does not apply to the input, then partial quantification
+      // probably will explode the diagram to something quadratic.
+      if (dd.number_of_terminals() < partial__terminal_threshold) {
+        // Singleton Quantification of bottom-most level
+#ifdef ADIAR_STATS
+        stats_quantify.singleton_sweeps += 1u;
+#endif
+        transposed = quantify<quantify_policy>(ep, std::move(dd), label, op);
+      } else {
+        // Partial Quantification
 #ifdef ADIAR_STATS
         stats_quantify.partial_sweeps += 1u;
 #endif
         partial_quantify_policy<quantify_policy> partial_impl(pred);
-        unreduced_t res = __quantify(ep, std::move(dd), partial_impl, op);
+        transposed = __quantify(ep, std::move(dd), partial_impl, op);
 
-        while (partial_impl.remaining_nodes > 0) {
+        if (partial_impl.remaining_nodes == 0) {
 #ifdef ADIAR_STATS
-          stats_quantify.partial_sweeps += 1u;
+          stats_quantify.partial_termination += 1u;
 #endif
+          return transposed;
+        }
+
+        for (size_t i = 1; i < partial__max_iterations; ++i) {
+          if (partial__size_threshold < transposed.size()) { break; }
+          if (transposed.number_of_terminals() < partial__terminal_threshold) { break; }
+
+          // Reset policy and rerun partial quantification
           partial_impl.reset();
-          res = __quantify(ep, res, partial_impl, op);
-        }
-        return res;
-      }
 
-    case exec_policy::quantify::Singleton:
-      { // ---------------------------------------------------------------------
-        // Case: Repeated single variable quantification
-#ifdef ADIAR_STATS
-        stats_quantify.singleton_sweeps += 1u;
-#endif
-        while (label <= quantify_policy::max_label) {
-          dd = quantify<quantify_policy>(ep, dd, label, op);
-          if (dd_isterminal(dd)) { return std::move(dd); }
-
-          label = quantify__get_deepest<quantify_policy>(dd, pred);
-        }
-        return dd;
-      }
-
-    case exec_policy::quantify::Nested:
-      { // ---------------------------------------------------------------------
-        // Case: Nested Sweeping
-#ifdef ADIAR_STATS
-        stats_quantify.nested_sweeps += 1u;
-#endif
-        multi_quantify_policy__pred<quantify_policy> inner_impl(op, pred);
-        return nested_sweep<>(ep,
-                              quantify<quantify_policy>(ep, std::move(dd), label, op),
-                              inner_impl);
-      }
-    case exec_policy::quantify::Auto:
-      { // ---------------------------------------------------------------------
-        // Case: Partial/Singleton Quantification + Nested Sweeping
-        const size_t dd_size = dd.size();
-
-        const size_t nodes_per_block =
-          get_block_size() / sizeof(typename quantify_policy::node_type);
-
-        // Do Partial Quantification as long as...
-        //   1. ... it stays smaller than 150% of the input size.
-        const size_t partial__size_threshold = 3u * (dd_size / 2u);
-
-        //   2. ... the number of terminals stays above 2% of the input.
-        //      (abusing rounding errors, this only has an effect if the
-        //      decision diagram is larger than a single block).
-        const size_t partial__terminal_threshold =
-          (nodes_per_block / (100u / 2u)) * (dd_size / nodes_per_block);
-
-        //   3. ... there (most likely) are still shallow to-be quantified
-        //      variables left for this iteration ('shallow' is in this context
-        //      variables above the deepest level with maximum width).
-        //
-        //      TODO: compute in the same iteration as 'label' above.
-        const size_t partial__max_iterations =
-          quantify__count_above_widest<quantify_policy>(dd, pred);
-
-        unreduced_t transposed;
-
-        // If 2. does not apply to the input, then partial quantification
-        // probably will explode the diagram to something quadratic.
-        if (dd.number_of_terminals() < partial__terminal_threshold) {
-          // Singleton Quantification of bottom-most level
-#ifdef ADIAR_STATS
-          stats_quantify.singleton_sweeps += 1u;
-#endif
-          transposed = quantify<quantify_policy>(ep, std::move(dd), label, op);
-        } else {
-          // Partial Quantification
 #ifdef ADIAR_STATS
           stats_quantify.partial_sweeps += 1u;
 #endif
-          partial_quantify_policy<quantify_policy> partial_impl(pred);
-          transposed = __quantify(ep, std::move(dd), partial_impl, op);
+          transposed = __quantify(ep, transposed, partial_impl, op);
 
+          // Reduce result, if no work is left to be done.
           if (partial_impl.remaining_nodes == 0) {
 #ifdef ADIAR_STATS
             stats_quantify.partial_termination += 1u;
 #endif
             return transposed;
           }
-
-          for (size_t i = 1; i < partial__max_iterations; ++i) {
-            if (partial__size_threshold < transposed.size()) {
-              break;
-            }
-            if (transposed.number_of_terminals() < partial__terminal_threshold) {
-              break;
-            }
-
-            // Reset policy and rerun partial quantification
-            partial_impl.reset();
-
-#ifdef ADIAR_STATS
-            stats_quantify.partial_sweeps += 1u;
-#endif
-            transposed = __quantify(ep, transposed, partial_impl, op);
-
-            // Reduce result, if no work is left to be done.
-            if (partial_impl.remaining_nodes == 0) {
-#ifdef ADIAR_STATS
-              stats_quantify.partial_termination += 1u;
-#endif
-              return transposed;
-            }
-          }
-        }
-        { // Nested Sweeping
-#ifdef ADIAR_STATS
-          stats_quantify.nested_sweeps += 1u;
-#endif
-          multi_quantify_policy__pred<quantify_policy> inner_impl(op, pred);
-          return nested_sweep<>(ep, std::move(transposed), inner_impl);
         }
       }
+      { // Nested Sweeping
+#ifdef ADIAR_STATS
+        stats_quantify.nested_sweeps += 1u;
+#endif
+        multi_quantify_policy__pred<quantify_policy> inner_impl(op, pred);
+        return nested_sweep<>(ep, std::move(transposed), inner_impl);
+      }
+    }
 
       // LCOV_EXCL_START
     default:
@@ -1009,9 +1036,8 @@ namespace adiar::internal
 
   //////////////////////////////////////////////////////////////////////////////
   // Multi-variable (descending generator)
-  template<typename quantify_policy>
-  class multi_quantify_policy__generator
-    : public multi_quantify_policy<quantify_policy>
+  template <typename quantify_policy>
+  class multi_quantify_policy__generator : public multi_quantify_policy<quantify_policy>
   {
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -1025,7 +1051,7 @@ namespace adiar::internal
     /// \brief Generator of levels to sweep on (or not to sweep on) in
     ///        descending order.
     ////////////////////////////////////////////////////////////////////////////
-    const generator_t &_lvls;
+    const generator_t& _lvls;
 
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Buffer for to hold onto the generated next level.
@@ -1034,8 +1060,9 @@ namespace adiar::internal
 
   public:
     ////////////////////////////////////////////////////////////////////////////
-    multi_quantify_policy__generator(const bool_op &op, const generator_t &g)
-      : multi_quantify_policy<quantify_policy>(op), _lvls(g)
+    multi_quantify_policy__generator(const bool_op& op, const generator_t& g)
+      : multi_quantify_policy<quantify_policy>(op)
+      , _lvls(g)
     {
       _next_level = _lvls();
     }
@@ -1044,11 +1071,11 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////
     /// \brief Whether the generator wants to sweep on the given level.
     ////////////////////////////////////////////////////////////////////////////
-    bool has_sweep(const typename quantify_policy::label_type l)
+    bool
+    has_sweep(const typename quantify_policy::label_type l)
     {
-      return l == next_level(l)
-        ? quantify_policy::quantify_onset
-        : !quantify_policy::quantify_onset;
+      return l == next_level(l) ? quantify_policy::quantify_onset
+                                : !quantify_policy::quantify_onset;
     }
 
   private:
@@ -1061,10 +1088,8 @@ namespace adiar::internal
     typename quantify_policy::label_type
     next_level(const typename quantify_policy::label_type l)
     {
-      while (_next_level.has_value() && l < _next_level.value()) {
-        _next_level = _lvls();
-      }
-      return _next_level.value_or(quantify_policy::max_label+1);
+      while (_next_level.has_value() && l < _next_level.value()) { _next_level = _lvls(); }
+      return _next_level.value_or(quantify_policy::max_label + 1);
     }
   };
 
@@ -1074,9 +1099,9 @@ namespace adiar::internal
   //         determine whether any variable may "survive".
   //       clean up
   //       - Make return type 'optional' rather than larger than 'max_label'
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   inline typename quantify_policy::label_type
-  quantify__get_deepest(const typename quantify_policy::dd_type &dd,
+  quantify__get_deepest(const typename quantify_policy::dd_type& dd,
                         const typename quantify_policy::label_type bot_level,
                         const optional<typename quantify_policy::label_type> top_level)
   {
@@ -1084,63 +1109,80 @@ namespace adiar::internal
 
     while (lis.can_pull()) {
       const typename quantify_policy::label_type l = lis.pull().label();
-      if ((!top_level || top_level.value() < l) && l < bot_level) {
-        return l;
-      }
+      if ((!top_level || top_level.value() < l) && l < bot_level) { return l; }
     }
-    return quantify_policy::max_label+1;
+    return quantify_policy::max_label + 1;
   }
 
-  template<typename quantify_policy>
+  template <typename quantify_policy>
   typename quantify_policy::__dd_type
-  quantify(const exec_policy &ep,
+  quantify(const exec_policy& ep,
            typename quantify_policy::dd_type dd,
-           const typename multi_quantify_policy__generator<quantify_policy>::generator_t &lvls,
-           const bool_op &op)
+           const typename multi_quantify_policy__generator<quantify_policy>::generator_t& lvls,
+           const bool_op& op)
   {
     adiar_assert(is_commutative(op), "Operator must be commutative");
 
     // NOTE: read-once access with 'gen' makes partial quantification not possible.
     switch (ep.template get<exec_policy::quantify>()) {
     case exec_policy::quantify::Partial:
-    case exec_policy::quantify::Singleton:
-      { // -------------------------------------------------------------------
-        // Case: Repeated single variable quantification
-        // TODO: correctly handle quantify_policy::quantify_onset
-        optional<typename quantify_policy::label_type> on_level = lvls();
+    case exec_policy::quantify::
+      Singleton: { // -------------------------------------------------------------------
+      // Case: Repeated single variable quantification
+      // TODO: correctly handle quantify_policy::quantify_onset
+      optional<typename quantify_policy::label_type> on_level = lvls();
 
-        if (quantify_policy::quantify_onset) {
-          if (!on_level) {
+      if (quantify_policy::quantify_onset) {
+        if (!on_level) {
 #ifdef ADIAR_STATS
-            stats_quantify.skipped += 1u;
+          stats_quantify.skipped += 1u;
 #endif
-            return dd;
-          }
+          return dd;
+        }
 
-          // Quantify all but the last 'on_level'. Hence, look one ahead with
-          // 'next_on_level' to see whether it is the last one.
-          optional<typename quantify_policy::label_type> next_on_level = lvls();
-          while (next_on_level) {
+        // Quantify all but the last 'on_level'. Hence, look one ahead with
+        // 'next_on_level' to see whether it is the last one.
+        optional<typename quantify_policy::label_type> next_on_level = lvls();
+        while (next_on_level) {
 #ifdef ADIAR_STATS
-            stats_quantify.singleton_sweeps += 1u;
+          stats_quantify.singleton_sweeps += 1u;
 #endif
-            dd = quantify<quantify_policy>(ep, dd, on_level.value(), op);
-            if (dd_isterminal(dd)) { return dd; }
+          dd = quantify<quantify_policy>(ep, dd, on_level.value(), op);
+          if (dd_isterminal(dd)) { return dd; }
 
-            on_level = next_on_level;
-            next_on_level = lvls();
-          }
-          return quantify<quantify_policy>(ep, dd, on_level.value(), op);
-        } else { // !quantify_policy::quantify_onset
-          // TODO: only designed for 'OR' at this point in time
-          if (!on_level) {
-            return typename quantify_policy::dd_type(dd->number_of_terminals[true] > 0);
-          }
+          on_level      = next_on_level;
+          next_on_level = lvls();
+        }
+        return quantify<quantify_policy>(ep, dd, on_level.value(), op);
+      } else { // !quantify_policy::quantify_onset
+        // TODO: only designed for 'OR' at this point in time
+        if (!on_level) {
+          return typename quantify_policy::dd_type(dd->number_of_terminals[true] > 0);
+        }
 
-          // Quantify everything below 'label'
+        // Quantify everything below 'label'
+        for (;;) {
+          const typename quantify_policy::label_type off_level =
+            quantify__get_deepest<quantify_policy>(
+              dd, quantify_policy::max_label, on_level.value());
+
+          if (quantify_policy::max_label < off_level) { break; }
+
+#ifdef ADIAR_STATS
+          stats_quantify.singleton_sweeps += 1u;
+#endif
+          dd = quantify<quantify_policy>(ep, dd, off_level, op);
+          if (dd_isterminal(dd)) { return dd; }
+        }
+
+        // Quantify everything strictly in between 'bot_level' and 'top_level'
+        optional<typename quantify_policy::label_type> bot_level = on_level;
+        optional<typename quantify_policy::label_type> top_level = lvls();
+
+        while (bot_level) {
           for (;;) {
             const typename quantify_policy::label_type off_level =
-              quantify__get_deepest<quantify_policy>(dd, quantify_policy::max_label, on_level.value());
+              quantify__get_deepest<quantify_policy>(dd, bot_level.value(), top_level);
 
             if (quantify_policy::max_label < off_level) { break; }
 
@@ -1151,109 +1193,91 @@ namespace adiar::internal
             if (dd_isterminal(dd)) { return dd; }
           }
 
-          // Quantify everything strictly in between 'bot_level' and 'top_level'
-          optional<typename quantify_policy::label_type> bot_level = on_level;
-          optional<typename quantify_policy::label_type> top_level = lvls();
-
-          while (bot_level) {
-            for (;;) {
-              const typename quantify_policy::label_type off_level =
-                quantify__get_deepest<quantify_policy>(dd, bot_level.value(), top_level);
-
-              if (quantify_policy::max_label < off_level) { break; }
-
-#ifdef ADIAR_STATS
-              stats_quantify.singleton_sweeps += 1u;
-#endif
-              dd = quantify<quantify_policy>(ep, dd, off_level, op);
-              if (dd_isterminal(dd)) { return dd; }
-            }
-
-            bot_level = top_level;
-            top_level = lvls();
-          }
-          return dd;
+          bot_level = top_level;
+          top_level = lvls();
         }
+        return dd;
       }
+    }
 
     case exec_policy::quantify::Auto:
-    case exec_policy::quantify::Nested:
-      { // ---------------------------------------------------------------------
-        // Case: Nested Sweeping
-        //
-        // NOTE: Despite partial quantification is not possible, we can
-        //       (assuming we have to quantify the on-set) still use the
-        //       bottom-most level to transpose the DAG.
-        if constexpr (quantify_policy::quantify_onset) {
-          // Obtain the bottom-most onset level that exists in the diagram.
-          optional<typename quantify_policy::label_type> transposition_level = lvls();
-          if (!transposition_level) {
+    case exec_policy::quantify::
+      Nested: { // ---------------------------------------------------------------------
+      // Case: Nested Sweeping
+      //
+      // NOTE: Despite partial quantification is not possible, we can
+      //       (assuming we have to quantify the on-set) still use the
+      //       bottom-most level to transpose the DAG.
+      if constexpr (quantify_policy::quantify_onset) {
+        // Obtain the bottom-most onset level that exists in the diagram.
+        optional<typename quantify_policy::label_type> transposition_level = lvls();
+        if (!transposition_level) {
 #ifdef ADIAR_STATS
-            stats_quantify.skipped += 1u;
+          stats_quantify.skipped += 1u;
 #endif
-            return dd;
-          }
+          return dd;
+        }
 
-          {
-            level_info_stream<true> in_meta(dd);
-            typename quantify_policy::label_type dd_level = in_meta.pull().level();
+        {
+          level_info_stream<true> in_meta(dd);
+          typename quantify_policy::label_type dd_level = in_meta.pull().level();
 
-            for (;;) {
-              // Go forward in the diagram's levels, until we are at or above
-              // the current candidate
-              while (in_meta.can_pull() && transposition_level.value() < dd_level) {
-                dd_level = in_meta.pull().level();
-              }
-              // There is no onset level in the diagram? If so, then nothing is
-              // going to change and we may just return the input.
-              if (!in_meta.can_pull() && transposition_level.value() < dd_level) {
+          for (;;) {
+            // Go forward in the diagram's levels, until we are at or above
+            // the current candidate
+            while (in_meta.can_pull() && transposition_level.value() < dd_level) {
+              dd_level = in_meta.pull().level();
+            }
+            // There is no onset level in the diagram? If so, then nothing is
+            // going to change and we may just return the input.
+            if (!in_meta.can_pull() && transposition_level.value() < dd_level) {
+#ifdef ADIAR_STATS
+              stats_quantify.skipped += 1u;
+#endif
+              return dd;
+            }
+
+            adiar_assert(dd_level <= transposition_level.value(),
+                         "Must be at or above candidate level");
+
+            // Did we find the current candidate or skipped past it?
+            if (dd_level == transposition_level.value()) {
+              break;
+            } else { // dd_level < transposition_level
+              transposition_level = lvls();
+
+              // Did we run out of 'onset' levels?
+              if (!transposition_level) {
 #ifdef ADIAR_STATS
                 stats_quantify.skipped += 1u;
 #endif
                 return dd;
               }
-
-              adiar_assert(dd_level <= transposition_level.value(),
-                           "Must be at or above candidate level");
-
-              // Did we find the current candidate or skipped past it?
-              if (dd_level == transposition_level.value()) {
-                break;
-              } else { // dd_level < transposition_level
-                transposition_level = lvls();
-
-                // Did we run out of 'onset' levels?
-                if (!transposition_level) {
-#ifdef ADIAR_STATS
-                  stats_quantify.skipped += 1u;
-#endif
-                  return dd;
-                }
-              }
             }
           }
-          adiar_assert(transposition_level.has_value());
-
-          // Quantify the 'transposition_level' as part of the initial transposition step
-#ifdef ADIAR_STATS
-          stats_quantify.singleton_sweeps += 1u;
-#endif
-          typename quantify_policy::__dd_type transposed =
-            quantify<quantify_policy>(ep, dd, transposition_level.value(), op);
-
-#ifdef ADIAR_STATS
-          stats_quantify.nested_sweeps += 1u;
-#endif
-          multi_quantify_policy__generator<quantify_policy> inner_impl(op, lvls);
-          return nested_sweep<>(ep, std::move(transposed), inner_impl);
-        } else { // !quantify_policy::quantify_onset
-#ifdef ADIAR_STATS
-          stats_quantify.nested_sweeps += 1u;
-#endif
-          multi_quantify_policy__generator<quantify_policy> inner_impl(op, lvls);
-          return nested_sweep<>(ep, dd, inner_impl);
         }
+        adiar_assert(transposition_level.has_value());
+
+        // Quantify the 'transposition_level' as part of the initial transposition step
+#ifdef ADIAR_STATS
+        stats_quantify.singleton_sweeps += 1u;
+#endif
+        typename quantify_policy::__dd_type transposed =
+          quantify<quantify_policy>(ep, dd, transposition_level.value(), op);
+
+#ifdef ADIAR_STATS
+        stats_quantify.nested_sweeps += 1u;
+#endif
+        multi_quantify_policy__generator<quantify_policy> inner_impl(op, lvls);
+        return nested_sweep<>(ep, std::move(transposed), inner_impl);
+      } else { // !quantify_policy::quantify_onset
+#ifdef ADIAR_STATS
+        stats_quantify.nested_sweeps += 1u;
+#endif
+        multi_quantify_policy__generator<quantify_policy> inner_impl(op, lvls);
+        return nested_sweep<>(ep, dd, inner_impl);
       }
+    }
 
       // LCOV_EXCL_START
     default:

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -908,11 +908,11 @@ namespace adiar::internal
       const size_t dd_size = dd.size();
 
       // Do Partial Quantification as long as...
-      //   1. ... it stays smaller than 1+epsilon% of the input size.
-      const size_t transposition__size_threshold = static_cast<size_t>(
-        std::min<double>(std::numeric_limits<size_t>::max(),
-                         ep.template get<exec_policy::quantify::transposition_growth>()
-                           * static_cast<double>(dd_size)));
+      //   1. ... it stays smaller than 1+epsilon of the input size.
+      const size_t transposition__size_threshold =
+        (std::min(static_cast<double>(std::numeric_limits<size_t>::max() / 2u),
+                  static_cast<double>(ep.template get<exec_policy::quantify::transposition_growth>())
+                  * static_cast<double>(dd_size)));
 
       //   2. ... it has not run more than the maximum number of iterations.
       const size_t transposition__max_iterations =

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -895,7 +895,7 @@ namespace adiar::internal
 #endif
       while (label <= quantify_policy::max_label) {
         dd = quantify<quantify_policy>(ep, dd, label, op);
-        if (dd_isterminal(dd)) { return std::move(dd); }
+        if (dd_isterminal(dd)) { return dd; }
 
         label = quantify__get_deepest<quantify_policy>(dd, pred);
       }

--- a/src/adiar/internal/algorithms/reduce.h
+++ b/src/adiar/internal/algorithms/reduce.h
@@ -623,8 +623,8 @@ namespace adiar::internal
     const tpie::memory_size_type pq_memory_fits =
       reduce_priority_queue<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>::memory_fits(pq_memory);
 
-    const bool internal_only = input._policy.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = input._policy.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = input._policy.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = input._policy.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_bound = in_file->max_1level_cut;
 

--- a/src/adiar/internal/algorithms/select.h
+++ b/src/adiar/internal/algorithms/select.h
@@ -209,8 +209,8 @@ namespace adiar::internal
     const tpie::memory_size_type pq_memory_fits =
       select_priority_queue_t<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>::memory_fits(aux_available_memory);
 
-    const bool internal_only = ep.memory_mode() == exec_policy::memory::Internal;
-    const bool external_only = ep.memory_mode() == exec_policy::memory::External;
+    const bool internal_only = ep.template get<exec_policy::memory>() == exec_policy::memory::Internal;
+    const bool external_only = ep.template get<exec_policy::memory>() == exec_policy::memory::External;
 
     const size_t pq_bound = __select_2level_upper_bound<SelectPolicy>(dd);
 

--- a/src/adiar/internal/data_structures/levelized_priority_queue.h
+++ b/src/adiar/internal/data_structures/levelized_priority_queue.h
@@ -450,7 +450,7 @@ namespace adiar::internal
     void init_buckets()
     {
       // Initially skip the number of levels
-      for (ptr_uint64::label_type idx = 0; _level_merger.can_pull() && idx < LevelSkip; idx++) {
+      for (size_t idx = 0; _level_merger.can_pull() && idx < LevelSkip; idx++) {
         _level_merger.pull();
       }
 

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -606,8 +606,8 @@ go_bandit([]() {
     //          than twice their original size. If each subtree itself also is
     //          duplicated, then it gets close(ish) to 200% the input size.
     //
-    //          The variables x0 and x1 are designed such that Partial
-    //          Quantification has to leave another node for later.
+    //          The variables x0 and x1 are designed such that repeated
+    //          transposition has to leave another node for later at x1.
     /*
     //                        __r1__                    ---- x0
     //                       /      \
@@ -660,21 +660,19 @@ go_bandit([]() {
     /*
     //                            _______(1,a)_______
     //                           /                   \
-    //              __________(1,b)__________      (1,c)   <-- (1,c) is symmetric to (1,b) (these
-    merge with (4,b) and (4,c))
-    //             /                         \       .         Size: 3 additional nodes (incl.
-    (1,c))
-    //           (2,b)                     (3,c)     .
-    //           /   \                      |  \     .
+    //                ________(1,b)________        (1,c)   <-- (1,c) is symmetric to (1,b) (these
+    //               /                     \         .          merge with (4,b) and (4,c))
+    //              /                       \        .          Size: 3 additional nodes
+    //             /                         \       .                (incl. (1,c))
+    //           (2,b)                     (3,c)
+    //           /   \                      |  \
     //          (b) (4,b)                (4,c) (c)
     //              /   \                /   \
-    //             (5) (6,d)           (5,d) (6)            <-- At this point we have copies of both
-    inputs.
+    //             (5) (6,d)           (5,d) (6)            <-- Here, both inputs are copied
     //                 /   \           /   \                    Left subtree:  #nodes - 4
     //              (7,f) (9,g)    (8,d) (7,g)                  Right subtree: #nodes - 1
     //              /   \                /   \
-    //          (8,f)   (9,f)          (8,g) (9,g)          <-- (8,g) and (9,g) also produce the
-    same pairs
+    //          (8,f)   (9,f)          (8,g) (9,g)          <-- (8,g), (9,g) produce same pairs
     //         /   |     |   \          / /   / /
     //        /    |     |    \        . .   . .
     //       /     |     |     \      . .   . .

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -2245,7 +2245,7 @@ go_bandit([]() {
 
       describe("algorithm: Nested, max: 1+", [&]() {
         const exec_policy ep = exec_policy::quantify::Nested
-          & exec_policy::quantify::transposition_growth(0.5)
+          & exec_policy::quantify::transposition_growth(1.5)
           & exec_policy::quantify::transposition_max(2);
 
         it("collapses during initial transposition of all variables in BDD 4 [&&]", [&]() {
@@ -3063,7 +3063,7 @@ go_bandit([]() {
 
         it("switches to nested sweeping when the transposition explodes with BDD 15 [&&]", [&]() {
           const exec_policy ep = exec_policy::quantify::Nested
-            & exec_policy::quantify::transposition_growth(0.5)
+            & exec_policy::quantify::transposition_growth(1.5)
             & exec_policy::quantify::transposition_max::max();
 
           std::vector<bdd::label_type> call_history;

--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -1,5 +1,4 @@
 #include "../../test.h"
-
 #include <vector>
 
 go_bandit([]() {
@@ -53,14 +52,14 @@ go_bandit([]() {
     shared_levelized_file<bdd::node_type> bdd_2;
 
     const node n2_5 = node(2, node::max_id, ptr_uint64(false), ptr_uint64(true));
-    const node n2_4 = node(2, node::max_id-1, ptr_uint64(true), ptr_uint64(false));
+    const node n2_4 = node(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
     const node n2_3 = node(1, node::max_id, n2_5.uid(), ptr_uint64(false));
-    const node n2_2 = node(1, node::max_id-1, n2_4.uid(), n2_5.uid());
+    const node n2_2 = node(1, node::max_id - 1, n2_4.uid(), n2_5.uid());
     const node n2_1 = node(0, node::max_id, n2_2.uid(), n2_3.uid());
 
     { // Garbage collect writer to free write-lock
       node_writer nw_2(bdd_2);
-      nw_2 << n2_5 << n2_4 << n2_3 <<n2_2 << n2_1;
+      nw_2 << n2_5 << n2_4 << n2_3 << n2_2 << n2_1;
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -77,7 +76,7 @@ go_bandit([]() {
     shared_levelized_file<bdd::node_type> bdd_3;
 
     const node n3_4 = node(2, node::max_id, ptr_uint64(false), ptr_uint64(true));
-    const node n3_3 = node(2, node::max_id-1, ptr_uint64(true), ptr_uint64(false));
+    const node n3_3 = node(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
     const node n3_2 = node(1, node::max_id, n3_3.uid(), n3_4.uid());
     const node n3_1 = node(0, node::max_id, n3_3.uid(), n3_2.uid());
 
@@ -103,7 +102,7 @@ go_bandit([]() {
 
     const node n4_5 = node(3, node::max_id, ptr_uint64(false), ptr_uint64(true));
     const node n4_4 = node(2, node::max_id, n4_5.uid(), ptr_uint64(true));
-    const node n4_3 = node(2, node::max_id-1, ptr_uint64(false), n4_5.uid());
+    const node n4_3 = node(2, node::max_id - 1, ptr_uint64(false), n4_5.uid());
     const node n4_2 = node(1, node::max_id, n4_3.uid(), n4_4.uid());
     const node n4_1 = node(0, node::max_id, n4_3.uid(), n4_2.uid());
 
@@ -126,7 +125,7 @@ go_bandit([]() {
     shared_levelized_file<bdd::node_type> bdd_5;
 
     const node n5_4 = node(2, node::max_id, ptr_uint64(true), ptr_uint64(false));
-    const node n5_3 = node(2, node::max_id-1, ptr_uint64(false), ptr_uint64(true));
+    const node n5_3 = node(2, node::max_id - 1, ptr_uint64(false), ptr_uint64(true));
     const node n5_2 = node(1, node::max_id, n5_3.uid(), n5_4.uid());
     const node n5_1 = node(0, node::max_id, ptr_uint64(false), n5_2.uid());
 
@@ -162,14 +161,24 @@ go_bandit([]() {
 
     { // Garbage collect writer to free write-lock
       node_writer nw_6(bdd_6);
-      nw_6 << node(3, node::max_id,   ptr_uint64(false),                   ptr_uint64(true))                    // 8
-           << node(3, node::max_id-1, ptr_uint64(true),                    ptr_uint64(false))                   // 7
-           << node(2, node::max_id,   ptr_uint64(3, ptr_uint64::max_id),   ptr_uint64(true))                    // 6
-           << node(2, node::max_id-1, ptr_uint64(3, ptr_uint64::max_id-1), ptr_uint64(false))                   // 5
-           << node(2, node::max_id-2, ptr_uint64(false),                   ptr_uint64(3, ptr_uint64::max_id))   // 4
-           << node(1, node::max_id,   ptr_uint64(2, ptr_uint64::max_id-2), ptr_uint64(2, ptr_uint64::max_id))   // 3
-           << node(1, node::max_id-1, ptr_uint64(2, ptr_uint64::max_id),   ptr_uint64(2, ptr_uint64::max_id-1)) // 2
-           << node(0, node::max_id,   ptr_uint64(1, ptr_uint64::max_id),   ptr_uint64(1, ptr_uint64::max_id-1)) // 1
+      nw_6 << node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))                 // 8
+           << node(3, node::max_id - 1, ptr_uint64(true), ptr_uint64(false))             // 7
+           << node(2, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true)) // 6
+           << node(
+                2, node::max_id - 1, ptr_uint64(3, ptr_uint64::max_id - 1), ptr_uint64(false)) // 5
+           << node(2, node::max_id - 2, ptr_uint64(false), ptr_uint64(3, ptr_uint64::max_id))  // 4
+           << node(1,
+                   node::max_id,
+                   ptr_uint64(2, ptr_uint64::max_id - 2),
+                   ptr_uint64(2, ptr_uint64::max_id)) // 3
+           << node(1,
+                   node::max_id - 1,
+                   ptr_uint64(2, ptr_uint64::max_id),
+                   ptr_uint64(2, ptr_uint64::max_id - 1)) // 2
+           << node(0,
+                   node::max_id,
+                   ptr_uint64(1, ptr_uint64::max_id),
+                   ptr_uint64(1, ptr_uint64::max_id - 1)) // 1
         ;
     }
 
@@ -179,15 +188,28 @@ go_bandit([]() {
 
     { // Garbage collect writer to free write-lock
       node_writer nw_6(bdd_6_x4T);
-      nw_6 << node(4, node::max_id,   ptr_uint64(false),                   ptr_uint64(true))                    // T
-           << node(3, node::max_id,   ptr_uint64(false),                   ptr_uint64(4, ptr_uint64::max_id))   // 8
-           << node(3, node::max_id-1, ptr_uint64(4, ptr_uint64::max_id),   ptr_uint64(false))                   // 7
-           << node(2, node::max_id,   ptr_uint64(3, ptr_uint64::max_id),   ptr_uint64(4, ptr_uint64::max_id))   // 6
-           << node(2, node::max_id-1, ptr_uint64(3, ptr_uint64::max_id-1), ptr_uint64(false))                   // 5
-           << node(2, node::max_id-2, ptr_uint64(false),                   ptr_uint64(3, ptr_uint64::max_id))   // 4
-           << node(1, node::max_id,   ptr_uint64(2, ptr_uint64::max_id-2), ptr_uint64(2, ptr_uint64::max_id))   // 3
-           << node(1, node::max_id-1, ptr_uint64(2, ptr_uint64::max_id),   ptr_uint64(2, ptr_uint64::max_id-1)) // 2
-           << node(0, node::max_id,   ptr_uint64(1, ptr_uint64::max_id),   ptr_uint64(1, ptr_uint64::max_id-1)) // 1
+      nw_6 << node(4, node::max_id, ptr_uint64(false), ptr_uint64(true))                      // T
+           << node(3, node::max_id, ptr_uint64(false), ptr_uint64(4, ptr_uint64::max_id))     // 8
+           << node(3, node::max_id - 1, ptr_uint64(4, ptr_uint64::max_id), ptr_uint64(false)) // 7
+           << node(2,
+                   node::max_id,
+                   ptr_uint64(3, ptr_uint64::max_id),
+                   ptr_uint64(4, ptr_uint64::max_id)) // 6
+           << node(
+                2, node::max_id - 1, ptr_uint64(3, ptr_uint64::max_id - 1), ptr_uint64(false)) // 5
+           << node(2, node::max_id - 2, ptr_uint64(false), ptr_uint64(3, ptr_uint64::max_id))  // 4
+           << node(1,
+                   node::max_id,
+                   ptr_uint64(2, ptr_uint64::max_id - 2),
+                   ptr_uint64(2, ptr_uint64::max_id)) // 3
+           << node(1,
+                   node::max_id - 1,
+                   ptr_uint64(2, ptr_uint64::max_id),
+                   ptr_uint64(2, ptr_uint64::max_id - 1)) // 2
+           << node(0,
+                   node::max_id,
+                   ptr_uint64(1, ptr_uint64::max_id),
+                   ptr_uint64(1, ptr_uint64::max_id - 1)) // 1
         ;
     }
 
@@ -208,11 +230,20 @@ go_bandit([]() {
 
     { // Garbage collect writer to free write-lock
       node_writer nw_7(bdd_7);
-      nw_7 << node(2, node::max_id,   ptr_uint64(false),      ptr_uint64(true))       // 5
-           << node(2, node::max_id-1, ptr_uint64(true),       ptr_uint64(false))      // 4
-           << node(1, node::max_id,   ptr_uint64(2, ptr_uint64::max_id),   ptr_uint64(2, ptr_uint64::max_id-1)) // 3
-           << node(1, node::max_id-1, ptr_uint64(2, ptr_uint64::max_id-1), ptr_uint64(2, ptr_uint64::max_id))   // 2
-           << node(0, node::max_id,   ptr_uint64(1, ptr_uint64::max_id),   ptr_uint64(1, ptr_uint64::max_id-1)) // 1
+      nw_7 << node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))     // 5
+           << node(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false)) // 4
+           << node(1,
+                   node::max_id,
+                   ptr_uint64(2, ptr_uint64::max_id),
+                   ptr_uint64(2, ptr_uint64::max_id - 1)) // 3
+           << node(1,
+                   node::max_id - 1,
+                   ptr_uint64(2, ptr_uint64::max_id - 1),
+                   ptr_uint64(2, ptr_uint64::max_id)) // 2
+           << node(0,
+                   node::max_id,
+                   ptr_uint64(1, ptr_uint64::max_id),
+                   ptr_uint64(1, ptr_uint64::max_id - 1)) // 1
         ;
     }
 
@@ -236,19 +267,31 @@ go_bandit([]() {
 
     { // Garbage collect writer to free write-lock
       node_writer nw_8a(bdd_8a);
-      nw_8a << node(3, node::max_id,   ptr_uint64(false),      ptr_uint64(true))       // 5
-            << node(2, node::max_id,   ptr_uint64(false),      ptr_uint64(3, ptr_uint64::max_id))   // 4
-            << node(2, node::max_id-1, ptr_uint64(true),       ptr_uint64(3, ptr_uint64::max_id))   // 3
-            << node(1, node::max_id,   ptr_uint64(2, ptr_uint64::max_id-1), ptr_uint64(2, ptr_uint64::max_id))   // 2
-            << node(0, node::max_id,   ptr_uint64(1, ptr_uint64::max_id),   ptr_uint64(3, ptr_uint64::max_id))   // 1
+      nw_8a << node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))                     // 5
+            << node(2, node::max_id, ptr_uint64(false), ptr_uint64(3, ptr_uint64::max_id))    // 4
+            << node(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(3, ptr_uint64::max_id)) // 3
+            << node(1,
+                    node::max_id,
+                    ptr_uint64(2, ptr_uint64::max_id - 1),
+                    ptr_uint64(2, ptr_uint64::max_id)) // 2
+            << node(0,
+                    node::max_id,
+                    ptr_uint64(1, ptr_uint64::max_id),
+                    ptr_uint64(3, ptr_uint64::max_id)) // 1
         ;
 
       node_writer nw_8b(bdd_8b);
-      nw_8b << node(3, node::max_id,   ptr_uint64(false),      ptr_uint64(true))       // 5
-            << node(2, node::max_id,   ptr_uint64(3, ptr_uint64::max_id),   ptr_uint64(false))      // 4
-            << node(2, node::max_id-1, ptr_uint64(3, ptr_uint64::max_id),   ptr_uint64(true))       // 3
-            << node(1, node::max_id,   ptr_uint64(2, ptr_uint64::max_id-1), ptr_uint64(2, ptr_uint64::max_id))   // 2
-            << node(0, node::max_id,   ptr_uint64(1, ptr_uint64::max_id),   ptr_uint64(3, ptr_uint64::max_id))   // 1
+      nw_8b << node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))                     // 5
+            << node(2, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(false))    // 4
+            << node(2, node::max_id - 1, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true)) // 3
+            << node(1,
+                    node::max_id,
+                    ptr_uint64(2, ptr_uint64::max_id - 1),
+                    ptr_uint64(2, ptr_uint64::max_id)) // 2
+            << node(0,
+                    node::max_id,
+                    ptr_uint64(1, ptr_uint64::max_id),
+                    ptr_uint64(3, ptr_uint64::max_id)) // 1
         ;
     }
 
@@ -269,14 +312,14 @@ go_bandit([]() {
     //      / \
     //      F T
     */
-    const node n9T_8 = node(6, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n9T_7 = node(5, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n9T_6 = node(4, node::max_id,   n9T_8.uid(),       n9T_7.uid());
-    const node n9T_5 = node(3, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n9T_4 = node(3, node::max_id-1, n9T_6.uid(),       ptr_uint64(false));
-    const node n9T_3 = node(2, node::max_id,   n9T_5.uid(),       n9T_7.uid());
-    const node n9T_2 = node(2, node::max_id-1, n9T_4.uid(),       n9T_5.uid());
-    const node n9T_1 = node(1, node::max_id,   n9T_2.uid(),       n9T_3.uid());
+    const node n9T_8 = node(6, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n9T_7 = node(5, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n9T_6 = node(4, node::max_id, n9T_8.uid(), n9T_7.uid());
+    const node n9T_5 = node(3, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n9T_4 = node(3, node::max_id - 1, n9T_6.uid(), ptr_uint64(false));
+    const node n9T_3 = node(2, node::max_id, n9T_5.uid(), n9T_7.uid());
+    const node n9T_2 = node(2, node::max_id - 1, n9T_4.uid(), n9T_5.uid());
+    const node n9T_1 = node(1, node::max_id, n9T_2.uid(), n9T_3.uid());
 
     shared_levelized_file<bdd::node_type> bdd_9T;
     { // Garbage collect writer to free write-lock
@@ -301,14 +344,14 @@ go_bandit([]() {
     //            / \
     //            F T
     */
-    const node n9F_8 = node(6, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n9F_7 = node(5, node::max_id,   ptr_uint64(false), n9F_8.uid());
-    const node n9F_6 = node(4, node::max_id,   ptr_uint64(false), n9F_7.uid());
-    const node n9F_5 = node(3, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n9F_4 = node(3, node::max_id-1, n9F_6.uid(),       ptr_uint64(false));
-    const node n9F_3 = node(2, node::max_id,   n9F_5.uid(),       n9F_7.uid());
-    const node n9F_2 = node(2, node::max_id-1, n9F_4.uid(),       n9F_5.uid());
-    const node n9F_1 = node(1, node::max_id,   n9F_2.uid(),       n9F_3.uid());
+    const node n9F_8 = node(6, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n9F_7 = node(5, node::max_id, ptr_uint64(false), n9F_8.uid());
+    const node n9F_6 = node(4, node::max_id, ptr_uint64(false), n9F_7.uid());
+    const node n9F_5 = node(3, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n9F_4 = node(3, node::max_id - 1, n9F_6.uid(), ptr_uint64(false));
+    const node n9F_3 = node(2, node::max_id, n9F_5.uid(), n9F_7.uid());
+    const node n9F_2 = node(2, node::max_id - 1, n9F_4.uid(), n9F_5.uid());
+    const node n9F_1 = node(1, node::max_id, n9F_2.uid(), n9F_3.uid());
 
     shared_levelized_file<bdd::node_type> bdd_9F;
 
@@ -332,14 +375,14 @@ go_bandit([]() {
     //             / \
     //             F T
     */
-    const node n10_8 = node(4, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n10_7 = node(3, node::max_id,   n10_8.uid(),       ptr_uint64(true));
-    const node n10_6 = node(3, node::max_id-1, n10_8.uid(),       n10_8.uid());
-    const node n10_5 = node(3, node::max_id-2, ptr_uint64(true),  n10_8.uid());
-    const node n10_4 = node(2, node::max_id,   n10_6.uid(),       n10_7.uid());
-    const node n10_3 = node(2, node::max_id-1, n10_5.uid(),       n10_6.uid());
-    const node n10_2 = node(1, node::max_id,   n10_3.uid(),       n10_4.uid());
-    const node n10_1 = node(0, node::max_id,   ptr_uint64(false), n10_2.uid());
+    const node n10_8 = node(4, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n10_7 = node(3, node::max_id, n10_8.uid(), ptr_uint64(true));
+    const node n10_6 = node(3, node::max_id - 1, n10_8.uid(), n10_8.uid());
+    const node n10_5 = node(3, node::max_id - 2, ptr_uint64(true), n10_8.uid());
+    const node n10_4 = node(2, node::max_id, n10_6.uid(), n10_7.uid());
+    const node n10_3 = node(2, node::max_id - 1, n10_5.uid(), n10_6.uid());
+    const node n10_2 = node(1, node::max_id, n10_3.uid(), n10_4.uid());
+    const node n10_1 = node(0, node::max_id, ptr_uint64(false), n10_2.uid());
 
     shared_levelized_file<bdd::node_type> bdd_10;
 
@@ -361,10 +404,10 @@ go_bandit([]() {
     */
     shared_levelized_file<bdd::node_type> bdd_11;
 
-    node n11_4 = node(6, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    node n11_3 = node(6, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    node n11_2 = node(4, node::max_id,   n11_3.uid(),       n11_4.uid());
-    node n11_1 = node(2, node::max_id,   n11_3.uid(),       n11_2.uid());
+    node n11_4 = node(6, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    node n11_3 = node(6, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    node n11_2 = node(4, node::max_id, n11_3.uid(), n11_4.uid());
+    node n11_1 = node(2, node::max_id, n11_3.uid(), n11_2.uid());
 
     { // Garbage collect writer to free write-lock
       node_writer nw_11(bdd_11);
@@ -386,13 +429,13 @@ go_bandit([]() {
     //              / \
     //              F T
     */
-    const node n12a_7 = node(4, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n12a_6 = node(3, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n12a_5 = node(3, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    const node n12a_4 = node(2, node::max_id,   n12a_6.uid(),      n12a_7.uid());
-    const node n12a_3 = node(2, node::max_id-1, n12a_5.uid(),      n12a_6.uid());
-    const node n12a_2 = node(1, node::max_id,   n12a_3.uid(),      n12a_4.uid());
-    const node n12a_1 = node(0, node::max_id,   n12a_3.uid(),      n12a_2.uid());
+    const node n12a_7 = node(4, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n12a_6 = node(3, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n12a_5 = node(3, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n12a_4 = node(2, node::max_id, n12a_6.uid(), n12a_7.uid());
+    const node n12a_3 = node(2, node::max_id - 1, n12a_5.uid(), n12a_6.uid());
+    const node n12a_2 = node(1, node::max_id, n12a_3.uid(), n12a_4.uid());
+    const node n12a_1 = node(0, node::max_id, n12a_3.uid(), n12a_2.uid());
 
     shared_levelized_file<bdd::node_type> bdd_12a;
 
@@ -417,14 +460,14 @@ go_bandit([]() {
     //      / \   / \
     //      T F   F T
     */
-    const node n12b_8 = node(4, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n12b_7 = node(4, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    const node n12b_6 = node(3, node::max_id,   ptr_uint64(false), n12b_8.uid());
-    const node n12b_5 = node(3, node::max_id-1, n12b_7.uid(),      ptr_uint64(false));
-    const node n12b_4 = node(2, node::max_id,   n12b_6.uid(),      n12b_8.uid());
-    const node n12b_3 = node(2, node::max_id-1, n12b_5.uid(),      n12b_6.uid());
-    const node n12b_2 = node(1, node::max_id,   n12b_3.uid(),      n12b_4.uid());
-    const node n12b_1 = node(0, node::max_id,   n12b_3.uid(),      n12b_2.uid());
+    const node n12b_8 = node(4, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n12b_7 = node(4, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n12b_6 = node(3, node::max_id, ptr_uint64(false), n12b_8.uid());
+    const node n12b_5 = node(3, node::max_id - 1, n12b_7.uid(), ptr_uint64(false));
+    const node n12b_4 = node(2, node::max_id, n12b_6.uid(), n12b_8.uid());
+    const node n12b_3 = node(2, node::max_id - 1, n12b_5.uid(), n12b_6.uid());
+    const node n12b_2 = node(1, node::max_id, n12b_3.uid(), n12b_4.uid());
+    const node n12b_1 = node(0, node::max_id, n12b_3.uid(), n12b_2.uid());
 
     shared_levelized_file<bdd::node_type> bdd_12b;
 
@@ -470,30 +513,29 @@ go_bandit([]() {
     */
 
     // This is definitely NOT canonical... it is not worth making.
-    const node n13_16 = node(7, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n13_15 = node(6, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n13_14 = node(6, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    const node n13_13 = node(5, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n13_12 = node(5, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    const node n13_11 = node(4, node::max_id,   n13_12.uid(),      n13_13.uid());
-    const node n13_10 = node(4, node::max_id-1, n13_13.uid(),      n13_12.uid());
-    const node n13_9  = node(4, node::max_id-2, n13_14.uid(),      n13_15.uid());
-    const node n13_8  = node(4, node::max_id-3, n13_15.uid(),      n13_14.uid());
-    const node n13_7  = node(3, node::max_id,   n13_10.uid(),      n13_11.uid());
-    const node n13_6  = node(3, node::max_id-1, ptr_uint64(false), n13_16.uid());
-    const node n13_5  = node(2, node::max_id,   ptr_uint64(false), n13_16.uid());
-    const node n13_4  = node(2, node::max_id-1, n13_8.uid(),       n13_9.uid());
-    const node n13_3  = node(1, node::max_id,   n13_6.uid(),       n13_7.uid());
-    const node n13_2  = node(1, node::max_id-1, n13_4.uid(),       n13_5.uid());
-    const node n13_1  = node(0, node::max_id,   n13_2.uid(),       n13_3.uid());
+    const node n13_16 = node(7, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n13_15 = node(6, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n13_14 = node(6, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n13_13 = node(5, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n13_12 = node(5, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n13_11 = node(4, node::max_id, n13_12.uid(), n13_13.uid());
+    const node n13_10 = node(4, node::max_id - 1, n13_13.uid(), n13_12.uid());
+    const node n13_9  = node(4, node::max_id - 2, n13_14.uid(), n13_15.uid());
+    const node n13_8  = node(4, node::max_id - 3, n13_15.uid(), n13_14.uid());
+    const node n13_7  = node(3, node::max_id, n13_10.uid(), n13_11.uid());
+    const node n13_6  = node(3, node::max_id - 1, ptr_uint64(false), n13_16.uid());
+    const node n13_5  = node(2, node::max_id, ptr_uint64(false), n13_16.uid());
+    const node n13_4  = node(2, node::max_id - 1, n13_8.uid(), n13_9.uid());
+    const node n13_3  = node(1, node::max_id, n13_6.uid(), n13_7.uid());
+    const node n13_2  = node(1, node::max_id - 1, n13_4.uid(), n13_5.uid());
+    const node n13_1  = node(0, node::max_id, n13_2.uid(), n13_3.uid());
 
     shared_levelized_file<bdd::node_type> bdd_13;
 
     { // Garbage collect writer to free write-lock
       node_writer nw(bdd_13);
-      nw << n13_16 << n13_15 << n13_14 << n13_13 << n13_12 << n13_11 << n13_10
-         << n13_9 << n13_8 << n13_7 << n13_6 << n13_5 << n13_4 << n13_3 << n13_2
-         << n13_1;
+      nw << n13_16 << n13_15 << n13_14 << n13_13 << n13_12 << n13_11 << n13_10 << n13_9 << n13_8
+         << n13_7 << n13_6 << n13_5 << n13_4 << n13_3 << n13_2 << n13_1;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -516,26 +558,26 @@ go_bandit([]() {
     //              /  \ /  \
     //              T  F F  T
     */
-    const node n14_13 = node(8, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n14_12 = node(8, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    const node n14_11 = node(7, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n14_10 = node(7, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
-    const node n14_9  = node(6, node::max_id,   n14_12.uid(),      n14_13.uid());
-    const node n14_8  = node(5, node::max_id,   n14_9.uid(),       n14_11.uid());
-    const node n14_7  = node(5, node::max_id-1, n14_10.uid(),      n14_9.uid());
-    const node n14_6  = node(4, node::max_id,   n14_8.uid(),       ptr_uint64(false));
-    const node n14_5  = node(4, node::max_id-1, n14_7.uid(),       n14_8.uid());
-    const node n14_4  = node(4, node::max_id-2, ptr_uint64(false), n14_7.uid());
-    const node n14_3  = node(3, node::max_id,   n14_5.uid(),       n14_6.uid());
-    const node n14_2  = node(3, node::max_id-1, n14_4.uid(),       n14_5.uid());
-    const node n14_1  = node(2, node::max_id,   n14_2.uid(),       n14_3.uid());
+    const node n14_13 = node(8, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n14_12 = node(8, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n14_11 = node(7, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n14_10 = node(7, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n14_9  = node(6, node::max_id, n14_12.uid(), n14_13.uid());
+    const node n14_8  = node(5, node::max_id, n14_9.uid(), n14_11.uid());
+    const node n14_7  = node(5, node::max_id - 1, n14_10.uid(), n14_9.uid());
+    const node n14_6  = node(4, node::max_id, n14_8.uid(), ptr_uint64(false));
+    const node n14_5  = node(4, node::max_id - 1, n14_7.uid(), n14_8.uid());
+    const node n14_4  = node(4, node::max_id - 2, ptr_uint64(false), n14_7.uid());
+    const node n14_3  = node(3, node::max_id, n14_5.uid(), n14_6.uid());
+    const node n14_2  = node(3, node::max_id - 1, n14_4.uid(), n14_5.uid());
+    const node n14_1  = node(2, node::max_id, n14_2.uid(), n14_3.uid());
 
     shared_levelized_file<bdd::node_type> bdd_14a;
 
     { // Garbage collect writer to free write-lock
       node_writer nw(bdd_14a);
-      nw << n14_13 << n14_12 << n14_11 << n14_10 << n14_9 << n14_8 << n14_7
-         << n14_6 << n14_5 << n14_4 << n14_3 << n14_2 << n14_1;
+      nw << n14_13 << n14_12 << n14_11 << n14_10 << n14_9 << n14_8 << n14_7 << n14_6 << n14_5
+         << n14_4 << n14_3 << n14_2 << n14_1;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -547,16 +589,15 @@ go_bandit([]() {
     //                  |     / \
     //               BDD 14   F T
     */
-    const node n14b_2  = node(1, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n14b_1  = node(0, node::max_id,   n14_1.uid(),       n14b_2.uid());
+    const node n14b_2 = node(1, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n14b_1 = node(0, node::max_id, n14_1.uid(), n14b_2.uid());
 
     shared_levelized_file<bdd::node_type> bdd_14b;
 
     { // Garbage collect writer to free write-lock
       node_writer nw(bdd_14b);
-      nw << n14_13 << n14_12 << n14_11 << n14_10 << n14_9 << n14_8 << n14_7
-         << n14_6 << n14_5 << n14_4 << n14_3 << n14_2 << n14_1
-         << n14b_2 << n14b_1;
+      nw << n14_13 << n14_12 << n14_11 << n14_10 << n14_9 << n14_8 << n14_7 << n14_6 << n14_5
+         << n14_4 << n14_3 << n14_2 << n14_1 << n14b_2 << n14b_1;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -618,17 +659,21 @@ go_bandit([]() {
     /*
     //                            _______(1,a)_______
     //                           /                   \
-    //              __________(1,b)__________      (1,c)   <-- (1,c) is symmetric to (1,b) (these merge with (4,b) and (4,c))
-    //             /                         \       .         Size: 3 additional nodes (incl. (1,c))
+    //              __________(1,b)__________      (1,c)   <-- (1,c) is symmetric to (1,b) (these
+    merge with (4,b) and (4,c))
+    //             /                         \       .         Size: 3 additional nodes (incl.
+    (1,c))
     //           (2,b)                     (3,c)     .
     //           /   \                      |  \     .
     //          (b) (4,b)                (4,c) (c)
     //              /   \                /   \
-    //             (5) (6,d)           (5,d) (6)            <-- At this point we have copies of both inputs.
+    //             (5) (6,d)           (5,d) (6)            <-- At this point we have copies of both
+    inputs.
     //                 /   \           /   \                    Left subtree:  #nodes - 4
     //              (7,f) (9,g)    (8,d) (7,g)                  Right subtree: #nodes - 1
     //              /   \                /   \
-    //          (8,f)   (9,f)          (8,g) (9,g)          <-- (8,g) and (9,g) also produce the same pairs
+    //          (8,f)   (9,f)          (8,g) (9,g)          <-- (8,g) and (9,g) also produce the
+    same pairs
     //         /   |     |   \          / /   / /
     //        /    |     |    \        . .   . .
     //       /     |     |     \      . .   . .
@@ -660,73 +705,62 @@ go_bandit([]() {
     // NOTE: This is not going to be canonical (i.e. ordered) because that would
     //       become too messy.
 
-    const node n15_o  = node(13, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n15_n  = node(13, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
+    const node n15_o = node(13, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n15_n = node(13, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
 
-    const node n15_17 = node(12, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-    const node n15_16 = node(12, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
+    const node n15_17 = node(12, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n15_16 = node(12, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
 
-    const node n15_m  = node(11, node::max_id,   n15_o.uid(),       n15_n.uid());
-    const node n15_l  = node(11, node::max_id-1, n15_n.uid(),       n15_o.uid());
-    const node n15_15 = node(11, node::max_id-2, n15_17.uid(),      n15_16.uid());
-    const node n15_14 = node(11, node::max_id-3, n15_16.uid(),      n15_17.uid());
+    const node n15_m  = node(11, node::max_id, n15_o.uid(), n15_n.uid());
+    const node n15_l  = node(11, node::max_id - 1, n15_n.uid(), n15_o.uid());
+    const node n15_15 = node(11, node::max_id - 2, n15_17.uid(), n15_16.uid());
+    const node n15_14 = node(11, node::max_id - 3, n15_16.uid(), n15_17.uid());
 
-    const node n15_k  = node(10, node::max_id,   n15_m.uid(),       n15_l.uid());
-    const node n15_j  = node(10, node::max_id-1, n15_l.uid(),       n15_m.uid());
-    const node n15_13 = node(10, node::max_id-2, n15_15.uid(),      n15_14.uid());
-    const node n15_12 = node(10, node::max_id-3, n15_14.uid(),      n15_15.uid());
+    const node n15_k  = node(10, node::max_id, n15_m.uid(), n15_l.uid());
+    const node n15_j  = node(10, node::max_id - 1, n15_l.uid(), n15_m.uid());
+    const node n15_13 = node(10, node::max_id - 2, n15_15.uid(), n15_14.uid());
+    const node n15_12 = node(10, node::max_id - 3, n15_14.uid(), n15_15.uid());
 
-    const node n15_i  = node(9,  node::max_id,   n15_k.uid(),       n15_j.uid());
-    const node n15_h  = node(9,  node::max_id-1, n15_j.uid(),       n15_k.uid());
-    const node n15_11 = node(9,  node::max_id-2, n15_13.uid(),      n15_12.uid());
-    const node n15_10 = node(9,  node::max_id-3, n15_12.uid(),      n15_13.uid());
+    const node n15_i  = node(9, node::max_id, n15_k.uid(), n15_j.uid());
+    const node n15_h  = node(9, node::max_id - 1, n15_j.uid(), n15_k.uid());
+    const node n15_11 = node(9, node::max_id - 2, n15_13.uid(), n15_12.uid());
+    const node n15_10 = node(9, node::max_id - 3, n15_12.uid(), n15_13.uid());
 
-    const node n15_g  = node(8,  node::max_id,   n15_i.uid(),       n15_h.uid());
-    const node n15_f  = node(8,  node::max_id-1, n15_h.uid(),       n15_i.uid());
-    const node n15_9  = node(8,  node::max_id-2, n15_11.uid(),      n15_10.uid());
-    const node n15_8  = node(8,  node::max_id-3, n15_10.uid(),      n15_11.uid());
+    const node n15_g = node(8, node::max_id, n15_i.uid(), n15_h.uid());
+    const node n15_f = node(8, node::max_id - 1, n15_h.uid(), n15_i.uid());
+    const node n15_9 = node(8, node::max_id - 2, n15_11.uid(), n15_10.uid());
+    const node n15_8 = node(8, node::max_id - 3, n15_10.uid(), n15_11.uid());
 
-    const node n15_7  = node(7,  node::max_id,   n15_8.uid(),       n15_9.uid());
+    const node n15_7 = node(7, node::max_id, n15_8.uid(), n15_9.uid());
 
-    const node n15_d  = node(6,  node::max_id,   n15_f.uid(),       n15_g.uid());
-    const node n15_6  = node(6,  node::max_id-1, n15_7.uid(),       n15_9.uid());
-    const node n15_5  = node(6,  node::max_id-2, n15_8.uid(),       n15_7.uid());
+    const node n15_d = node(6, node::max_id, n15_f.uid(), n15_g.uid());
+    const node n15_6 = node(6, node::max_id - 1, n15_7.uid(), n15_9.uid());
+    const node n15_5 = node(6, node::max_id - 2, n15_8.uid(), n15_7.uid());
 
-    const node n15_c  = node(5,  node::max_id,   n15_d.uid(),       ptr_uint64(false));
-    const node n15_b  = node(5,  node::max_id-1, ptr_uint64(false), n15_d.uid());
-    const node n15_4  = node(5,  node::max_id-2, n15_5.uid(),       n15_6.uid());
+    const node n15_c = node(5, node::max_id, n15_d.uid(), ptr_uint64(false));
+    const node n15_b = node(5, node::max_id - 1, ptr_uint64(false), n15_d.uid());
+    const node n15_4 = node(5, node::max_id - 2, n15_5.uid(), n15_6.uid());
 
-    const node n15_3  = node(4,  node::max_id,   n15_4.uid(),       ptr_uint64(false));
-    const node n15_2  = node(4,  node::max_id-1, ptr_uint64(false), n15_4.uid());
+    const node n15_3 = node(4, node::max_id, n15_4.uid(), ptr_uint64(false));
+    const node n15_2 = node(4, node::max_id - 1, ptr_uint64(false), n15_4.uid());
 
-    const node n15_1  = node(3,  node::max_id,   n15_2.uid(),       n15_3.uid());
+    const node n15_1 = node(3, node::max_id, n15_2.uid(), n15_3.uid());
 
-    const node n15_a  = node(2,  node::max_id,   n15_b.uid(),       n15_c.uid());
+    const node n15_a = node(2, node::max_id, n15_b.uid(), n15_c.uid());
 
-    const node n15_r3 = node(1,  node::max_id,   n15_5.uid(),       n15_d.uid());
-    const node n15_r2 = node(1,  node::max_id-1, n15_1.uid(),       n15_a.uid());
+    const node n15_r3 = node(1, node::max_id, n15_5.uid(), n15_d.uid());
+    const node n15_r2 = node(1, node::max_id - 1, n15_1.uid(), n15_a.uid());
 
-    const node n15_r1 = node(0,  node::max_id,   n15_r2.uid(),      n15_r3.uid());
+    const node n15_r1 = node(0, node::max_id, n15_r2.uid(), n15_r3.uid());
 
     shared_levelized_file<bdd::node_type> bdd_15;
 
     { // Garbage collect writer to free write-lock
       node_writer nw(bdd_15);
-      nw << n15_o  << n15_n
-         << n15_17 << n15_16
-         << n15_m  << n15_l  << n15_15 << n15_14
-         << n15_k  << n15_j  << n15_13 << n15_12
-         << n15_i  << n15_h  << n15_11 << n15_10
-         << n15_g  << n15_f  << n15_9  << n15_8
-         << n15_7
-         << n15_d  << n15_6  << n15_5
-         << n15_c  << n15_b  << n15_4
-         << n15_3  << n15_2
-         << n15_1
-         << n15_a
-         << n15_r3 << n15_r2
-         << n15_r1
-        ;
+      nw << n15_o << n15_n << n15_17 << n15_16 << n15_m << n15_l << n15_15 << n15_14 << n15_k
+         << n15_j << n15_13 << n15_12 << n15_i << n15_h << n15_11 << n15_10 << n15_g << n15_f
+         << n15_9 << n15_8 << n15_7 << n15_d << n15_6 << n15_5 << n15_c << n15_b << n15_4 << n15_3
+         << n15_2 << n15_1 << n15_a << n15_r3 << n15_r2 << n15_r1;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -756,27 +790,25 @@ go_bandit([]() {
     shared_levelized_file<bdd::node_type> bdd_16;
 
     {
-      const node nc   = node(6, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-      const node nb   = node(5, node::max_id,   ptr_uint64(false), ptr_uint64(true));
-      const node na   = node(5, node::max_id-1, ptr_uint64(true),  ptr_uint64(false));
+      const node nc = node(6, node::max_id, ptr_uint64(false), ptr_uint64(true));
+      const node nb = node(5, node::max_id, ptr_uint64(false), ptr_uint64(true));
+      const node na = node(5, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
 
-      const node n9_3 = node(4, node::max_id,   na.uid(),          nb.uid());
-      const node n9_2 = node(4, node::max_id-1, na.uid(),          nb.uid());
-      const node n9_1 = node(4, node::max_id-2, na.uid(),          nb.uid());
+      const node n9_3 = node(4, node::max_id, na.uid(), nb.uid());
+      const node n9_2 = node(4, node::max_id - 1, na.uid(), nb.uid());
+      const node n9_1 = node(4, node::max_id - 2, na.uid(), nb.uid());
 
-      const node n8   = node(3, node::max_id,   n9_2.uid(),        n9_3.uid());
-      const node n7   = node(3, node::max_id-1, n9_1.uid(),        n9_3.uid());
-      const node n6   = node(3, node::max_id-2, n9_2.uid(),        n9_1.uid());
-      const node n5   = node(3, node::max_id-3, n9_1.uid(),        n9_2.uid());
-      const node n4   = node(2, node::max_id,   n7.uid(),          n8.uid());
-      const node n3   = node(2, node::max_id-1, n5.uid(),          n6.uid());
-      const node n2   = node(1, node::max_id,   n3.uid(),          n4.uid());
-      const node n1   = node(0, node::max_id,   n2.uid(),          nc.uid());
+      const node n8 = node(3, node::max_id, n9_2.uid(), n9_3.uid());
+      const node n7 = node(3, node::max_id - 1, n9_1.uid(), n9_3.uid());
+      const node n6 = node(3, node::max_id - 2, n9_2.uid(), n9_1.uid());
+      const node n5 = node(3, node::max_id - 3, n9_1.uid(), n9_2.uid());
+      const node n4 = node(2, node::max_id, n7.uid(), n8.uid());
+      const node n3 = node(2, node::max_id - 1, n5.uid(), n6.uid());
+      const node n2 = node(1, node::max_id, n3.uid(), n4.uid());
+      const node n1 = node(0, node::max_id, n2.uid(), nc.uid());
 
       node_writer nw(bdd_16);
-      nw << nc << nb << na
-         << n9_3 << n9_2 << n9_1
-         << n8 << n7 << n6 << n5 << n4 << n3 << n2 << n1;
+      nw << nc << nb << na << n9_3 << n9_2 << n9_1 << n8 << n7 << n6 << n5 << n4 << n3 << n2 << n1;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -806,13 +838,21 @@ go_bandit([]() {
 
         AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->levels(), Is().EqualTo(0u));
 
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_False], Is().EqualTo(0u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::All], Is().EqualTo(1u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal],
+                   Is().EqualTo(0u));
+        AssertThat(
+          out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_False],
+          Is().EqualTo(0u));
+        AssertThat(
+          out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_True],
+          Is().EqualTo(1u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::All],
+                   Is().EqualTo(1u));
 
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[false],
+                   Is().EqualTo(0u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[true],
+                   Is().EqualTo(1u));
       });
 
       it("should shortcut quantification of root into T terminal [x2]", [&]() {
@@ -826,13 +866,21 @@ go_bandit([]() {
 
         AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->levels(), Is().EqualTo(0u));
 
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal], Is().EqualTo(0u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_False], Is().EqualTo(0u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::All], Is().EqualTo(1u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal],
+                   Is().EqualTo(0u));
+        AssertThat(
+          out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_False],
+          Is().EqualTo(0u));
+        AssertThat(
+          out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::Internal_True],
+          Is().EqualTo(1u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->max_1level_cut[cut::All],
+                   Is().EqualTo(1u));
 
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[false],
+                   Is().EqualTo(0u));
+        AssertThat(out.get<shared_levelized_file<bdd::node_type>>()->number_of_terminals[true],
+                   Is().EqualTo(1u));
       });
 
       it("should shortcut quantification on non-existent label in input [BDD 1]", [&]() {
@@ -850,25 +898,28 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(0u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(0u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(0u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(2u));
       });
 
       it("should quantify root without terminal arcs [BDD 2]", [&]() {
@@ -878,46 +929,49 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (4,5)
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (5,_)
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(3u));
       });
 
       it("should quantify root with F terminal [BDD 5]", [&]() {
@@ -927,46 +981,49 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high()
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high()
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to its own leaf
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(2u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(2u));
 
         // TODO: meta variables...
       });
@@ -978,46 +1035,49 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,   ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (4,5)
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,   ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // (5,_)
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(3u));
       });
 
       it("should output terminal arcs in order, despite the order of resolvement [BDD 2]", [&]() {
@@ -1027,46 +1087,49 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(1, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,   ptr_uint64(1,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(1, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high()
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high()
-                   Is().EqualTo(arc { ptr_uint64(1,1), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 1), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to its own leaf
-                   Is().EqualTo(arc { ptr_uint64(1,1), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 1), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(3u));
       });
 
       it("should keep nodes as is when skipping quantified level [BDD 3]", [&]() {
@@ -1078,46 +1141,49 @@ go_bandit([]() {
         // request without forwarding n3 through the secondary priority queue
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // n3
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // n3
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.high()
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(3u));
       });
 
       it("should output terminal arcs in order, despite the order of resolvement [BDD 3]", [&]() {
@@ -1129,38 +1195,41 @@ go_bandit([]() {
         // request without forwarding n3 through the secondary priority queue
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(1, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.high()
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(1u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(0u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(3u));
       });
 
       it("should resolve terminal-terminal requests in [BDD 5]", [&]() {
@@ -1172,38 +1241,41 @@ go_bandit([]() {
         // request without forwarding n3 through the secondary priority queue
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 3.high()
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(1u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(2u));
       });
 
       it("can shortcut/prune irrelevant subtrees [OR-chain]", [&]() {
@@ -1225,37 +1297,40 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(1,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(1, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to quantification of x2
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(1u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(0u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(3u));
       });
 
       it("can forward information across a level [BDD 6]", [&]() {
@@ -1265,62 +1340,65 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(3, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (8,F)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(3, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 0), false, ptr_uint64(true) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (8,F)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 1), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 1), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(3u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(3u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(5u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(5u));
       });
 
       it("can forward multiple arcs to the same node across a level [BDD 7]", [&]() {
@@ -1330,144 +1408,155 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,5)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,5)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,5)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(0u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(0u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(2u));
       });
 
-      it("should collapse tuple requests of the same node back into request on a single node [BDD 8a]", [&]() {
-        __bdd out = bdd_exists(bdd_8a, 1);
+      it("should collapse tuple requests of the same node back into request on a single node [BDD "
+         "8a]",
+         [&]() {
+           __bdd out = bdd_exists(bdd_8a, 1);
 
-        arc_test_stream arcs(out);
+           arc_test_stream arcs(out);
 
-        AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
-        AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,0) }));
-        AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(3, 0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True());
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(3, 0) }));
 
-        AssertThat(arcs.can_pull_internal(), Is().False());
+           AssertThat(arcs.can_pull_internal(), Is().False());
 
-        AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
+           AssertThat(arcs.pull_terminal(),                   // true due to 3.low()
+                      Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
 
-        AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
-        AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
-        AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
+           AssertThat(arcs.pull_terminal(),
+                      Is().EqualTo(arc{ ptr_uint64(3, 0), false, ptr_uint64(false) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True());
+           AssertThat(arcs.pull_terminal(),
+                      Is().EqualTo(arc{ ptr_uint64(3, 0), true, ptr_uint64(true) }));
 
+           AssertThat(arcs.can_pull_terminal(), Is().False());
 
-        AssertThat(arcs.can_pull_terminal(), Is().False());
+           level_info_test_stream levels(out);
 
-        level_info_test_stream levels(out);
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,1u)));
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(3u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(3u,1u)));
+           AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(levels.can_pull(), Is().False());
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                      Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                      Is().EqualTo(1u));
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                      Is().EqualTo(2u));
+         });
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(2u));
-      });
+      it("should collapse tuple requests of the same node back into request on a single node [BDD "
+         "8b]",
+         [&]() {
+           __bdd out = bdd_exists(bdd_8b, 1);
 
-      it("should collapse tuple requests of the same node back into request on a single node [BDD 8b]", [&]() {
-        __bdd out = bdd_exists(bdd_8b, 1);
+           arc_test_stream arcs(out);
 
-        arc_test_stream arcs(out);
+           AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
-        AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(3, 0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True());
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(3, 0) }));
 
-        AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,0) }));
-        AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(3,0) }));
+           AssertThat(arcs.can_pull_internal(), Is().False());
 
-        AssertThat(arcs.can_pull_internal(), Is().False());
+           AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
+           AssertThat(arcs.pull_terminal(),                   // true due to 3.low()
+                      Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(true) }));
 
-        AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_terminal(), // true due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(true) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
+           AssertThat(arcs.pull_terminal(),
+                      Is().EqualTo(arc{ ptr_uint64(3, 0), false, ptr_uint64(false) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True());
+           AssertThat(arcs.pull_terminal(),
+                      Is().EqualTo(arc{ ptr_uint64(3, 0), true, ptr_uint64(true) }));
 
-        AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
-        AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
-        AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
+           AssertThat(arcs.can_pull_terminal(), Is().False());
 
+           level_info_test_stream levels(out);
 
-        AssertThat(arcs.can_pull_terminal(), Is().False());
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
-        level_info_test_stream levels(out);
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(3u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,1u)));
+           AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(3u,1u)));
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                      Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(levels.can_pull(), Is().False());
-
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
-
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(2u));
-      });
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                      Is().EqualTo(1u));
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                      Is().EqualTo(2u));
+         });
     });
 
     describe("bdd_exists(const bdd&, const predicate<bdd::label_type>&)", [&]() {
       it("returns input on always-false predicate BDD 1 [const &]", [&]() {
-        bdd in = bdd_1;
+        bdd in    = bdd_1;
         __bdd out = bdd_exists(in, [](const bdd::label_type) -> bool { return false; });
         AssertThat(out.get<shared_levelized_file<bdd::node_type>>(), Is().EqualTo(bdd_1));
       });
@@ -1481,31 +1570,28 @@ go_bandit([]() {
         const exec_policy ep = exec_policy::quantify::Singleton;
 
         it("quantifies odd variables in BDD 4 [&&]", [&]() {
-          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type x) -> bool {
-            return x % 2;
-          });
+          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type x) -> bool { return x % 2; });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(2, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(0, node::max_id, ptr_uint64(2, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -1513,31 +1599,29 @@ go_bandit([]() {
         });
 
         it("quantifies 1, 2 in BDD 4 [&&]", [&]() {
-          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type x) -> bool {
-            return x == 1 || x == 2;
-          });
+          bdd out =
+            bdd_exists(ep, bdd_4, [](const bdd::label_type x) -> bool { return x == 1 || x == 2; });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(3, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(0, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -1546,31 +1630,29 @@ go_bandit([]() {
 
         it("quantifies even variables in BDD 4 [const &]", [&]() {
           const bdd in = bdd_4;
-          const bdd out = bdd_exists(ep, in, [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          const bdd out =
+            bdd_exists(ep, in, [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(3, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(1, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -1578,9 +1660,7 @@ go_bandit([]() {
         });
 
         it("quantifies odd variables in BDD 1 [&&]", [&]() {
-          bdd out = bdd_exists(ep, bdd_1, [](const bdd::label_type x) -> bool {
-            return x % 2;
-          });
+          bdd out = bdd_exists(ep, bdd_1, [](const bdd::label_type x) -> bool { return x % 2; });
 
           node_test_stream out_nodes(out);
 
@@ -1620,9 +1700,7 @@ go_bandit([]() {
         });
 
         it("quantifies with always-true predicate in BDD 4 [&&]", [&]() {
-          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type) -> bool {
-            return true;
-          });
+          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type) -> bool { return true; });
 
           node_test_stream out_nodes(out);
 
@@ -1668,7 +1746,6 @@ go_bandit([]() {
           // - First check for at least one variable satisfying the predicate.
           AssertThat(call_history.at(0), Is().EqualTo(3u));
 
-
           // - First top-down sweep (root call)
           AssertThat(call_history.at(1), Is().EqualTo(0u));
 
@@ -1681,7 +1758,7 @@ go_bandit([]() {
         it("finishes during initial transposition of even variables in BDD 4 [const &]", [&]() {
           std::vector<bdd::label_type> call_history;
 
-          const bdd in = bdd_4;
+          const bdd in  = bdd_4;
           const bdd out = bdd_exists(ep, in, [&call_history](const bdd::label_type x) -> bool {
             call_history.push_back(x);
             return !(x % 2);
@@ -1690,24 +1767,23 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(3, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(1, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -1734,54 +1810,55 @@ go_bandit([]() {
           AssertThat(call_history.at(6), Is().EqualTo(3u));
         });
 
-        it("collapses during repeated transposition with variables 1 2 variables in BDD 11a [&&]", [&]() {
-          std::vector<bdd::label_type> call_history;
-          bdd out = bdd_exists(ep, bdd_12a, [&call_history](const bdd::label_type x) -> bool {
-            call_history.push_back(x);
-            return 0 < x && x < 3;
-          });
+        it("collapses during repeated transposition with variables 1 2 variables in BDD 11a [&&]",
+           [&]() {
+             std::vector<bdd::label_type> call_history;
+             bdd out = bdd_exists(ep, bdd_12a, [&call_history](const bdd::label_type x) -> bool {
+               call_history.push_back(x);
+               return 0 < x && x < 3;
+             });
 
-          node_test_stream out_nodes(out);
+             node_test_stream out_nodes(out);
 
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-          AssertThat(out_nodes.can_pull(), Is().False());
+             AssertThat(out_nodes.can_pull(), Is().True());
+             AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+             AssertThat(out_nodes.can_pull(), Is().False());
 
-          level_info_test_stream out_meta(out);
-          AssertThat(out_meta.can_pull(), Is().False());
+             level_info_test_stream out_meta(out);
+             AssertThat(out_meta.can_pull(), Is().False());
 
-          // TODO: meta variables...
+             // TODO: meta variables...
 
-          // Check call history
-          //
-          // NOTE: Test failure does NOT indicate a bug, but only indicates a
-          //       change. Please verify that this change makes sense and is as
-          //       intended.
-          AssertThat(call_history.size(), Is().EqualTo(13u));
+             // Check call history
+             //
+             // NOTE: Test failure does NOT indicate a bug, but only indicates a
+             //       change. Please verify that this change makes sense and is as
+             //       intended.
+             AssertThat(call_history.size(), Is().EqualTo(13u));
 
-          // - First check for at least one variable satisfying the predicate.
-          AssertThat(call_history.at(0), Is().EqualTo(4u));
-          AssertThat(call_history.at(1), Is().EqualTo(3u));
-          AssertThat(call_history.at(2), Is().EqualTo(2u));
+             // - First check for at least one variable satisfying the predicate.
+             AssertThat(call_history.at(0), Is().EqualTo(4u));
+             AssertThat(call_history.at(1), Is().EqualTo(3u));
+             AssertThat(call_history.at(2), Is().EqualTo(2u));
 
-          // - First top-down sweep (root call)
-          AssertThat(call_history.at(3), Is().EqualTo(0u));
+             // - First top-down sweep (root call)
+             AssertThat(call_history.at(3), Is().EqualTo(0u));
 
-          // - First top-down sweep
-          AssertThat(call_history.at(4),  Is().EqualTo(0u));
-          AssertThat(call_history.at(5),  Is().EqualTo(1u));
-          AssertThat(call_history.at(6), Is().EqualTo(2u));
-          AssertThat(call_history.at(7), Is().EqualTo(3u));
-          AssertThat(call_history.at(8), Is().EqualTo(4u));
+             // - First top-down sweep
+             AssertThat(call_history.at(4), Is().EqualTo(0u));
+             AssertThat(call_history.at(5), Is().EqualTo(1u));
+             AssertThat(call_history.at(6), Is().EqualTo(2u));
+             AssertThat(call_history.at(7), Is().EqualTo(3u));
+             AssertThat(call_history.at(8), Is().EqualTo(4u));
 
-          // - Second top-down sweep (root call)
-          AssertThat(call_history.at(9),  Is().EqualTo(0u));
+             // - Second top-down sweep (root call)
+             AssertThat(call_history.at(9), Is().EqualTo(0u));
 
-          // - Second top-down sweep
-          AssertThat(call_history.at(10), Is().EqualTo(0u));
-          AssertThat(call_history.at(11), Is().EqualTo(2u));
-          AssertThat(call_history.at(12), Is().EqualTo(3u));
-        });
+             // - Second top-down sweep
+             AssertThat(call_history.at(10), Is().EqualTo(0u));
+             AssertThat(call_history.at(11), Is().EqualTo(2u));
+             AssertThat(call_history.at(12), Is().EqualTo(3u));
+           });
 
         it("finishes during repeated transposition with variables 1 and 2 in BDD 11b [&&]", [&]() {
           std::vector<bdd::label_type> call_history;
@@ -1812,42 +1889,47 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(4, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       4, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,6,8)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              3, node::max_id, node::pointer_type(true), node::pointer_type(4, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,6)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id-1,
-                                                         node::pointer_type(4, node::max_id-1),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id - 1,
+                                       node::pointer_type(4, node::max_id - 1),
+                                       node::pointer_type(4, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         node::pointer_type(3, node::max_id-1),
-                                                         node::pointer_type(3, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0,
+                                       node::max_id,
+                                       node::pointer_type(3, node::max_id - 1),
+                                       node::pointer_type(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -1876,7 +1958,7 @@ go_bandit([]() {
           AssertThat(call_history.at(8), Is().EqualTo(4u));
 
           // - Second top-down sweep (root call)
-          AssertThat(call_history.at(9),  Is().EqualTo(0u));
+          AssertThat(call_history.at(9), Is().EqualTo(0u));
 
           // - Second top-down sweep
           AssertThat(call_history.at(10), Is().EqualTo(0u));
@@ -1895,116 +1977,143 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(7, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(6, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-1,
-                                                         node::pointer_type(7, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              6, node::max_id - 1, node::pointer_type(7, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-2,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       6, node::max_id - 2, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(7, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              6, node::max_id - 3, node::pointer_type(true), node::pointer_type(7, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,15)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         node::pointer_type(6, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              5, node::max_id, node::pointer_type(6, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,15,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-1,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 1,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,14,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-2,
-                                                         node::pointer_type(6, node::max_id-3),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 2,
+                                       node::pointer_type(6, node::max_id - 3),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,15,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(6, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 3,
+                                       node::pointer_type(true),
+                                       node::pointer_type(6, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,14)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-4,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(6, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 4,
+                                       node::pointer_type(true),
+                                       node::pointer_type(6, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,14,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-5,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(6, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 5,
+                                       node::pointer_type(true),
+                                       node::pointer_type(6, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,11,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(5, node::max_id-5),
-                                                         node::pointer_type(5, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id,
+                                       node::pointer_type(5, node::max_id - 5),
+                                       node::pointer_type(5, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,11,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(5, node::max_id-3),
-                                                         node::pointer_type(5, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 1,
+                                       node::pointer_type(5, node::max_id - 3),
+                                       node::pointer_type(5, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,10,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-2,
-                                                         node::pointer_type(5, node::max_id-2),
-                                                         node::pointer_type(5, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 2,
+                                       node::pointer_type(5, node::max_id - 2),
+                                       node::pointer_type(5, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,10)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-3,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(5, node::max_id-4))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 3,
+                                       node::pointer_type(5, node::max_id),
+                                       node::pointer_type(5, node::max_id - 4))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,7,9,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id-2),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id,
+                                       node::pointer_type(4, node::max_id - 2),
+                                       node::pointer_type(4, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,7,8)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id-1,
-                                                         node::pointer_type(4, node::max_id-3),
-                                                         node::pointer_type(4, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id - 1,
+                                       node::pointer_type(4, node::max_id - 3),
+                                       node::pointer_type(4, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4,5,6,7)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         node::pointer_type(3, node::max_id-1),
-                                                         node::pointer_type(3, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2,
+                                       node::max_id,
+                                       node::pointer_type(3, node::max_id - 1),
+                                       node::pointer_type(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,6u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 6u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2030,8 +2139,8 @@ go_bandit([]() {
           AssertThat(call_history.at(7), Is().EqualTo(0u));
 
           // - First top-down sweep
-          AssertThat(call_history.at(8),  Is().EqualTo(0u));
-          AssertThat(call_history.at(9),  Is().EqualTo(1u));
+          AssertThat(call_history.at(8), Is().EqualTo(0u));
+          AssertThat(call_history.at(9), Is().EqualTo(1u));
           AssertThat(call_history.at(10), Is().EqualTo(2u));
           AssertThat(call_history.at(11), Is().EqualTo(3u));
           AssertThat(call_history.at(12), Is().EqualTo(4u));
@@ -2062,157 +2171,210 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(13, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       13, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(13, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       13, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (17,o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id,
-                                                         node::pointer_type(13, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              12, node::max_id, node::pointer_type(13, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (17,n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-1,
-                                                         node::pointer_type(13, node::max_id-1),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 1,
+                                       node::pointer_type(13, node::max_id - 1),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16,o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-2,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(13, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 2,
+                                       node::pointer_type(true),
+                                       node::pointer_type(13, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16,n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(13, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 3,
+                                       node::pointer_type(true),
+                                       node::pointer_type(13, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,l)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id,
-                                                         node::pointer_type(12, node::max_id-3),
-                                                         node::pointer_type(12, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id,
+                                       node::pointer_type(12, node::max_id - 3),
+                                       node::pointer_type(12, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,m)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-1,
-                                                         node::pointer_type(12, node::max_id-2),
-                                                         node::pointer_type(12, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 1,
+                                       node::pointer_type(12, node::max_id - 2),
+                                       node::pointer_type(12, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,l)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-2,
-                                                         node::pointer_type(12, node::max_id-1),
-                                                         node::pointer_type(12, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 2,
+                                       node::pointer_type(12, node::max_id - 1),
+                                       node::pointer_type(12, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,m)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-3,
-                                                         node::pointer_type(12, node::max_id),
-                                                         node::pointer_type(12, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 3,
+                                       node::pointer_type(12, node::max_id),
+                                       node::pointer_type(12, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,k)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id,
-                                                         node::pointer_type(11, node::max_id-3),
-                                                         node::pointer_type(11, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id,
+                                       node::pointer_type(11, node::max_id - 3),
+                                       node::pointer_type(11, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,j)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-1,
-                                                         node::pointer_type(11, node::max_id-2),
-                                                         node::pointer_type(11, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 1,
+                                       node::pointer_type(11, node::max_id - 2),
+                                       node::pointer_type(11, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,k)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-2,
-                                                         node::pointer_type(11, node::max_id-1),
-                                                         node::pointer_type(11, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 2,
+                                       node::pointer_type(11, node::max_id - 1),
+                                       node::pointer_type(11, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,j)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-3,
-                                                         node::pointer_type(11, node::max_id),
-                                                         node::pointer_type(11, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 3,
+                                       node::pointer_type(11, node::max_id),
+                                       node::pointer_type(11, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (10,h)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id,
-                                                         node::pointer_type(10, node::max_id-3),
-                                                         node::pointer_type(10, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id,
+                                       node::pointer_type(10, node::max_id - 3),
+                                       node::pointer_type(10, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (10,i)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-1,
-                                                         node::pointer_type(10, node::max_id-2),
-                                                         node::pointer_type(10, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 1,
+                                       node::pointer_type(10, node::max_id - 2),
+                                       node::pointer_type(10, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (11,h)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-2,
-                                                         node::pointer_type(10, node::max_id-1),
-                                                         node::pointer_type(10, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 2,
+                                       node::pointer_type(10, node::max_id - 1),
+                                       node::pointer_type(10, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (11,i)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-3,
-                                                         node::pointer_type(10, node::max_id),
-                                                         node::pointer_type(10, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 3,
+                                       node::pointer_type(10, node::max_id),
+                                       node::pointer_type(10, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id,
-                                                         node::pointer_type(9, node::max_id-3),
-                                                         node::pointer_type(9, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id,
+                                       node::pointer_type(9, node::max_id - 3),
+                                       node::pointer_type(9, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id-1,
-                                                         node::pointer_type(9, node::max_id-1),
-                                                         node::pointer_type(9, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id - 1,
+                                       node::pointer_type(9, node::max_id - 1),
+                                       node::pointer_type(9, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,f)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id-2,
-                                                         node::pointer_type(9, node::max_id),
-                                                         node::pointer_type(9, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id - 2,
+                                       node::pointer_type(9, node::max_id),
+                                       node::pointer_type(9, node::max_id - 3))));
 
           // NOTE: (9,f) because the pair (7,f) is is merged with (8) which
           //       prunes that entire subtree away.
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,8,f)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id,
-                                                         node::pointer_type(8, node::max_id-2),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              7, node::max_id, node::pointer_type(8, node::max_id - 2), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,g,9)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(8, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              7, node::max_id - 1, node::pointer_type(true), node::pointer_type(8, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-2,
-                                                         node::pointer_type(8, node::max_id-1),
-                                                         node::pointer_type(8, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(7,
+                                       node::max_id - 2,
+                                       node::pointer_type(8, node::max_id - 1),
+                                       node::pointer_type(8, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id,
-                                                         node::pointer_type(7, node::max_id),
-                                                         node::pointer_type(7, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(6,
+                                       node::max_id,
+                                       node::pointer_type(7, node::max_id),
+                                       node::pointer_type(7, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-1,
-                                                         node::pointer_type(8, node::max_id-2),
-                                                         node::pointer_type(7, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(6,
+                                       node::max_id - 1,
+                                       node::pointer_type(8, node::max_id - 2),
+                                       node::pointer_type(7, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(6, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(6, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(6, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id,
+                                       node::pointer_type(5, node::max_id),
+                                       node::pointer_type(6, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(5, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 1,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(5, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id-1),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id,
+                                       node::pointer_type(4, node::max_id - 1),
+                                       node::pointer_type(4, node::max_id))));
 
           // NOTE: The root (1,a,5,d) has x2 suppressed as the choice at (a)
           //       only is relevant for (b) and (c), not for (d).
@@ -2222,37 +2384,37 @@ go_bandit([]() {
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(13u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(13u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(12u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(12u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(11u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(11u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(10u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(10u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(9u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(9u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(8u,3u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(8u, 3u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u,3u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u, 3u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2266,16 +2428,16 @@ go_bandit([]() {
           AssertThat(call_history.size(), Is().EqualTo(42u));
 
           // - First check for at least one variable satisfying the predicate.
-          AssertThat(call_history.at(0),  Is().EqualTo(13u));
-          AssertThat(call_history.at(1),  Is().EqualTo(12u));
-          AssertThat(call_history.at(2),  Is().EqualTo(11u));
-          AssertThat(call_history.at(3),  Is().EqualTo(10u));
-          AssertThat(call_history.at(4),  Is().EqualTo(9u));
-          AssertThat(call_history.at(5),  Is().EqualTo(8u));
-          AssertThat(call_history.at(6),  Is().EqualTo(7u));
-          AssertThat(call_history.at(7),  Is().EqualTo(6u));
-          AssertThat(call_history.at(8),  Is().EqualTo(5u));
-          AssertThat(call_history.at(9),  Is().EqualTo(4u));
+          AssertThat(call_history.at(0), Is().EqualTo(13u));
+          AssertThat(call_history.at(1), Is().EqualTo(12u));
+          AssertThat(call_history.at(2), Is().EqualTo(11u));
+          AssertThat(call_history.at(3), Is().EqualTo(10u));
+          AssertThat(call_history.at(4), Is().EqualTo(9u));
+          AssertThat(call_history.at(5), Is().EqualTo(8u));
+          AssertThat(call_history.at(6), Is().EqualTo(7u));
+          AssertThat(call_history.at(7), Is().EqualTo(6u));
+          AssertThat(call_history.at(8), Is().EqualTo(5u));
+          AssertThat(call_history.at(9), Is().EqualTo(4u));
           AssertThat(call_history.at(10), Is().EqualTo(3u));
           AssertThat(call_history.at(11), Is().EqualTo(2u));
           AssertThat(call_history.at(12), Is().EqualTo(1u));
@@ -2333,24 +2495,23 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(2, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(0, node::max_id, ptr_uint64(2, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2374,9 +2535,7 @@ go_bandit([]() {
         });
 
         it("quantifies odd variables in BDD 1", [&]() {
-          bdd out = bdd_exists(ep, bdd_1, [](const bdd::label_type x) -> bool {
-            return x % 2;
-          });
+          bdd out = bdd_exists(ep, bdd_1, [](const bdd::label_type x) -> bool { return x % 2; });
 
           node_test_stream out_nodes(out);
 
@@ -2393,9 +2552,7 @@ go_bandit([]() {
         });
 
         it("quantifies with always-true predicate in BDD 4 [&&]", [&]() {
-          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type) -> bool {
-            return true;
-          });
+          bdd out = bdd_exists(ep, bdd_4, [](const bdd::label_type) -> bool { return true; });
 
           node_test_stream out_nodes(out);
 
@@ -2410,39 +2567,37 @@ go_bandit([]() {
         });
 
         it("bails out on a level that only shortcuts", [&]() {
-          bdd out = bdd_exists(ep, bdd_9T, [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          bdd out =
+            bdd_exists(ep, bdd_9T, [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(3, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(1, node::max_id, ptr_uint64(true), ptr_uint64(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2450,31 +2605,29 @@ go_bandit([]() {
         });
 
         it("bails out on a level that only is irrelevant", [&]() {
-          bdd out = bdd_exists(ep, bdd_9F, [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          bdd out =
+            bdd_exists(ep, bdd_9F, [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2511,16 +2664,15 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2559,9 +2711,7 @@ go_bandit([]() {
           //        |
           //        T
           */
-          bdd out = bdd_exists(ep, bdd_6, [](const bdd::label_type x) -> bool {
-            return (x % 2);
-          });
+          bdd out = bdd_exists(ep, bdd_6, [](const bdd::label_type x) -> bool { return (x % 2); });
 
           node_test_stream out_nodes(out);
 
@@ -2583,157 +2733,210 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(13, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       13, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(13, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       13, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (17,o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id,
-                                                         node::pointer_type(13, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              12, node::max_id, node::pointer_type(13, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (17,n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-1,
-                                                         node::pointer_type(13, node::max_id-1),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 1,
+                                       node::pointer_type(13, node::max_id - 1),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16,o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-2,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(13, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 2,
+                                       node::pointer_type(true),
+                                       node::pointer_type(13, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16,n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(13, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 3,
+                                       node::pointer_type(true),
+                                       node::pointer_type(13, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,l)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id,
-                                                         node::pointer_type(12, node::max_id-3),
-                                                         node::pointer_type(12, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id,
+                                       node::pointer_type(12, node::max_id - 3),
+                                       node::pointer_type(12, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,m)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-1,
-                                                         node::pointer_type(12, node::max_id-2),
-                                                         node::pointer_type(12, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 1,
+                                       node::pointer_type(12, node::max_id - 2),
+                                       node::pointer_type(12, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,l)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-2,
-                                                         node::pointer_type(12, node::max_id-1),
-                                                         node::pointer_type(12, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 2,
+                                       node::pointer_type(12, node::max_id - 1),
+                                       node::pointer_type(12, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,m)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-3,
-                                                         node::pointer_type(12, node::max_id),
-                                                         node::pointer_type(12, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 3,
+                                       node::pointer_type(12, node::max_id),
+                                       node::pointer_type(12, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,k)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id,
-                                                         node::pointer_type(11, node::max_id-3),
-                                                         node::pointer_type(11, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id,
+                                       node::pointer_type(11, node::max_id - 3),
+                                       node::pointer_type(11, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,j)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-1,
-                                                         node::pointer_type(11, node::max_id-2),
-                                                         node::pointer_type(11, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 1,
+                                       node::pointer_type(11, node::max_id - 2),
+                                       node::pointer_type(11, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,k)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-2,
-                                                         node::pointer_type(11, node::max_id-1),
-                                                         node::pointer_type(11, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 2,
+                                       node::pointer_type(11, node::max_id - 1),
+                                       node::pointer_type(11, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,j)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-3,
-                                                         node::pointer_type(11, node::max_id),
-                                                         node::pointer_type(11, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 3,
+                                       node::pointer_type(11, node::max_id),
+                                       node::pointer_type(11, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (10,h)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id,
-                                                         node::pointer_type(10, node::max_id-3),
-                                                         node::pointer_type(10, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id,
+                                       node::pointer_type(10, node::max_id - 3),
+                                       node::pointer_type(10, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (10,i)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-1,
-                                                         node::pointer_type(10, node::max_id-2),
-                                                         node::pointer_type(10, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 1,
+                                       node::pointer_type(10, node::max_id - 2),
+                                       node::pointer_type(10, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (11,h)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-2,
-                                                         node::pointer_type(10, node::max_id-1),
-                                                         node::pointer_type(10, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 2,
+                                       node::pointer_type(10, node::max_id - 1),
+                                       node::pointer_type(10, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (11,i)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-3,
-                                                         node::pointer_type(10, node::max_id),
-                                                         node::pointer_type(10, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 3,
+                                       node::pointer_type(10, node::max_id),
+                                       node::pointer_type(10, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id,
-                                                         node::pointer_type(9, node::max_id-3),
-                                                         node::pointer_type(9, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id,
+                                       node::pointer_type(9, node::max_id - 3),
+                                       node::pointer_type(9, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id-1,
-                                                         node::pointer_type(9, node::max_id-1),
-                                                         node::pointer_type(9, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id - 1,
+                                       node::pointer_type(9, node::max_id - 1),
+                                       node::pointer_type(9, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,f)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id-2,
-                                                         node::pointer_type(9, node::max_id),
-                                                         node::pointer_type(9, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id - 2,
+                                       node::pointer_type(9, node::max_id),
+                                       node::pointer_type(9, node::max_id - 3))));
 
           // NOTE: (9,f) because the pair (7,f) is is merged with (8) which
           //       prunes that entire subtree away.
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,8,f)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id,
-                                                         node::pointer_type(8, node::max_id-2),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              7, node::max_id, node::pointer_type(8, node::max_id - 2), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,g,9)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(8, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              7, node::max_id - 1, node::pointer_type(true), node::pointer_type(8, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-2,
-                                                         node::pointer_type(8, node::max_id-1),
-                                                         node::pointer_type(8, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(7,
+                                       node::max_id - 2,
+                                       node::pointer_type(8, node::max_id - 1),
+                                       node::pointer_type(8, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id,
-                                                         node::pointer_type(7, node::max_id),
-                                                         node::pointer_type(7, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(6,
+                                       node::max_id,
+                                       node::pointer_type(7, node::max_id),
+                                       node::pointer_type(7, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-1,
-                                                         node::pointer_type(8, node::max_id-2),
-                                                         node::pointer_type(7, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(6,
+                                       node::max_id - 1,
+                                       node::pointer_type(8, node::max_id - 2),
+                                       node::pointer_type(7, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(6, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(6, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(6, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id,
+                                       node::pointer_type(5, node::max_id),
+                                       node::pointer_type(6, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(5, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 1,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(5, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id-1),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id,
+                                       node::pointer_type(4, node::max_id - 1),
+                                       node::pointer_type(4, node::max_id))));
 
           // NOTE: The root (1,a,5,d) has x2 suppressed as the choice at (a)
           //       only is relevant for (b) and (c), not for (d).
@@ -2745,37 +2948,37 @@ go_bandit([]() {
           // TODO
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(13u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(13u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(12u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(12u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(11u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(11u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(10u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(10u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(9u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(9u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(8u,3u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(8u, 3u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u,3u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u, 3u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2852,7 +3055,7 @@ go_bandit([]() {
         it("finishes during initial transposition of even variables in BDD 4 [const &]", [&]() {
           std::vector<bdd::label_type> call_history;
 
-          const bdd in = bdd_4;
+          const bdd in  = bdd_4;
           const bdd out = bdd_exists(ep, in, [&call_history](const bdd::label_type x) -> bool {
             call_history.push_back(x);
             return !(x % 2);
@@ -2861,24 +3064,23 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(3, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(1, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -2910,60 +3112,61 @@ go_bandit([]() {
           AssertThat(call_history.at(9), Is().EqualTo(3u));
         });
 
-        it("collapses during repeated transposition with variables 1 2 variables in BDD 11a [&&]", [&]() {
-          std::vector<bdd::label_type> call_history;
-          bdd out = bdd_exists(ep, bdd_12a, [&call_history](const bdd::label_type x) -> bool {
-            call_history.push_back(x);
-            return 0 < x && x < 3;
-          });
+        it("collapses during repeated transposition with variables 1 2 variables in BDD 11a [&&]",
+           [&]() {
+             std::vector<bdd::label_type> call_history;
+             bdd out = bdd_exists(ep, bdd_12a, [&call_history](const bdd::label_type x) -> bool {
+               call_history.push_back(x);
+               return 0 < x && x < 3;
+             });
 
-          node_test_stream out_nodes(out);
+             node_test_stream out_nodes(out);
 
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
-          AssertThat(out_nodes.can_pull(), Is().False());
+             AssertThat(out_nodes.can_pull(), Is().True());
+             AssertThat(out_nodes.pull(), Is().EqualTo(node(true)));
+             AssertThat(out_nodes.can_pull(), Is().False());
 
-          level_info_test_stream out_meta(out);
-          AssertThat(out_meta.can_pull(), Is().False());
+             level_info_test_stream out_meta(out);
+             AssertThat(out_meta.can_pull(), Is().False());
 
-          // TODO: meta variables...
+             // TODO: meta variables...
 
-          // Check call history
-          //
-          // NOTE: Test failure does NOT indicate a bug, but only indicates a
-          //       change. Please verify that this change makes sense and is as
-          //       intended.
-          AssertThat(call_history.size(), Is().EqualTo(17u));
+             // Check call history
+             //
+             // NOTE: Test failure does NOT indicate a bug, but only indicates a
+             //       change. Please verify that this change makes sense and is as
+             //       intended.
+             AssertThat(call_history.size(), Is().EqualTo(17u));
 
-          // - First check for at least one variable satisfying the predicate.
-          AssertThat(call_history.at(0), Is().EqualTo(4u));
-          AssertThat(call_history.at(1), Is().EqualTo(3u));
-          AssertThat(call_history.at(2), Is().EqualTo(2u));
+             // - First check for at least one variable satisfying the predicate.
+             AssertThat(call_history.at(0), Is().EqualTo(4u));
+             AssertThat(call_history.at(1), Is().EqualTo(3u));
+             AssertThat(call_history.at(2), Is().EqualTo(2u));
 
-          // - Count number of variables above widest
-          AssertThat(call_history.at(3), Is().EqualTo(3u)); // <-- widest level
-          AssertThat(call_history.at(4), Is().EqualTo(2u));
-          AssertThat(call_history.at(5), Is().EqualTo(1u));
-          AssertThat(call_history.at(6), Is().EqualTo(0u));
+             // - Count number of variables above widest
+             AssertThat(call_history.at(3), Is().EqualTo(3u)); // <-- widest level
+             AssertThat(call_history.at(4), Is().EqualTo(2u));
+             AssertThat(call_history.at(5), Is().EqualTo(1u));
+             AssertThat(call_history.at(6), Is().EqualTo(0u));
 
-          // - First top-down sweep (root call)
-          AssertThat(call_history.at(7), Is().EqualTo(0u));
+             // - First top-down sweep (root call)
+             AssertThat(call_history.at(7), Is().EqualTo(0u));
 
-          // - First top-down sweep
-          AssertThat(call_history.at(8),  Is().EqualTo(0u));
-          AssertThat(call_history.at(9),  Is().EqualTo(1u));
-          AssertThat(call_history.at(10), Is().EqualTo(2u));
-          AssertThat(call_history.at(11), Is().EqualTo(3u));
-          AssertThat(call_history.at(12), Is().EqualTo(4u));
+             // - First top-down sweep
+             AssertThat(call_history.at(8), Is().EqualTo(0u));
+             AssertThat(call_history.at(9), Is().EqualTo(1u));
+             AssertThat(call_history.at(10), Is().EqualTo(2u));
+             AssertThat(call_history.at(11), Is().EqualTo(3u));
+             AssertThat(call_history.at(12), Is().EqualTo(4u));
 
-          // - Second top-down sweep (root call)
-          AssertThat(call_history.at(13),  Is().EqualTo(0u));
+             // - Second top-down sweep (root call)
+             AssertThat(call_history.at(13), Is().EqualTo(0u));
 
-          // - Second top-down sweep
-          AssertThat(call_history.at(14), Is().EqualTo(0u));
-          AssertThat(call_history.at(15), Is().EqualTo(2u));
-          AssertThat(call_history.at(16), Is().EqualTo(3u));
-        });
+             // - Second top-down sweep
+             AssertThat(call_history.at(14), Is().EqualTo(0u));
+             AssertThat(call_history.at(15), Is().EqualTo(2u));
+             AssertThat(call_history.at(16), Is().EqualTo(3u));
+           });
 
         it("finishes during repeated transposition with variables 1 and 2 in BDD 11b [&&]", [&]() {
           std::vector<bdd::label_type> call_history;
@@ -2994,42 +3197,47 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(4, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       4, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,6,8)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              3, node::max_id, node::pointer_type(true), node::pointer_type(4, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,6)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id-1,
-                                                         node::pointer_type(4, node::max_id-1),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id - 1,
+                                       node::pointer_type(4, node::max_id - 1),
+                                       node::pointer_type(4, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         node::pointer_type(3, node::max_id-1),
-                                                         node::pointer_type(3, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0,
+                                       node::max_id,
+                                       node::pointer_type(3, node::max_id - 1),
+                                       node::pointer_type(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -3058,14 +3266,14 @@ go_bandit([]() {
           AssertThat(call_history.at(8), Is().EqualTo(0u));
 
           // - First top-down sweep
-          AssertThat(call_history.at(9),  Is().EqualTo(0u));
+          AssertThat(call_history.at(9), Is().EqualTo(0u));
           AssertThat(call_history.at(10), Is().EqualTo(1u));
           AssertThat(call_history.at(11), Is().EqualTo(2u));
           AssertThat(call_history.at(12), Is().EqualTo(3u));
           AssertThat(call_history.at(13), Is().EqualTo(4u));
 
           // - Second top-down sweep (root call)
-          AssertThat(call_history.at(14),  Is().EqualTo(0u));
+          AssertThat(call_history.at(14), Is().EqualTo(0u));
 
           // - Second top-down sweep
           AssertThat(call_history.at(15), Is().EqualTo(0u));
@@ -3084,116 +3292,143 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(7, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(6, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-1,
-                                                         node::pointer_type(7, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              6, node::max_id - 1, node::pointer_type(7, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-2,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       6, node::max_id - 2, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(7, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              6, node::max_id - 3, node::pointer_type(true), node::pointer_type(7, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,15)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         node::pointer_type(6, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              5, node::max_id, node::pointer_type(6, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,15,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-1,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 1,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,14,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-2,
-                                                         node::pointer_type(6, node::max_id-3),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 2,
+                                       node::pointer_type(6, node::max_id - 3),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,15,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(6, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 3,
+                                       node::pointer_type(true),
+                                       node::pointer_type(6, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,14)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-4,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(6, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 4,
+                                       node::pointer_type(true),
+                                       node::pointer_type(6, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,14,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id-5,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(6, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id - 5,
+                                       node::pointer_type(true),
+                                       node::pointer_type(6, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,11,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(5, node::max_id-5),
-                                                         node::pointer_type(5, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id,
+                                       node::pointer_type(5, node::max_id - 5),
+                                       node::pointer_type(5, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,11,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(5, node::max_id-3),
-                                                         node::pointer_type(5, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 1,
+                                       node::pointer_type(5, node::max_id - 3),
+                                       node::pointer_type(5, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,10,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-2,
-                                                         node::pointer_type(5, node::max_id-2),
-                                                         node::pointer_type(5, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 2,
+                                       node::pointer_type(5, node::max_id - 2),
+                                       node::pointer_type(5, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,10)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-3,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(5, node::max_id-4))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 3,
+                                       node::pointer_type(5, node::max_id),
+                                       node::pointer_type(5, node::max_id - 4))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,7,9,16)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id-2),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id,
+                                       node::pointer_type(4, node::max_id - 2),
+                                       node::pointer_type(4, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,7,8)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id-1,
-                                                         node::pointer_type(4, node::max_id-3),
-                                                         node::pointer_type(4, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id - 1,
+                                       node::pointer_type(4, node::max_id - 3),
+                                       node::pointer_type(4, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4,5,6,7)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         node::pointer_type(3, node::max_id-1),
-                                                         node::pointer_type(3, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2,
+                                       node::max_id,
+                                       node::pointer_type(3, node::max_id - 1),
+                                       node::pointer_type(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,6u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 6u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -3216,9 +3451,9 @@ go_bandit([]() {
           AssertThat(call_history.at(6), Is().EqualTo(1u));
 
           // - Count number of variables above widest
-          AssertThat(call_history.at(7),  Is().EqualTo(4u)); // <-- widest level
-          AssertThat(call_history.at(8),  Is().EqualTo(3u));
-          AssertThat(call_history.at(9),  Is().EqualTo(2u));
+          AssertThat(call_history.at(7), Is().EqualTo(4u)); // <-- widest level
+          AssertThat(call_history.at(8), Is().EqualTo(3u));
+          AssertThat(call_history.at(9), Is().EqualTo(2u));
           AssertThat(call_history.at(10), Is().EqualTo(1u));
           AssertThat(call_history.at(11), Is().EqualTo(0u));
 
@@ -3258,16 +3493,16 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(0, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -3293,10 +3528,10 @@ go_bandit([]() {
           AssertThat(call_history.at(5), Is().EqualTo(0u));
 
           // - First top-down sweep
-          AssertThat(call_history.at(6),  Is().EqualTo(0u));
-          AssertThat(call_history.at(7),  Is().EqualTo(1u));
-          AssertThat(call_history.at(8),  Is().EqualTo(2u));
-          AssertThat(call_history.at(9),  Is().EqualTo(3u));
+          AssertThat(call_history.at(6), Is().EqualTo(0u));
+          AssertThat(call_history.at(7), Is().EqualTo(1u));
+          AssertThat(call_history.at(8), Is().EqualTo(2u));
+          AssertThat(call_history.at(9), Is().EqualTo(3u));
 
           // NOTE: Even though there are three levels that should be quantified,
           //       we only do one partial quantification.
@@ -3312,157 +3547,210 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(13, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       13, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(13, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       13, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (17,o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id,
-                                                         node::pointer_type(13, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              12, node::max_id, node::pointer_type(13, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (17,n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-1,
-                                                         node::pointer_type(13, node::max_id-1),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 1,
+                                       node::pointer_type(13, node::max_id - 1),
+                                       node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16,o)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-2,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(13, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 2,
+                                       node::pointer_type(true),
+                                       node::pointer_type(13, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (16,n)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(12, node::max_id-3,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(13, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(12,
+                                       node::max_id - 3,
+                                       node::pointer_type(true),
+                                       node::pointer_type(13, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,l)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id,
-                                                         node::pointer_type(12, node::max_id-3),
-                                                         node::pointer_type(12, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id,
+                                       node::pointer_type(12, node::max_id - 3),
+                                       node::pointer_type(12, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (14,m)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-1,
-                                                         node::pointer_type(12, node::max_id-2),
-                                                         node::pointer_type(12, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 1,
+                                       node::pointer_type(12, node::max_id - 2),
+                                       node::pointer_type(12, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,l)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-2,
-                                                         node::pointer_type(12, node::max_id-1),
-                                                         node::pointer_type(12, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 2,
+                                       node::pointer_type(12, node::max_id - 1),
+                                       node::pointer_type(12, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (15,m)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(11, node::max_id-3,
-                                                         node::pointer_type(12, node::max_id),
-                                                         node::pointer_type(12, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(11,
+                                       node::max_id - 3,
+                                       node::pointer_type(12, node::max_id),
+                                       node::pointer_type(12, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,k)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id,
-                                                         node::pointer_type(11, node::max_id-3),
-                                                         node::pointer_type(11, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id,
+                                       node::pointer_type(11, node::max_id - 3),
+                                       node::pointer_type(11, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (13,j)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-1,
-                                                         node::pointer_type(11, node::max_id-2),
-                                                         node::pointer_type(11, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 1,
+                                       node::pointer_type(11, node::max_id - 2),
+                                       node::pointer_type(11, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,k)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-2,
-                                                         node::pointer_type(11, node::max_id-1),
-                                                         node::pointer_type(11, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 2,
+                                       node::pointer_type(11, node::max_id - 1),
+                                       node::pointer_type(11, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (12,j)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(10, node::max_id-3,
-                                                         node::pointer_type(11, node::max_id),
-                                                         node::pointer_type(11, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(10,
+                                       node::max_id - 3,
+                                       node::pointer_type(11, node::max_id),
+                                       node::pointer_type(11, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (10,h)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id,
-                                                         node::pointer_type(10, node::max_id-3),
-                                                         node::pointer_type(10, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id,
+                                       node::pointer_type(10, node::max_id - 3),
+                                       node::pointer_type(10, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (10,i)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-1,
-                                                         node::pointer_type(10, node::max_id-2),
-                                                         node::pointer_type(10, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 1,
+                                       node::pointer_type(10, node::max_id - 2),
+                                       node::pointer_type(10, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (11,h)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-2,
-                                                         node::pointer_type(10, node::max_id-1),
-                                                         node::pointer_type(10, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 2,
+                                       node::pointer_type(10, node::max_id - 1),
+                                       node::pointer_type(10, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (11,i)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(9, node::max_id-3,
-                                                         node::pointer_type(10, node::max_id),
-                                                         node::pointer_type(10, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(9,
+                                       node::max_id - 3,
+                                       node::pointer_type(10, node::max_id),
+                                       node::pointer_type(10, node::max_id - 3))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (9,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id,
-                                                         node::pointer_type(9, node::max_id-3),
-                                                         node::pointer_type(9, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id,
+                                       node::pointer_type(9, node::max_id - 3),
+                                       node::pointer_type(9, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id-1,
-                                                         node::pointer_type(9, node::max_id-1),
-                                                         node::pointer_type(9, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id - 1,
+                                       node::pointer_type(9, node::max_id - 1),
+                                       node::pointer_type(9, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (8,f)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(8, node::max_id-2,
-                                                         node::pointer_type(9, node::max_id),
-                                                         node::pointer_type(9, node::max_id-3))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(8,
+                                       node::max_id - 2,
+                                       node::pointer_type(9, node::max_id),
+                                       node::pointer_type(9, node::max_id - 3))));
 
           // NOTE: (9,f) because the pair (7,f) is is merged with (8) which
           //       prunes that entire subtree away.
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,8,f)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id,
-                                                         node::pointer_type(8, node::max_id-2),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              7, node::max_id, node::pointer_type(8, node::max_id - 2), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,g,9)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(8, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              7, node::max_id - 1, node::pointer_type(true), node::pointer_type(8, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7,g)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-2,
-                                                         node::pointer_type(8, node::max_id-1),
-                                                         node::pointer_type(8, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(7,
+                                       node::max_id - 2,
+                                       node::pointer_type(8, node::max_id - 1),
+                                       node::pointer_type(8, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id,
-                                                         node::pointer_type(7, node::max_id),
-                                                         node::pointer_type(7, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(6,
+                                       node::max_id,
+                                       node::pointer_type(7, node::max_id),
+                                       node::pointer_type(7, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(6, node::max_id-1,
-                                                         node::pointer_type(8, node::max_id-2),
-                                                         node::pointer_type(7, node::max_id-2))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(6,
+                                       node::max_id - 1,
+                                       node::pointer_type(8, node::max_id - 2),
+                                       node::pointer_type(7, node::max_id - 2))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(6, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5,
+                                       node::max_id,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(6, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(6, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id,
+                                       node::pointer_type(5, node::max_id),
+                                       node::pointer_type(6, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(6, node::max_id-1),
-                                                         node::pointer_type(5, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(4,
+                                       node::max_id - 1,
+                                       node::pointer_type(6, node::max_id - 1),
+                                       node::pointer_type(5, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1,5,d)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id-1),
-                                                         node::pointer_type(4, node::max_id))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id,
+                                       node::pointer_type(4, node::max_id - 1),
+                                       node::pointer_type(4, node::max_id))));
 
           // NOTE: The root (1,a,5,d) has x2 suppressed as the choice at (a)
           //       only is relevant for (b) and (c), not for (d).
@@ -3474,37 +3762,37 @@ go_bandit([]() {
           // TODO
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(13u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(13u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(12u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(12u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(11u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(11u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(10u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(10u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(9u,4u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(9u, 4u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(8u,3u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(8u, 3u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u,3u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7u, 3u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(6u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -3518,16 +3806,16 @@ go_bandit([]() {
           AssertThat(call_history.size(), Is().EqualTo(53u));
 
           // - First check for at least one variable satisfying the predicate.
-          AssertThat(call_history.at(0),  Is().EqualTo(13u));
-          AssertThat(call_history.at(1),  Is().EqualTo(12u));
-          AssertThat(call_history.at(2),  Is().EqualTo(11u));
-          AssertThat(call_history.at(3),  Is().EqualTo(10u));
-          AssertThat(call_history.at(4),  Is().EqualTo(9u));
-          AssertThat(call_history.at(5),  Is().EqualTo(8u));
-          AssertThat(call_history.at(6),  Is().EqualTo(7u));
-          AssertThat(call_history.at(7),  Is().EqualTo(6u));
-          AssertThat(call_history.at(8),  Is().EqualTo(5u));
-          AssertThat(call_history.at(9),  Is().EqualTo(4u));
+          AssertThat(call_history.at(0), Is().EqualTo(13u));
+          AssertThat(call_history.at(1), Is().EqualTo(12u));
+          AssertThat(call_history.at(2), Is().EqualTo(11u));
+          AssertThat(call_history.at(3), Is().EqualTo(10u));
+          AssertThat(call_history.at(4), Is().EqualTo(9u));
+          AssertThat(call_history.at(5), Is().EqualTo(8u));
+          AssertThat(call_history.at(6), Is().EqualTo(7u));
+          AssertThat(call_history.at(7), Is().EqualTo(6u));
+          AssertThat(call_history.at(8), Is().EqualTo(5u));
+          AssertThat(call_history.at(9), Is().EqualTo(4u));
           AssertThat(call_history.at(10), Is().EqualTo(3u));
           AssertThat(call_history.at(11), Is().EqualTo(2u));
           AssertThat(call_history.at(12), Is().EqualTo(1u));
@@ -3591,42 +3879,47 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(4, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       4, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              3, node::max_id, node::pointer_type(4, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(4, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id - 1,
+                                       node::pointer_type(true),
+                                       node::pointer_type(4, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         node::pointer_type(3, node::max_id),
-                                                         node::pointer_type(3, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2,
+                                       node::max_id,
+                                       node::pointer_type(3, node::max_id),
+                                       node::pointer_type(3, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -3653,9 +3946,9 @@ go_bandit([]() {
           AssertThat(call_history.at(6), Is().EqualTo(2u));
 
           // - Top-down sweep
-          AssertThat(call_history.at(7),  Is().EqualTo(2u));
-          AssertThat(call_history.at(8),  Is().EqualTo(3u));
-          AssertThat(call_history.at(9),  Is().EqualTo(4u));
+          AssertThat(call_history.at(7), Is().EqualTo(2u));
+          AssertThat(call_history.at(8), Is().EqualTo(3u));
+          AssertThat(call_history.at(9), Is().EqualTo(4u));
           AssertThat(call_history.at(10), Is().EqualTo(5u));
           AssertThat(call_history.at(11), Is().EqualTo(6u));
           AssertThat(call_history.at(12), Is().EqualTo(7u));
@@ -3680,50 +3973,56 @@ go_bandit([]() {
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (4)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id,
-                                                         node::pointer_type(false),
-                                                         node::pointer_type(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(4, node::max_id, node::pointer_type(false), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (6)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(4, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(
+                       4, node::max_id - 1, node::pointer_type(true), node::pointer_type(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         node::pointer_type(4, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              3, node::max_id, node::pointer_type(4, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id-1,
-                                                         node::pointer_type(true),
-                                                         node::pointer_type(4, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3,
+                                       node::max_id - 1,
+                                       node::pointer_type(true),
+                                       node::pointer_type(4, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         node::pointer_type(3, node::max_id),
-                                                         node::pointer_type(3, node::max_id-1))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2,
+                                       node::max_id,
+                                       node::pointer_type(3, node::max_id),
+                                       node::pointer_type(3, node::max_id - 1))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1*)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         node::pointer_type(2, node::max_id),
-                                                         node::pointer_type(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(
+              0, node::max_id, node::pointer_type(2, node::max_id), node::pointer_type(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(4u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,2u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 2u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -3752,7 +4051,7 @@ go_bandit([]() {
           AssertThat(call_history.at(8), Is().EqualTo(0u));
 
           // - Top-down sweep
-          AssertThat(call_history.at(9),  Is().EqualTo(0u));
+          AssertThat(call_history.at(9), Is().EqualTo(0u));
           AssertThat(call_history.at(10), Is().EqualTo(1u));
           AssertThat(call_history.at(11), Is().EqualTo(2u));
           AssertThat(call_history.at(12), Is().EqualTo(3u));
@@ -3776,9 +4075,7 @@ go_bandit([]() {
 
     describe("bdd_exists(const bdd&, const generator<bdd::label_type>&)", [&]() {
       it("returns input on 'optional::none' generator BDD 1 [&&]", [&]() {
-        __bdd out = bdd_exists(bdd_1, []() -> optional<bdd::label_type> {
-          return {};
-        });
+        __bdd out = bdd_exists(bdd_1, []() -> optional<bdd::label_type> { return {}; });
 
         AssertThat(out.get<shared_levelized_file<bdd::node_type>>(), Is().EqualTo(bdd_1));
       });
@@ -3788,36 +4085,33 @@ go_bandit([]() {
 
         it("quantifies 3, 1 in BDD 4 [&&]", [&]() {
           bdd out = bdd_exists(ep, bdd_4, [var = 3]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return {};
-              }
+            if (var == 42) { return {}; }
 
-              const bdd::label_type ret = var;
-              var = ret == 1 ? 42 : var-2;
-              return {ret};
-            });
+            const bdd::label_type ret = var;
+            var                       = ret == 1 ? 42 : var - 2;
+            return { ret };
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(2, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(0, node::max_id, ptr_uint64(2, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
@@ -3826,47 +4120,42 @@ go_bandit([]() {
           const bdd in = bdd_4;
 
           bdd out = bdd_exists(ep, in, [var = 2]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return {};
-              }
+            if (var == 42) { return {}; }
 
-              const bdd::label_type res = var;
-              var = res == 0 ? 42 : var-2;
-              return {res};
-            });
+            const bdd::label_type res = var;
+            var                       = res == 0 ? 42 : var - 2;
+            return { res };
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (2')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(3, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(1, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
         it("quantifies 1 in BDD 1 [&&]", [&]() {
           bdd out = bdd_exists(ep, bdd_1, [var = 1]() mutable -> optional<bdd::label_type> {
-              if (var == 0) {
-                return {};
-              }
-              return {var--};
-            });
+            if (var == 0) { return {}; }
+            return { var-- };
+          });
 
           node_test_stream out_nodes(out);
 
@@ -3883,9 +4172,8 @@ go_bandit([]() {
         it("terminates early when quantifying to a terminal in BDD 3 [&&]", [&]() {
           int calls = 0;
 
-          const bdd out = bdd_exists(ep, bdd_3, [&calls]() -> bdd::label_type {
-            return 2 - 2*(calls++);
-          });
+          const bdd out =
+            bdd_exists(ep, bdd_3, [&calls]() -> bdd::label_type { return 2 - 2 * (calls++); });
 
           // What could be expected is 3 calls: 2, 0 . But, here it terminates early.
           AssertThat(calls, Is().EqualTo(2));
@@ -3908,46 +4196,41 @@ go_bandit([]() {
 
         it("quantifies 3, 1 in BDD 4 [&&]", [&]() {
           bdd out = bdd_exists(ep, bdd_4, [var = 3]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return {};
-              }
+            if (var == 42) { return {}; }
 
-              const bdd::label_type ret = var;
-              var = ret == 1 ? 42 : var-2;
-              return {ret};
-            });
+            const bdd::label_type ret = var;
+            var                       = ret == 1 ? 42 : var - 2;
+            return { ret };
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(2, ptr_uint64::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(
+                       node(0, node::max_id, ptr_uint64(2, ptr_uint64::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
         it("quantifies 1 in BDD 1 [&&]", [&]() {
           bdd out = bdd_exists(ep, bdd_1, [var = 1]() mutable -> optional<bdd::label_type> {
-            if (var == 0) {
-              return {};
-            }
-            return {var--};
+            if (var == 0) { return {}; }
+            return { var-- };
           });
 
           node_test_stream out_nodes(out);
@@ -3964,44 +4247,41 @@ go_bandit([]() {
 
         it("bails out on a level that only shortcuts", [&]() {
           bdd out = bdd_exists(ep, bdd_9T, [var = 6]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return {};
-              }
+            if (var == 42) { return {}; }
 
-              const bdd::label_type res = var;
-              var = res == 0 ? 42 : var-2;
-              return {res};
-            });
+            const bdd::label_type res = var;
+            var                       = res == 0 ? 42 : var - 2;
+            return { res };
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(3, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(1, node::max_id, ptr_uint64(true), ptr_uint64(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4010,36 +4290,33 @@ go_bandit([]() {
 
         it("bails out on a level that only is irrelevant", [&]() {
           bdd out = bdd_exists(ep, bdd_9F, [var = 6]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return make_optional<bdd::label_type>();
-              }
+            if (var == 42) { return make_optional<bdd::label_type>(); }
 
-              const bdd::label_type res = var;
-              var = res == 0 ? 42 : var-2;
-              return res;
-            });
+            const bdd::label_type res = var;
+            var                       = res == 0 ? 42 : var - 2;
+            return res;
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(true))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4048,16 +4325,23 @@ go_bandit([]() {
 
         it("bails out on a level that both shortcuts and is irrelevant", [&]() {
           bdd out = bdd_exists(ep, bdd_6_x4T, [var = 4]() mutable -> optional<bdd::label_type> {
-            if (var == 42) {
-              return {};
-            }
+            if (var == 42) { return {}; }
             const bdd::label_type res = var;
             switch (res) {
-            case 4:  { var = 2;  break; } // <-- 4: transposing
-            case 2:  { var = 1;  break; } // <-- 2: shortuctting / irrelevant
-            default: { var = 42; break; } // <-- 1: final sweep
+            case 4: {
+              var = 2;
+              break;
+            } // <-- 4: transposing
+            case 2: {
+              var = 1;
+              break;
+            } // <-- 2: shortuctting / irrelevant
+            default: {
+              var = 42;
+              break;
+            } // <-- 1: final sweep
             }
-            return {res};
+            return { res };
           });
 
           // TODO predict output!
@@ -4077,28 +4361,30 @@ go_bandit([]() {
 
         it("kills intermediate dead partial solution", [&]() {
           bdd out = bdd_exists(ep, bdd_10, [var = make_optional<bdd::label_type>(3)]() mutable {
-              if (!var) { return var; }
+            if (!var) { return var; }
 
-              const optional<bdd::label_type> res = var;
-              if (2 < var.value()) { var = var.value()-1; }
-              else                 { var = {}; }
+            const optional<bdd::label_type> res = var;
+            if (2 < var.value()) {
+              var = var.value() - 1;
+            } else {
+              var = {};
+            }
 
-              return res;
-            });
+            return res;
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4120,12 +4406,10 @@ go_bandit([]() {
           //        T
           */
           bdd out = bdd_exists(ep, bdd_6, [var = 7]() mutable -> optional<bdd::label_type> {
-            if (var == 42) {
-              return make_optional<bdd::label_type>();
-            }
+            if (var == 42) { return make_optional<bdd::label_type>(); }
 
             const bdd::label_type ret = var;
-            var = ret == 1 ? 42 : var-2;
+            var                       = ret == 1 ? 42 : var - 2;
             return ret;
           });
 
@@ -4149,16 +4433,12 @@ go_bandit([]() {
           //        T
           */
           bdd out = bdd_exists(ep, bdd_16, [var = 6]() mutable -> optional<bdd::label_type> {
-              var -= 1;
+            var -= 1;
 
-              if (var < 0) {
-                return {};
-              }
-              if (var == 5) {
-                var -= 1;
-              }
-              return {var};
-            });
+            if (var < 0) { return {}; }
+            if (var == 5) { var -= 1; }
+            return { var };
+          });
 
           node_test_stream out_nodes(out);
 
@@ -4178,58 +4458,57 @@ go_bandit([]() {
 
     describe("bdd_exists(const bdd&, ForwardIt begin, ForwardIt end)", [&]() {
       it("returns original file for [].begin() in BDD 1 [&]", [&]() {
-        const std::vector<bdd::label_type> vars = { };
-        const bdd out = bdd_exists(bdd_1, vars.begin(), vars.end());
+        const std::vector<bdd::label_type> vars = {};
+        const bdd out                           = bdd_exists(bdd_1, vars.begin(), vars.end());
 
         AssertThat(out.file_ptr(), Is().EqualTo(bdd_1));
       });
 
       it("returns original file for [3, 5].rbegin() in BDD 11 [&]", [&]() {
-        const std::vector<bdd::label_type> vars = { 3,5 };
-        const bdd out = bdd_exists(bdd_11, vars.rbegin(), vars.rend());
+        const std::vector<bdd::label_type> vars = { 3, 5 };
+        const bdd out                           = bdd_exists(bdd_11, vars.rbegin(), vars.rend());
 
         AssertThat(out.file_ptr(), Is().EqualTo(bdd_11));
       });
 
       it("returns original file for [0, 3].rbegin() in BDD 11 [&]", [&]() {
-        const std::vector<bdd::label_type> vars = { 0,3 };
-        const bdd out = bdd_exists(bdd_11, vars.rbegin(), vars.rend());
+        const std::vector<bdd::label_type> vars = { 0, 3 };
+        const bdd out                           = bdd_exists(bdd_11, vars.rbegin(), vars.rend());
 
         AssertThat(out.file_ptr(), Is().EqualTo(bdd_11));
       });
 
       it("quantifies [1, 3].rbegin() in BDD 4 [&&]", [&]() {
-        std::vector<bdd::label_type> vars = { 1 , 3 };
+        std::vector<bdd::label_type> vars = { 1, 3 };
 
         bdd out = bdd_exists(bdd_4, vars.rbegin(), vars.rend());
 
         node_test_stream out_nodes(out);
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (3)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
+        AssertThat(out_nodes.pull(),
+                   Is().EqualTo(node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (1)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                       ptr_uint64(2, ptr_uint64::max_id),
-                                                       ptr_uint64(true))));
+        AssertThat(
+          out_nodes.pull(),
+          Is().EqualTo(node(0, node::max_id, ptr_uint64(2, ptr_uint64::max_id), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(2u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().False());
       });
 
       it("quantifies [2, 0].begin() in BDD 4 [const &]", [&]() {
-        const bdd in = bdd_4;
+        const bdd in                            = bdd_4;
         const std::vector<bdd::label_type> vars = { 2, 0 };
 
         bdd out = bdd_exists(in, vars.begin(), vars.end());
@@ -4237,31 +4516,30 @@ go_bandit([]() {
         node_test_stream out_nodes(out);
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (5)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
+        AssertThat(out_nodes.pull(),
+                   Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (2')
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                       ptr_uint64(3, ptr_uint64::max_id),
-                                                       ptr_uint64(true))));
+        AssertThat(
+          out_nodes.pull(),
+          Is().EqualTo(node(1, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().False());
       });
 
       it("quantifies [4, 2, 0].begin() in BDD 4 [const &]", [&]() {
         const exec_policy ep;
-        const bdd in = bdd_4;
+        const bdd in                            = bdd_4;
         const std::vector<bdd::label_type> vars = { 4, 2, 0 };
 
         bdd out = bdd_exists(ep, in, vars.begin(), vars.end());
@@ -4269,24 +4547,23 @@ go_bandit([]() {
         node_test_stream out_nodes(out);
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (5)
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
+        AssertThat(out_nodes.pull(),
+                   Is().EqualTo(node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (2')
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                       ptr_uint64(3, ptr_uint64::max_id),
-                                                       ptr_uint64(true))));
+        AssertThat(
+          out_nodes.pull(),
+          Is().EqualTo(node(1, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().False());
       });
@@ -4319,25 +4596,28 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(0u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(0u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(1u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(1u));
       });
 
       it("quantifies root of [BDD 3]", [&]() {
@@ -4347,46 +4627,49 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(3u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(1u));
       });
 
       it("should prune shortcuttable requests [BDD 4]", [&]() {
@@ -4396,49 +4679,52 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(1,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(1, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True());
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(1,0), true,  ptr_uint64(3,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), true, ptr_uint64(3, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to 3.low()
-                   Is().EqualTo(arc { ptr_uint64(1,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(1, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // false due to 5.low()
-                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(), // true due to 5.high() and 4.high()
-                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 0), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(3u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(3u, 1u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(1u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(3u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(3u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(1u));
       });
 
       it("can forward information across a level [BDD 6]", [&]() {
@@ -4448,119 +4734,126 @@ go_bandit([]() {
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(2,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), false, ptr_uint64(3,0) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), false, ptr_uint64(3, 0) }));
 
         AssertThat(arcs.can_pull_internal(), Is().True()); // (8,T)
         AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,1) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(3, 1) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (4,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,6)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(2,1), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(2, 1), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (7,8)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 0), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 0), true, ptr_uint64(false) }));
 
         AssertThat(arcs.can_pull_terminal(), Is().True()); // (8,T)
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,1), false, ptr_uint64(false) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 1), false, ptr_uint64(false) }));
         AssertThat(arcs.can_pull_terminal(), Is().True());
         AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,1), true,  ptr_uint64(true) }));
+                   Is().EqualTo(arc{ ptr_uint64(3, 1), true, ptr_uint64(true) }));
 
         AssertThat(arcs.can_pull_internal(), Is().False());
 
         level_info_test_stream levels(out);
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 2u)));
 
         AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(3u,2u)));
+        AssertThat(levels.pull(), Is().EqualTo(level_info(3u, 2u)));
 
         AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                   Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(5u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(1u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                   Is().EqualTo(5u));
+        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                   Is().EqualTo(1u));
       });
 
-      it("should collapse tuple requests of the same node back into request on a single node [BDD 8a]", [&]() {
-        __bdd out = bdd_forall(bdd_8a, 1);
+      it("should collapse tuple requests of the same node back into request on a single node [BDD "
+         "8a]",
+         [&]() {
+           __bdd out = bdd_forall(bdd_8a, 1);
 
-        arc_test_stream arcs(out);
+           arc_test_stream arcs(out);
 
-        AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), false, ptr_uint64(2,0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True()); // (3,4)
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(0, 0), false, ptr_uint64(2, 0) }));
 
-        AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(0,0), true,  ptr_uint64(3,0) }));
-        AssertThat(arcs.can_pull_internal(), Is().True());
-        AssertThat(arcs.pull_internal(),
-                   Is().EqualTo(arc { ptr_uint64(2,0), true,  ptr_uint64(3,0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True()); // (5,_)
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(3, 0) }));
+           AssertThat(arcs.can_pull_internal(), Is().True());
+           AssertThat(arcs.pull_internal(),
+                      Is().EqualTo(arc{ ptr_uint64(2, 0), true, ptr_uint64(3, 0) }));
 
-        AssertThat(arcs.can_pull_internal(), Is().False());
+           AssertThat(arcs.can_pull_internal(), Is().False());
 
-        AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
-        AssertThat(arcs.pull_terminal(), // false due to 4.low()
-                   Is().EqualTo(arc { ptr_uint64(2,0), false, ptr_uint64(false) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True()); // (3,4)
+           AssertThat(arcs.pull_terminal(),                   // false due to 4.low()
+                      Is().EqualTo(arc{ ptr_uint64(2, 0), false, ptr_uint64(false) }));
 
-        AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
-        AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), false, ptr_uint64(false) }));
-        AssertThat(arcs.can_pull_terminal(), Is().True());
-        AssertThat(arcs.pull_terminal(),
-                   Is().EqualTo(arc { ptr_uint64(3,0), true,  ptr_uint64(true) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True()); // (5,_)
+           AssertThat(arcs.pull_terminal(),
+                      Is().EqualTo(arc{ ptr_uint64(3, 0), false, ptr_uint64(false) }));
+           AssertThat(arcs.can_pull_terminal(), Is().True());
+           AssertThat(arcs.pull_terminal(),
+                      Is().EqualTo(arc{ ptr_uint64(3, 0), true, ptr_uint64(true) }));
 
+           AssertThat(arcs.can_pull_terminal(), Is().False());
 
-        AssertThat(arcs.can_pull_terminal(), Is().False());
+           level_info_test_stream levels(out);
 
-        level_info_test_stream levels(out);
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(0u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(0u,1u)));
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(2u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(2u,1u)));
+           AssertThat(levels.can_pull(), Is().True());
+           AssertThat(levels.pull(), Is().EqualTo(level_info(3u, 1u)));
 
-        AssertThat(levels.can_pull(), Is().True());
-        AssertThat(levels.pull(), Is().EqualTo(level_info(3u,1u)));
+           AssertThat(levels.can_pull(), Is().False());
 
-        AssertThat(levels.can_pull(), Is().False());
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut,
+                      Is().GreaterThanOrEqualTo(2u));
 
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->max_1level_cut, Is().GreaterThanOrEqualTo(2u));
-
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false], Is().EqualTo(2u));
-        AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],  Is().EqualTo(1u));
-      });
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[false],
+                      Is().EqualTo(2u));
+           AssertThat(out.get<__bdd::shared_arc_file_type>()->number_of_terminals[true],
+                      Is().EqualTo(1u));
+         });
     });
 
     describe("bdd_forall(const bdd&, const predicate<bdd::label_type>&)", [&]() {
       it("returns input on always-false predicate BDD 1 [const &]", [&]() {
-        bdd in = bdd_1;
+        bdd in    = bdd_1;
         __bdd out = bdd_forall(in, [](const bdd::label_type) -> bool { return false; });
         AssertThat(out.get<shared_levelized_file<bdd::node_type>>(), Is().EqualTo(bdd_1));
       });
@@ -4575,23 +4868,21 @@ go_bandit([]() {
 
         it("quantifies even variables in BDD 1 [const &]", [&]() {
           const bdd in = bdd_1;
-          const bdd out = bdd_forall(ep, in, [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          const bdd out =
+            bdd_forall(ep, in, [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4599,23 +4890,21 @@ go_bandit([]() {
         });
 
         it("quantifies odd variables in BDD 1 [&&]", [&]() {
-          const bdd out = bdd_forall(ep, bdd_1, [](const bdd::label_type x) -> bool {
-            return x % 2;
-          });
+          const bdd out =
+            bdd_forall(ep, bdd_1, [](const bdd::label_type x) -> bool { return x % 2; });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4623,9 +4912,8 @@ go_bandit([]() {
         });
 
         it("quantifies <= 2 variables in BDD 4 [&&]", [&]() {
-          const bdd out = bdd_forall(ep, bdd_4, [](const bdd::label_type x) -> bool {
-            return x <= 2;
-          });
+          const bdd out =
+            bdd_forall(ep, bdd_4, [](const bdd::label_type x) -> bool { return x <= 2; });
 
           node_test_stream out_nodes(out);
 
@@ -4666,7 +4954,7 @@ go_bandit([]() {
       });
 
       describe("quantify_alg == Partial", [&]() {
-        //const exec_policy ep = exec_policy::quantify::Partial;
+        // const exec_policy ep = exec_policy::quantify::Partial;
 
         // TODO
       });
@@ -4675,61 +4963,57 @@ go_bandit([]() {
         const exec_policy ep = exec_policy::quantify::Nested;
 
         it("quantifies even variables in BDD 1", [&]() {
-          const bdd out = bdd_forall(ep, bdd_1, [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          const bdd out =
+            bdd_forall(ep, bdd_1, [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
         it("bails out on a level that only shortcuts", [&]() {
-          bdd out = bdd_forall(ep, bdd_not(bdd_9T), [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          bdd out = bdd_forall(
+            ep, bdd_not(bdd_9T), [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(false))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(3, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4737,31 +5021,29 @@ go_bandit([]() {
         });
 
         it("bails out on a level that only is irrelevant", [&]() {
-          bdd out = bdd_forall(ep, bdd_not(bdd_9F), [](const bdd::label_type x) -> bool {
-            return !(x % 2);
-          });
+          bdd out = bdd_forall(
+            ep, bdd_not(bdd_9F), [](const bdd::label_type x) -> bool { return !(x % 2); });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(false))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -4794,23 +5076,21 @@ go_bandit([]() {
         const exec_policy ep = exec_policy::quantify::Auto;
 
         it("quantifies odd variables in BDD 1", [&]() {
-          const bdd out = bdd_forall(ep, bdd_1, [](const bdd::label_type x) -> bool {
-            return x % 2;
-          });
+          const bdd out =
+            bdd_forall(ep, bdd_1, [](const bdd::label_type x) -> bool { return x % 2; });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
@@ -4819,9 +5099,7 @@ go_bandit([]() {
 
     describe("bdd_forall(const bdd&, const generator<bdd::label_type>&)", [&]() {
       it("returns input on 'optional::none' generator in BDD 1 [&&]", [&]() {
-        __bdd out = bdd_forall(bdd_1, []() {
-          return make_optional<bdd::label_type>();
-        });
+        __bdd out = bdd_forall(bdd_1, []() { return make_optional<bdd::label_type>(); });
 
         AssertThat(out.get<shared_levelized_file<bdd::node_type>>(), Is().EqualTo(bdd_1));
       });
@@ -4830,52 +5108,46 @@ go_bandit([]() {
         const exec_policy ep = exec_policy::quantify::Singleton;
 
         it("quantifies 0 in BDD 1 [const &]", [&]() {
-          const bdd in = bdd_1;
+          const bdd in  = bdd_1;
           const bdd out = bdd_forall(ep, in, [var = 0]() mutable -> optional<bdd::label_type> {
-              if (var > 0) {
-                return make_optional<bdd::label_type>();
-              }
-              return var++;
-            });
+            if (var > 0) { return make_optional<bdd::label_type>(); }
+            return var++;
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
         it("quantifies 1 in BDD 1 [&&]", [&]() {
           const bdd out = bdd_forall(ep, bdd_1, [var = 1]() mutable -> optional<bdd::label_type> {
-              if (var == 0) {
-                return {};
-              }
-              return {var--};
-            });
+            if (var == 0) { return {}; }
+            return { var-- };
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
@@ -4883,9 +5155,8 @@ go_bandit([]() {
         it("terminates early when quantifying 2, 0 to a terminal in BDD 3 [&&]", [&]() {
           int calls = 0;
 
-          const bdd out = bdd_forall(ep, bdd_3, [&calls]() -> optional<bdd::label_type> {
-            return {2 - 2*(calls++)};
-          });
+          const bdd out = bdd_forall(
+            ep, bdd_3, [&calls]() -> optional<bdd::label_type> { return { 2 - 2 * (calls++) }; });
 
           // What could be expected is 3 calls: 2, 0, none . But, here it terminates early.
           AssertThat(calls, Is().EqualTo(2));
@@ -4908,97 +5179,89 @@ go_bandit([]() {
 
         it("quantifies 0 in BDD 1", [&]() {
           const bdd out = bdd_forall(ep, bdd_1, [var = 0]() mutable -> optional<bdd::label_type> {
-              if (var == 1) {
-                return {};
-              }
-              return {var++};
-            });
+            if (var == 1) { return {}; }
+            return { var++ };
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(true))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
         it("quantifies 1 in BDD 1", [&]() {
           const bdd out = bdd_forall(ep, bdd_1, [var = 1]() mutable -> optional<bdd::label_type> {
-              if (var == 0) {
-                return make_optional<bdd::label_type>();
-              }
+            if (var == 0) { return make_optional<bdd::label_type>(); }
 
-              const bdd::label_type ret = var;
-              var--;
-              return ret;
-            });
+            const bdd::label_type ret = var;
+            var--;
+            return ret;
+          });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(0, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
         });
 
         it("bails out on a level that only shortcuts", [&]() {
-          bdd out = bdd_forall(ep, bdd_not(bdd_9T), [var = 6]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return {};
-              }
+          bdd out =
+            bdd_forall(ep, bdd_not(bdd_9T), [var = 6]() mutable -> optional<bdd::label_type> {
+              if (var == 42) { return {}; }
 
               const bdd::label_type res = var;
-              var = res == 0 ? 42 : var-2;
-              return {res};
+              var                       = res == 0 ? 42 : var - 2;
+              return { res };
             });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(false))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         ptr_uint64(false),
-                                                         ptr_uint64(3, node::max_id))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(3, node::max_id))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -5006,37 +5269,35 @@ go_bandit([]() {
         });
 
         it("bails out on a level that only is irrelevant", [&]() {
-          bdd out = bdd_forall(ep, bdd_not(bdd_9F), [var = 6]() mutable -> optional<bdd::label_type> {
-              if (var == 42) {
-                return {};
-              }
+          bdd out =
+            bdd_forall(ep, bdd_not(bdd_9F), [var = 6]() mutable -> optional<bdd::label_type> {
+              if (var == 42) { return {}; }
 
               const bdd::label_type res = var;
-              var = res == 0 ? 42 : var-2;
-              return {res};
+              var                       = res == 0 ? 42 : var - 2;
+              return { res };
             });
 
           node_test_stream out_nodes(out);
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (7')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         ptr_uint64(true),
-                                                         ptr_uint64(false))));
+          AssertThat(out_nodes.pull(),
+                     Is().EqualTo(node(5, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().True()); // (5')
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
-                                                         ptr_uint64(5, node::max_id),
-                                                         ptr_uint64(false))));
+          AssertThat(
+            out_nodes.pull(),
+            Is().EqualTo(node(3, node::max_id, ptr_uint64(5, node::max_id), ptr_uint64(false))));
 
           AssertThat(out_nodes.can_pull(), Is().False());
 
           level_info_test_stream out_meta(out);
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u,1u)));
+          AssertThat(out_meta.pull(), Is().EqualTo(level_info(3u, 1u)));
 
           AssertThat(out_meta.can_pull(), Is().False());
 
@@ -5049,16 +5310,12 @@ go_bandit([]() {
           //        F
           */
           bdd out = bdd_forall(ep, bdd_16, [var = 6]() mutable -> optional<bdd::label_type> {
-              var -= 1;
+            var -= 1;
 
-              if (var < 0) {
-                return {};
-              }
-              if (var == 5) {
-                var -= 1;
-              }
-              return {var};
-            });
+            if (var < 0) { return {}; }
+            if (var == 5) { var -= 1; }
+            return { var };
+          });
 
           node_test_stream out_nodes(out);
 
@@ -5078,7 +5335,7 @@ go_bandit([]() {
 
     describe("bdd_forall(const bdd&, ForwardIt begin, ForwardIt end)", [&]() {
       it("quantifies [0].rbegin() in BDD 1 [const &]", [&]() {
-        const bdd in = bdd_1;
+        const bdd in                            = bdd_1;
         const std::vector<bdd::label_type> vars = { 0 };
 
         const bdd out = bdd_forall(in, vars.rbegin(), vars.rend());
@@ -5086,16 +5343,15 @@ go_bandit([]() {
         node_test_stream out_nodes(out);
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                       ptr_uint64(false),
-                                                       ptr_uint64(true))));
+        AssertThat(out_nodes.pull(),
+                   Is().EqualTo(node(1, node::max_id, ptr_uint64(false), ptr_uint64(true))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(1u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().False());
       });
@@ -5104,24 +5360,23 @@ go_bandit([]() {
         const exec_policy ep = exec_policy::quantify::Auto;
 
         const std::vector<bdd::label_type> vars = { 1 };
-        const bdd out = bdd_forall(ep, bdd_1, vars.begin(), vars.end());
+        const bdd out                           = bdd_forall(ep, bdd_1, vars.begin(), vars.end());
 
         node_test_stream out_nodes(out);
 
         AssertThat(out_nodes.can_pull(), Is().True()); // (1')
-        AssertThat(out_nodes.pull(), Is().EqualTo(node(0, node::max_id,
-                                                       ptr_uint64(true),
-                                                       ptr_uint64(false))));
+        AssertThat(out_nodes.pull(),
+                   Is().EqualTo(node(0, node::max_id, ptr_uint64(true), ptr_uint64(false))));
 
         AssertThat(out_nodes.can_pull(), Is().False());
 
         level_info_test_stream out_meta(out);
 
         AssertThat(out_meta.can_pull(), Is().True());
-        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u,1u)));
+        AssertThat(out_meta.pull(), Is().EqualTo(level_info(0u, 1u)));
 
         AssertThat(out_meta.can_pull(), Is().False());
       });
     });
   });
- });
+});

--- a/test/adiar/internal/algorithms/test_nested_sweeping.cpp
+++ b/test/adiar/internal/algorithms/test_nested_sweeping.cpp
@@ -3582,6 +3582,92 @@ go_bandit([]() {
 
             AssertThat(out_pq.can_pull(), Is().False());
           });
+
+          it("reduces forest canonically anyway if 'is_last_inner == true'", [&]() {
+            shared_levelized_file<node> out = __reduce_init_output<bdd_policy>();
+            node_writer out_writer(out);
+
+            const size_t available_memory = memory_available();
+
+            outer_pq_t out_pq({in_outer}, available_memory / 2, in_outer->max_1level_cut);
+            out_pq.setup_next_level(2);
+
+            /* output
+            //      1   2           ---- x1
+            //  -   -\ _X_  -   -   -    -
+            //        3   4         ---- x2
+            //       / \ / \
+            //       T 6 F T        ---- x3
+            //        / \
+            //        T F
+            */
+            nested_sweeping::inner::up<test_policy>(exec_policy::nested::fast_reduce(1.0),
+                                                    stream_outer, out_pq, out_writer,
+                                                    in_inner, available_memory / 2, true);
+
+            // Check meta variables before detach computations
+            AssertThat(out->width, Is().EqualTo(2u));
+
+            AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
+            AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+
+            // Over-approximation, since T-terminal from level (2) is removed
+            AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(3u));
+            AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(4u));
+            AssertThat(out->max_1level_cut[cut::All], Is().GreaterThanOrEqualTo(4u));
+            AssertThat(out->max_1level_cut[cut::All], Is().LessThanOrEqualTo(6u));
+
+            AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
+            AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
+
+            // Check node and meta files are correct
+            out_writer.detach();
+
+            node_test_stream out_nodes(out);
+
+            AssertThat(out_nodes.can_pull(), Is().True()); // 6
+            AssertThat(out_nodes.pull(), Is().EqualTo(node(3, node::max_id,
+                                                           terminal_T,
+                                                           terminal_F)));
+
+            AssertThat(out_nodes.can_pull(), Is().True()); // 5
+            AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id,
+                                                           terminal_F,
+                                                           terminal_T)));
+
+            AssertThat(out_nodes.can_pull(), Is().True()); // 3
+            AssertThat(out_nodes.pull(), Is().EqualTo(node(2, node::max_id-1,
+                                                           terminal_T,
+                                                           ptr_uint64(3, ptr_uint64::max_id))));
+
+            AssertThat(out_nodes.can_pull(), Is().False());
+
+            level_info_test_stream out_meta(out);
+
+            AssertThat(out_meta.can_pull(), Is().True());
+            AssertThat(out_meta.pull(), Is().EqualTo(level_info(3,1u)));
+
+            AssertThat(out_meta.can_pull(), Is().True());
+            AssertThat(out_meta.pull(), Is().EqualTo(level_info(2,2u)));
+
+            AssertThat(out_meta.can_pull(), Is().False());
+
+            // Check outer priority queue is correct
+            AssertThat(out_pq.size(),  Is().EqualTo(3u));
+
+            out_pq.setup_next_level();
+
+            AssertThat(out_pq.can_pull(), Is().True());
+            AssertThat(out_pq.pull(), Is().EqualTo(arc(n2, true, ptr_uint64(2, ptr_uint64::max_id-1))));
+
+            AssertThat(out_pq.can_pull(), Is().True());
+            AssertThat(out_pq.pull(), Is().EqualTo(arc(n2, false, ptr_uint64(2, ptr_uint64::max_id))));
+
+            AssertThat(out_pq.can_pull(), Is().True());
+            AssertThat(out_pq.pull(), Is().EqualTo(arc(n1, true,  ptr_uint64(2, ptr_uint64::max_id-1))));
+
+            AssertThat(out_pq.can_pull(), Is().False());
+          });
         }
 
         it("uses fast reduce with non-negative value [adjacent duplicates]", []() {

--- a/test/adiar/internal/algorithms/test_nested_sweeping.cpp
+++ b/test/adiar/internal/algorithms/test_nested_sweeping.cpp
@@ -19,7 +19,7 @@
 ///                 single non-nil member, i.e. it is a request preserving a
 ///                 subtree but (presumably) not changing it.
 ////////////////////////////////////////////////////////////////////////////////
-template<nested_sweeping::reduce_strategy reduce_strat, bool only_gc = false>
+template<bool FinalCanonical = true, bool only_gc = false>
 class test_not_sweep
   : public bdd_policy, public statistics::__alg_base::__lpq_t
 {
@@ -163,10 +163,10 @@ public:
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  static constexpr auto reduce_strategy = reduce_strat;
+  static constexpr bool final_canonical = FinalCanonical;
 };
 
-template<nested_sweeping::reduce_strategy reduce_strat>
+template<bool FinalCanonical = true>
 class test_terminal_sweep
   : public bdd_policy, public statistics::__alg_base::__lpq_t
 {
@@ -297,7 +297,7 @@ public:
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  static constexpr auto reduce_strategy = reduce_strat;
+  static constexpr bool final_canonical = FinalCanonical;
 };
 
 go_bandit([]() {
@@ -1006,7 +1006,7 @@ go_bandit([]() {
       });
 
       describe("outer::inner_iterator", [&terminal_F, &terminal_T]() {
-        using test_iter_t = nested_sweeping::outer::inner_iterator<test_not_sweep<nested_sweeping::Always_Canonical>>;
+        using test_iter_t = nested_sweeping::outer::inner_iterator<test_not_sweep<>>;
 
         it("provides {end} for {3,2,1} % 4", [&]() {
           /*
@@ -1041,7 +1041,7 @@ go_bandit([]() {
             aw.push(level_info(3,1u));
           }
 
-          test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(4);
+          test_not_sweep<> inner_impl(4);
           test_iter_t inner_iter(dag, inner_impl);
 
           AssertThat(inner_iter.next_inner(), Is().EqualTo(test_iter_t::end));
@@ -1080,7 +1080,7 @@ go_bandit([]() {
             aw.push(level_info(3,1u));
           }
 
-          test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+          test_not_sweep<> inner_impl(2);
           test_iter_t inner_iter(dag, inner_impl);
 
           AssertThat(inner_iter.next_inner(), Is().EqualTo(2u));
@@ -1126,7 +1126,7 @@ go_bandit([]() {
             aw.push(level_info(4,1u));
           }
 
-          test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+          test_not_sweep<> inner_impl(2);
           test_iter_t inner_iter(dag, inner_impl);
 
           AssertThat(inner_iter.next_inner(), Is().EqualTo(4u));
@@ -2890,7 +2890,7 @@ go_bandit([]() {
 
     describe("nested_sweeping:: _ ::sweeps", [&terminal_F, &terminal_T, &outer_dag]() {
       describe("inner::down(...)", [&]() {
-        using inner_down_sweep = test_not_sweep<nested_sweeping::Always_Canonical>;
+        using inner_down_sweep = test_not_sweep<>;
         using inner_roots_t =
           nested_sweeping::outer::roots_sorter<memory_mode::Internal,
                                                inner_down_sweep::request_t,
@@ -3069,7 +3069,7 @@ go_bandit([]() {
         });
 
         it("can collapse to a terminal", []() {
-          test_terminal_sweep<nested_sweeping::Always_Canonical> test_policy(2);
+          test_terminal_sweep<> test_policy(2);
 
           /*
           //  nil
@@ -3124,8 +3124,10 @@ go_bandit([]() {
       });
 
       describe("inner::up(...)", []() {
-        using test_policy = test_not_sweep<nested_sweeping::Always_Canonical>;
+        using test_policy = test_not_sweep<>;
         using outer_pq_t  = nested_sweeping::outer::up__pq_t<1, memory_mode::Internal>;
+
+        // TODO: copy over test from below with non-negative value.
 
         it("reduces forest and pushes roots back out", []() {
           /* input
@@ -3805,7 +3807,7 @@ go_bandit([]() {
           nw << node(true);
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         const bdd out = nested_sweep<>(exec_policy(),in, inner_impl);
 
@@ -3852,7 +3854,7 @@ go_bandit([]() {
           in->max_1level_cut = 3;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     1      ---- x1
@@ -3948,7 +3950,7 @@ go_bandit([]() {
           in->max_1level_cut = 3;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //       1     ---- x1
@@ -4039,7 +4041,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //             ---- x0
@@ -4140,7 +4142,7 @@ go_bandit([]() {
           in->max_1level_cut = 3;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output (note, the deepest ones are doubly-negated!)
         //       1     ---- x1
@@ -4263,7 +4265,7 @@ go_bandit([]() {
           in->max_1level_cut = 3;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //                    ---- x0
@@ -4349,7 +4351,7 @@ go_bandit([]() {
         // Just a sanity check we created the input as intended
         AssertThat(in->canonical, Is().True());
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         // See 'accumulates multiple nested sweeps [excl. root]' above.
@@ -4466,7 +4468,7 @@ go_bandit([]() {
           in->max_1level_cut = 3;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //         _1_       ---- x1
@@ -4589,7 +4591,7 @@ go_bandit([]() {
           in->max_1level_cut = 4;
         }
 
-        test_terminal_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_terminal_sweep<> inner_impl(2);
 
         /* output
         //        1            ---- x1
@@ -4678,7 +4680,7 @@ go_bandit([]() {
           in->max_1level_cut = 2;
         }
 
-        test_terminal_sweep<nested_sweeping::Always_Canonical> inner_impl(3);
+        test_terminal_sweep<> inner_impl(3);
 
         /* output
         //         _1_        ---- x2
@@ -4773,7 +4775,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     1       ---- x1
@@ -4852,7 +4854,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     1       ---- x1
@@ -4925,7 +4927,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     T
@@ -4992,7 +4994,7 @@ go_bandit([]() {
           in->max_1level_cut = 2;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     2         ---- x1
@@ -5063,7 +5065,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     T
@@ -5129,7 +5131,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_not_sweep<> inner_impl(2);
 
         /* output
         //     F
@@ -5195,7 +5197,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_terminal_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
+        test_terminal_sweep<> inner_impl(2);
 
         /* output
         //     T
@@ -5263,7 +5265,7 @@ go_bandit([]() {
           in->max_1level_cut = 1;
         }
 
-        test_terminal_sweep<nested_sweeping::Always_Canonical> inner_impl(4);
+        test_terminal_sweep<> inner_impl(4);
         /* output
         //     T   <-- reduced from  2'    ---- x2
         //                          / \
@@ -5355,7 +5357,7 @@ go_bandit([]() {
             in->max_1level_cut = 3;
           }
 
-          test_not_sweep<nested_sweeping::Always_Canonical, true> inner_impl(2);
+          test_not_sweep<true, true> inner_impl(2);
 
           /* output
           //        _1_      ---- x1
@@ -5492,7 +5494,7 @@ go_bandit([]() {
             in->max_1level_cut = 3;
           }
 
-          test_not_sweep<nested_sweeping::Always_Canonical, true> inner_impl(2);
+          test_not_sweep<true, true> inner_impl(2);
 
           /* output
           //        _1_      ---- x1
@@ -5664,72 +5666,8 @@ go_bandit([]() {
         //     T F  T
         */
 
-        it("outputs with 'Always_Canonical' a canonical BDD", [&]() {
-          test_not_sweep<nested_sweeping::Always_Canonical> inner_impl(2);
-
-          const bdd out = nested_sweep<>(exec_policy(), __bdd(in, exec_policy()), inner_impl);
-
-          // Check it looks all right
-          node_test_stream out_nodes(out);
-
-          // n8
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id, terminal_F, terminal_T)));
-
-          // n9
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-1, terminal_T, terminal_F)));
-
-          // n4
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         terminal_T,
-                                                         node::pointer_type(7, node::max_id))));
-
-          // n1
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(7, node::max_id-1))));
-
-          AssertThat(out_nodes.can_pull(), Is().False());
-
-          level_info_test_stream out_meta(out);
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7,2u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().False());
-
-          AssertThat(out->width, Is().EqualTo(2u));
-
-          AssertThat(out->canonical, Is().True());
-
-          AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(2u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
-          AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(3u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
-
-          AssertThat(out->max_2level_cut[cut::Internal], Is().GreaterThanOrEqualTo(2u));
-          AssertThat(out->max_2level_cut[cut::Internal], Is().LessThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(4u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
-
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
-          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
-        });
-
-        it("outputs with 'Final_Canonical' a canonical BDD", [&]() {
-          test_not_sweep<nested_sweeping::Final_Canonical> inner_impl(2);
+        it("outputs with 'final_canonical == true' a canonical BDD", [&]() {
+          test_not_sweep<true> inner_impl(2);
 
           const bdd out = nested_sweep<>(exec_policy(), __bdd(in, exec_policy()), inner_impl);
 
@@ -5809,7 +5747,7 @@ go_bandit([]() {
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
         });
 
-        it("outputs with 'Never_Canonical' an unordered and unmerged BDD", [&]() {
+        it("outputs with 'final_canonical == false' an unordered and unmerged BDD", [&]() {
           /* fast-reduce output
           //         _1_          ---- x1
           //        /   \
@@ -5828,7 +5766,7 @@ go_bandit([]() {
           //           F T T F
           */
 
-          test_not_sweep<nested_sweeping::Never_Canonical> inner_impl(2);
+          test_not_sweep<false> inner_impl(2);
 
           const bdd out = nested_sweep<>(exec_policy(), __bdd(in, exec_policy()), inner_impl);
 
@@ -5905,76 +5843,6 @@ go_bandit([]() {
 
           AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
           AssertThat(out->number_of_terminals[true],  Is().EqualTo(4u));
-        });
-
-        it("outputs with 'Auto' a canonical BDD", [&]() {
-          test_not_sweep<nested_sweeping::Auto> inner_impl(2);
-
-          const bdd out = nested_sweep<>(exec_policy(), __bdd(in, exec_policy()), inner_impl);
-
-          // Check it looks all right
-          node_test_stream out_nodes(out);
-
-          // n8
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id, terminal_F, terminal_T)));
-
-          // n9
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(7, node::max_id-1, terminal_T, terminal_F)));
-
-          // n4
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(5, node::max_id,
-                                                         terminal_T,
-                                                         node::pointer_type(7, node::max_id))));
-
-          // n1
-          AssertThat(out_nodes.can_pull(), Is().True());
-          AssertThat(out_nodes.pull(), Is().EqualTo(node(1, node::max_id,
-                                                         node::pointer_type(5, node::max_id),
-                                                         node::pointer_type(7, node::max_id-1))));
-
-          AssertThat(out_nodes.can_pull(), Is().False());
-
-          level_info_test_stream out_meta(out);
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(7,2u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(5,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().True());
-          AssertThat(out_meta.pull(), Is().EqualTo(level_info(1,1u)));
-
-          AssertThat(out_meta.can_pull(), Is().False());
-
-          AssertThat(out->width, Is().EqualTo(2u));
-
-          AssertThat(out->canonical, Is().True());
-
-          // Over-approximation:
-          //   It is somewhere in-between Always_Canonical and Final_Canonical,
-          //   and so should the cuts too.
-          AssertThat(out->max_1level_cut[cut::Internal], Is().GreaterThanOrEqualTo(2u));
-          AssertThat(out->max_1level_cut[cut::Internal], Is().LessThanOrEqualTo(3u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
-          AssertThat(out->max_1level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
-          AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(5u));
-          AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(5u));
-
-          AssertThat(out->max_2level_cut[cut::Internal], Is().GreaterThanOrEqualTo(2u));
-          AssertThat(out->max_2level_cut[cut::Internal], Is().LessThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
-          AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(4u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(3u));
-          AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(5u));
-          AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(5u));
-
-          AssertThat(out->number_of_terminals[false], Is().EqualTo(2u));
-          AssertThat(out->number_of_terminals[true],  Is().EqualTo(3u));
         });
       });
     });

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -3,17 +3,19 @@
 go_bandit([]() {
   describe("adiar/exec_policy.h", []() {
     describe("exec_policy", []() {
-      it("uses expected number of bytes", []() {
-        AssertThat(sizeof(exec_policy),  Is().EqualTo(4u));
-      });
+      it("uses expected number of bytes",
+         []() { AssertThat(sizeof(exec_policy), Is().EqualTo(4u)); });
 
       describe("exec_policy(const __ &)", []() {
         it("is default constructed with default settings", []() {
           exec_policy ep;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -21,9 +23,12 @@ go_bandit([]() {
         it("can be conversion constructed from 'access mode'", []() {
           exec_policy ep = exec_policy::access::Priority_Queue;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -31,9 +36,12 @@ go_bandit([]() {
         it("can be conversion constructed from 'memory mode'", []() {
           exec_policy ep = exec_policy::memory::Internal;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -41,9 +49,12 @@ go_bandit([]() {
         it("can be conversion constructed from 'quantify algorithm'", []() {
           exec_policy ep = exec_policy::quantify::Nested;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -52,47 +63,60 @@ go_bandit([]() {
       describe("set(const __ &)", []() {
         it("can set 'access mode'", []() {
           exec_policy ep;
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
 
           ep.set(exec_policy::access::Random_Access);
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
 
           ep.set(exec_policy::access::Priority_Queue);
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Priority_Queue));
 
           ep.set(exec_policy::access::Auto);
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
         });
 
         it("can set 'memory mode'", []() {
           exec_policy ep;
-          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
 
           ep.set(exec_policy::memory::Internal);
-          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
 
           ep.set(exec_policy::memory::External);
-          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::External));
 
           ep.set(exec_policy::memory::Auto);
-          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
         });
 
         it("can set 'quantify algorithm'", []() {
           exec_policy ep;
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
 
           ep.set(exec_policy::quantify::Nested);
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
 
           ep.set(exec_policy::quantify::Partial);
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Partial));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Partial));
 
           ep.set(exec_policy::quantify::Singleton);
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
 
           ep.set(exec_policy::quantify::Auto);
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can set 'nested::fast reduce epsilon'", []() {
@@ -129,9 +153,12 @@ go_bandit([]() {
             .set(exec_policy::quantify::Singleton)
             .set(exec_policy::nested::fast_reduce(1.0));
 
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
@@ -148,13 +175,13 @@ go_bandit([]() {
         it("matches for (non-default) Adiar v1.0 settings", []() {
           exec_policy ep1;
           ep1.set(exec_policy::quantify::Singleton)
-             .set(exec_policy::memory::External)
-             .set(exec_policy::access::Priority_Queue);
+            .set(exec_policy::memory::External)
+            .set(exec_policy::access::Priority_Queue);
 
           exec_policy ep2;
           ep2.set(exec_policy::access::Priority_Queue)
-             .set(exec_policy::memory::External)
-             .set(exec_policy::quantify::Singleton);
+            .set(exec_policy::memory::External)
+            .set(exec_policy::quantify::Singleton);
 
           AssertThat(ep1, Is().EqualTo(ep2));
         });
@@ -190,57 +217,81 @@ go_bandit([]() {
 
       describe("operator &(const exec_policy&)", []() {
         it("can create a copy with another 'access mode'", []() {
-          const exec_policy in = exec_policy::memory::Internal;
+          const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::access::Random_Access;
 
-          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(in.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(in.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(out.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(out.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can create a copy with another 'memory mode'", []() {
-          const exec_policy in = exec_policy::access::Priority_Queue;
+          const exec_policy in  = exec_policy::access::Priority_Queue;
           const exec_policy out = in & exec_policy::memory::Internal;
 
-          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(in.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(in.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(out.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(out.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can create a copy with another 'quantify algorithm'", []() {
-          const exec_policy in = exec_policy::memory::Internal;
+          const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::quantify::Partial;
 
-          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(in.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(in.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Partial));
+          AssertThat(out.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(out.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Partial));
         });
 
         it("can create a copy with another 'nested::fast reduce epsilon'", []() {
-          const exec_policy in = exec_policy::memory::Internal;
+          const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::nested::fast_reduce(1.0);
 
-          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(in.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(in.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(in.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
 
-          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(out.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(out.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(out.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
@@ -248,9 +299,12 @@ go_bandit([]() {
         it("can lift enum values [access & memory]", []() {
           const exec_policy ep = exec_policy::access::Random_Access & exec_policy::memory::Internal;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -258,29 +312,40 @@ go_bandit([]() {
         it("can lift enum values [memory & access]", []() {
           const exec_policy ep = exec_policy::memory::Internal & exec_policy::access::Random_Access;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
         it("can lift enum values [access & quantify]", []() {
-          const exec_policy ep = exec_policy::access::Random_Access & exec_policy::quantify::Singleton;
+          const exec_policy ep =
+            exec_policy::access::Random_Access & exec_policy::quantify::Singleton;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
         it("can lift enum values [quantify & access]", []() {
-          const exec_policy ep = exec_policy::quantify::Singleton & exec_policy::access::Random_Access;
+          const exec_policy ep =
+            exec_policy::quantify::Singleton & exec_policy::access::Random_Access;
 
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -288,9 +353,12 @@ go_bandit([]() {
         it("can lift enum values [memory & quantify]", []() {
           const exec_policy ep = exec_policy::memory::External & exec_policy::quantify::Nested;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -298,69 +366,96 @@ go_bandit([]() {
         it("can lift enum values [quantify & memory]", []() {
           const exec_policy ep = exec_policy::quantify::Nested & exec_policy::memory::External;
 
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
         it("can lift enum values [access & nested::fast reduce epsilon]", []() {
-          const exec_policy ep = exec_policy::access::Random_Access & exec_policy::nested::fast_reduce(1.0);
+          const exec_policy ep =
+            exec_policy::access::Random_Access & exec_policy::nested::fast_reduce(1.0);
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
 
         it("can lift enum values [nested::fast reduce epsilon & access]", []() {
-          const exec_policy ep = exec_policy::nested::fast_reduce(1.0) & exec_policy::access::Random_Access;
+          const exec_policy ep =
+            exec_policy::nested::fast_reduce(1.0) & exec_policy::access::Random_Access;
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
 
         it("can lift enum values [memory & nested::fast reduce epsilon]", []() {
-          const exec_policy ep = exec_policy::memory::Internal & exec_policy::nested::fast_reduce(1.0);
+          const exec_policy ep =
+            exec_policy::memory::Internal & exec_policy::nested::fast_reduce(1.0);
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
 
         it("can lift enum values [nested::fast reduce epsilon & memory]", []() {
-          const exec_policy ep = exec_policy::nested::fast_reduce(1.0) & exec_policy::memory::External;
+          const exec_policy ep =
+            exec_policy::nested::fast_reduce(1.0) & exec_policy::memory::External;
 
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Auto));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
 
         it("can lift enum values [quantify & nested::fast reduce epsilon]", []() {
-          const exec_policy ep = exec_policy::quantify::Singleton & exec_policy::nested::fast_reduce(1.0);
+          const exec_policy ep =
+            exec_policy::quantify::Singleton & exec_policy::nested::fast_reduce(1.0);
 
-          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
         });
 
         it("can lift enum values [nested::fast reduce epsilon & quantify]", []() {
-          const exec_policy ep = exec_policy::nested::fast_reduce(1.0) & exec_policy::quantify::Nested;
+          const exec_policy ep =
+            exec_policy::nested::fast_reduce(1.0) & exec_policy::quantify::Nested;
 
-          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
         });
       });
     });
   });
- });
+});

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -3,6 +3,10 @@
 go_bandit([]() {
   describe("adiar/exec_policy.h", []() {
     describe("exec_policy", []() {
+      it("uses expected number of bytes", []() {
+        AssertThat(sizeof(exec_policy),  Is().EqualTo(3u));
+      });
+
       describe("set(const __ &)", []() {
         it("is default constructed with default settings", []() {
           exec_policy ep;

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -146,8 +146,8 @@ go_bandit([]() {
 
       describe("operator &(const exec_policy&)", []() {
         it("can create a copy with another 'access mode'", []() {
-          exec_policy in = exec_policy::memory::Internal;
-          exec_policy out = in & exec_policy::access::Random_Access;
+          const exec_policy in = exec_policy::memory::Internal;
+          const exec_policy out = in & exec_policy::access::Random_Access;
 
           AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
           AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
@@ -159,8 +159,8 @@ go_bandit([]() {
         });
 
         it("can create a copy with another 'memory mode'", []() {
-          exec_policy in = exec_policy::access::Priority_Queue;
-          exec_policy out = in & exec_policy::memory::Internal;
+          const exec_policy in = exec_policy::access::Priority_Queue;
+          const exec_policy out = in & exec_policy::memory::Internal;
 
           AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
           AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
@@ -172,8 +172,8 @@ go_bandit([]() {
         });
 
         it("can create a copy with another 'quantify algorithm'", []() {
-          exec_policy in = exec_policy::memory::Internal;
-          exec_policy out = in & exec_policy::quantify::Partial;
+          const exec_policy in = exec_policy::memory::Internal;
+          const exec_policy out = in & exec_policy::quantify::Partial;
 
           AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
           AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
@@ -185,7 +185,7 @@ go_bandit([]() {
         });
 
         it("can lift enum values [access & memory]", []() {
-          exec_policy ep = exec_policy::access::Random_Access & exec_policy::memory::Internal;
+          const exec_policy ep = exec_policy::access::Random_Access & exec_policy::memory::Internal;
 
           AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
           AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
@@ -193,7 +193,7 @@ go_bandit([]() {
         });
 
         it("can lift enum values [memory & access]", []() {
-          exec_policy ep = exec_policy::memory::Internal & exec_policy::access::Random_Access;
+          const exec_policy ep = exec_policy::memory::Internal & exec_policy::access::Random_Access;
 
           AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
           AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
@@ -201,7 +201,7 @@ go_bandit([]() {
         });
 
         it("can lift enum values [access & quantify]", []() {
-          exec_policy ep = exec_policy::access::Random_Access & exec_policy::quantify::Singleton;
+          const exec_policy ep = exec_policy::access::Random_Access & exec_policy::quantify::Singleton;
 
           AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
           AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
@@ -209,7 +209,7 @@ go_bandit([]() {
         });
 
         it("can lift enum values [quantify & access]", []() {
-          exec_policy ep = exec_policy::quantify::Singleton & exec_policy::access::Random_Access;
+          const exec_policy ep = exec_policy::quantify::Singleton & exec_policy::access::Random_Access;
 
           AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Random_Access));
           AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
@@ -217,7 +217,7 @@ go_bandit([]() {
         });
 
         it("can lift enum values [memory & quantify]", []() {
-          exec_policy ep = exec_policy::memory::External & exec_policy::quantify::Nested;
+          const exec_policy ep = exec_policy::memory::External & exec_policy::quantify::Nested;
 
           AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
           AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::External));

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -3,11 +3,33 @@
 go_bandit([]() {
   describe("adiar/exec_policy.h", []() {
     describe("exec_policy", []() {
-      it("uses expected number of bytes",
-         []() { AssertThat(sizeof(exec_policy), Is().EqualTo(12u)); });
+      // TODO: Lots of tests missing for 'quantify::transposition_growth' and 'quantify::transposition_max'
 
-      describe("exec_policy(const __ &)", []() {
-        it("is default constructed with default settings", []() {
+      it("uses expected number of bytes", []() {
+        AssertThat(sizeof(exec_policy), Is().EqualTo(12u));
+      });
+
+      const float default__transposition_growth      = exec_policy::quantify::transposition_growth();
+      const unsigned char default__transposition_max = exec_policy::quantify::transposition_max();
+      const float default__fast_reduce               = exec_policy::nested::fast_reduce();
+
+      describe("exec_policy::_::number wrapper", [&]() {
+        it("'quantify::transposition growth' defaults to a non-negative value", [&]() {
+          AssertThat(default__transposition_growth, Is().GreaterThanOrEqualTo(0.0f));
+        });
+
+        it("'quantify::transposition max' defaults to a non-negative value", [&]() {
+          AssertThat(default__transposition_max, Is().GreaterThanOrEqualTo(0u));
+        });
+
+        it("'nested::fast reduce epsilon' defaults to a value in [-1,1]", [&]() {
+          AssertThat(default__fast_reduce, Is().GreaterThanOrEqualTo(-1.0f));
+          AssertThat(default__fast_reduce, Is().LessThanOrEqualTo(1.0f));
+        });
+      });
+
+      describe("exec_policy(const __ &)", [&]() {
+        it("is default constructed with default settings", [&]() {
           exec_policy ep;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -20,16 +42,16 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(1.5));
+            Is().EqualTo(default__transposition_growth));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
-            Is().EqualTo(1));
+            Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
 
-        it("can be conversion constructed from 'access mode'", []() {
+        it("can be conversion constructed from 'access mode'", [&]() {
           exec_policy ep = exec_policy::access::Priority_Queue;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -41,16 +63,16 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(1.5));
+            Is().EqualTo(default__transposition_growth));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
-            Is().EqualTo(1));
+            Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
 
-        it("can be conversion constructed from 'memory mode'", []() {
+        it("can be conversion constructed from 'memory mode'", [&]() {
           exec_policy ep = exec_policy::memory::Internal;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -62,16 +84,16 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(1.5));
+            Is().EqualTo(default__transposition_growth));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
-            Is().EqualTo(1));
+            Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
 
-        it("can be conversion constructed from 'quantify algorithm'", []() {
+        it("can be conversion constructed from 'quantify algorithm'", [&]() {
           exec_policy ep = exec_policy::quantify::Singleton;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -83,18 +105,20 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Singleton));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(1.5));
+            Is().EqualTo(default__transposition_growth));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
-            Is().EqualTo(1));
+            Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
+
+        // TODO: other values
       });
 
-      describe("set(const __ &)", []() {
-        it("can set 'access mode'", []() {
+      describe("set(const __ &)", [&]() {
+        it("can set 'access mode'", [&]() {
           exec_policy ep;
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
@@ -112,7 +136,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Auto));
         });
 
-        it("can set 'memory mode'", []() {
+        it("can set 'memory mode'", [&]() {
           exec_policy ep;
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Auto));
@@ -130,7 +154,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::memory::Auto));
         });
 
-        it("can set 'quantify algorithm'", []() {
+        it("can set 'quantify algorithm'", [&]() {
           exec_policy ep;
           AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
@@ -144,11 +168,11 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
         });
 
-        it("can set 'quantify::transposition growth epsilon'", []() {
+        it("can set 'quantify::transposition growth epsilon'", [&]() {
           exec_policy ep;
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(1.5));
+            Is().EqualTo(default__transposition_growth));
 
           ep.set(exec_policy::quantify::transposition_growth(4.2));
           AssertThat(
@@ -163,11 +187,11 @@ go_bandit([]() {
         });
         */
 
-        it("can set 'quantify::transposition max delta'", []() {
+        it("can set 'quantify::transposition max delta'", [&]() {
           exec_policy ep;
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
-            Is().EqualTo(1));
+            Is().EqualTo(default__transposition_max));
 
           ep.set(exec_policy::quantify::transposition_max(42));
           AssertThat(
@@ -175,10 +199,10 @@ go_bandit([]() {
             Is().EqualTo(42));
         });
 
-        it("can set 'nested::fast reduce epsilon'", []() {
+        it("can set 'nested::fast reduce epsilon'", [&]() {
           exec_policy ep;
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
 
           ep.set(exec_policy::nested::fast_reduce(0.0));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
@@ -201,7 +225,7 @@ go_bandit([]() {
                      Is().LessThan(0.51));
         });
 
-        it("can set settigs with a builder pattern syntax", []() {
+        it("can set settigs with a builder pattern syntax", [&]() {
           exec_policy ep;
 
           ep.set(exec_policy::access::Priority_Queue)
@@ -220,15 +244,15 @@ go_bandit([]() {
         });
       });
 
-      describe("operator ==(const exec_policy&)", []() {
-        it("matches for default settings", []() {
+      describe("operator ==(const exec_policy&)", [&]() {
+        it("matches for default settings", [&]() {
           exec_policy ep1;
           exec_policy ep2;
 
           AssertThat(ep1, Is().EqualTo(ep2));
         });
 
-        it("matches for (non-default) Adiar v1.0 settings", []() {
+        it("matches for (non-default) Adiar v1.0 settings", [&]() {
           exec_policy ep1;
           ep1.set(exec_policy::quantify::Singleton)
             .set(exec_policy::memory::External)
@@ -242,21 +266,21 @@ go_bandit([]() {
           AssertThat(ep1, Is().EqualTo(ep2));
         });
 
-        it("mismatches on 'access mode'", []() {
+        it("mismatches on 'access mode'", [&]() {
           exec_policy ep1 = exec_policy::access::Priority_Queue;
           exec_policy ep2 = exec_policy::access::Random_Access;
 
           AssertThat(ep1, Is().Not().EqualTo(ep2));
         });
 
-        it("mismatches on 'memory mode'", []() {
+        it("mismatches on 'memory mode'", [&]() {
           exec_policy ep1 = exec_policy::memory::Internal;
           exec_policy ep2 = exec_policy::memory::Auto;
 
           AssertThat(ep1, Is().Not().EqualTo(ep2));
         });
 
-        it("mismatches on 'quantify algorithm'", []() {
+        it("mismatches on 'quantify algorithm'", [&]() {
           exec_policy ep1 = exec_policy::quantify::Nested;
           exec_policy ep2 = exec_policy::quantify::Singleton;
 
@@ -271,8 +295,8 @@ go_bandit([]() {
         });
       });
 
-      describe("operator &(const exec_policy&)", []() {
-        it("can create a copy with another 'access mode'", []() {
+      describe("operator &(const exec_policy&)", [&]() {
+        it("can create a copy with another 'access mode'", [&]() {
           const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::access::Random_Access;
 
@@ -283,7 +307,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Random_Access));
         });
 
-        it("can create a copy with another 'memory mode'", []() {
+        it("can create a copy with another 'memory mode'", [&]() {
           const exec_policy in  = exec_policy::access::Priority_Queue;
           const exec_policy out = in & exec_policy::memory::Internal;
 
@@ -294,7 +318,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::memory::Internal));
         });
 
-        it("can create a copy with another 'quantify algorithm'", []() {
+        it("can create a copy with another 'quantify algorithm'", [&]() {
           const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::quantify::Singleton;
 
@@ -305,7 +329,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Singleton));
         });
 
-        it("can create a copy with another 'nested::fast reduce epsilon'", []() {
+        it("can create a copy with another 'nested::fast reduce epsilon'", [&]() {
           const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::nested::fast_reduce(1.0);
 
@@ -316,7 +340,7 @@ go_bandit([]() {
           AssertThat(in.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(in.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
 
           AssertThat(out.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
@@ -328,7 +352,7 @@ go_bandit([]() {
                      Is().EqualTo(1.0));
         });
 
-        it("can lift enum values [access]", []() {
+        it("can lift enum values [access]", [&]() {
           const exec_policy ep = exec_policy::access::Random_Access & exec_policy::memory::Internal;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -338,10 +362,10 @@ go_bandit([]() {
           AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
 
-        it("can lift enum values [memory]", []() {
+        it("can lift enum values [memory]", [&]() {
           const exec_policy ep = exec_policy::memory::Internal & exec_policy::access::Random_Access;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -351,10 +375,10 @@ go_bandit([]() {
           AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
 
-        it("can lift enum values [quantify::*]", []() {
+        it("can lift enum values [quantify::*]", [&]() {
           const exec_policy ep = exec_policy::quantify::Nested
             & exec_policy::quantify::transposition_growth(4.2)
             & exec_policy::quantify::transposition_max(42);
@@ -375,10 +399,10 @@ go_bandit([]() {
             Is().EqualTo(42));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
+                     Is().EqualTo(default__fast_reduce));
         });
 
-        it("can lift enum values [nested::fast reduce epsilon]", []() {
+        it("can lift enum values [nested::fast reduce epsilon]", [&]() {
           const exec_policy ep =
             exec_policy::nested::fast_reduce(1.0) & exec_policy::quantify::Nested;
 
@@ -392,10 +416,10 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(1.5));
+            Is().EqualTo(default__transposition_growth));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
-            Is().EqualTo(1));
+            Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -4,7 +4,7 @@ go_bandit([]() {
   describe("adiar/exec_policy.h", []() {
     describe("exec_policy", []() {
       it("uses expected number of bytes", []() {
-        AssertThat(sizeof(exec_policy),  Is().EqualTo(3u));
+        AssertThat(sizeof(exec_policy),  Is().EqualTo(4u));
       });
 
       describe("set(const __ &)", []() {

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -3,8 +3,6 @@
 go_bandit([]() {
   describe("adiar/exec_policy.h", []() {
     describe("exec_policy", []() {
-      // TODO: Lots of tests missing for 'quantify::transposition_growth' and 'quantify::transposition_max'
-
       it("uses expected number of bytes", []() {
         AssertThat(sizeof(exec_policy), Is().EqualTo(12u));
       });
@@ -44,7 +42,7 @@ go_bandit([]() {
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(default__transposition_growth));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
@@ -65,7 +63,7 @@ go_bandit([]() {
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(default__transposition_growth));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
@@ -86,14 +84,14 @@ go_bandit([]() {
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(default__transposition_growth));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(default__fast_reduce));
         });
 
-        it("can be conversion constructed from 'quantify algorithm'", [&]() {
+        it("can be conversion constructed from 'quantify::algorithm'", [&]() {
           exec_policy ep = exec_policy::quantify::Singleton;
 
           AssertThat(ep.template get<exec_policy::access>(),
@@ -107,14 +105,75 @@ go_bandit([]() {
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(default__transposition_growth));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(default__fast_reduce));
         });
 
-        // TODO: other values
+        it("can be conversion constructed from 'quantify::transposition growth'", [&]() {
+          exec_policy ep = exec_policy::quantify::transposition_growth(4.2f);
+
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(4.2f));
+          AssertThat(
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(default__transposition_max));
+
+          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
+                     Is().EqualTo(default__fast_reduce));
+        });
+
+        it("can be conversion constructed from 'quantify::transposition max'", [&]() {
+          exec_policy ep = exec_policy::quantify::transposition_max(42);
+
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(default__transposition_growth));
+          AssertThat(
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(42));
+
+          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
+                     Is().EqualTo(default__fast_reduce));
+        });
+
+        it("can be conversion constructed from 'nested::fast reduce epsilon'", [&]() {
+          exec_policy ep = exec_policy::nested::fast_reduce(-1.0);
+
+          AssertThat(ep.template get<exec_policy::access>(),
+                     Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(default__transposition_growth));
+          AssertThat(
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(default__transposition_max));
+
+          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
+                     Is().EqualTo(-1.0));
+        });
       });
 
       describe("set(const __ &)", [&]() {
@@ -190,12 +249,12 @@ go_bandit([]() {
         it("can set 'quantify::transposition max delta'", [&]() {
           exec_policy ep;
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(default__transposition_max));
 
           ep.set(exec_policy::quantify::transposition_max(42));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(42));
         });
 
@@ -231,14 +290,25 @@ go_bandit([]() {
           ep.set(exec_policy::access::Priority_Queue)
             .set(exec_policy::memory::External)
             .set(exec_policy::quantify::Singleton)
+            .set(exec_policy::quantify::transposition_growth(4.2f))
+            .set(exec_policy::quantify::transposition_max(42))
             .set(exec_policy::nested::fast_reduce(1.0));
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Priority_Queue));
+
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::External));
+
           AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(
+                     static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+                     Is().EqualTo(4.2f));
+          AssertThat(
+                     static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
+                     Is().EqualTo(42));
+
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
@@ -280,9 +350,23 @@ go_bandit([]() {
           AssertThat(ep1, Is().Not().EqualTo(ep2));
         });
 
-        it("mismatches on 'quantify algorithm'", [&]() {
+        it("mismatches on 'quantify::algorithm'", [&]() {
           exec_policy ep1 = exec_policy::quantify::Nested;
           exec_policy ep2 = exec_policy::quantify::Singleton;
+
+          AssertThat(ep1, Is().Not().EqualTo(ep2));
+        });
+
+        it("mismatches on 'quantify::transposition growth'", [&]() {
+          exec_policy ep1 = exec_policy::quantify::transposition_growth(4.2f);
+          exec_policy ep2 = exec_policy::quantify::transposition_growth(2.1f);
+
+          AssertThat(ep1, Is().Not().EqualTo(ep2));
+        });
+
+        it("mismatches on 'quantify::transposition max'", [&]() {
+          exec_policy ep1 = exec_policy::quantify::transposition_max(32);
+          exec_policy ep2 = exec_policy::quantify::transposition_max(12);
 
           AssertThat(ep1, Is().Not().EqualTo(ep2));
         });
@@ -318,36 +402,42 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::memory::Internal));
         });
 
-        it("can create a copy with another 'quantify algorithm'", [&]() {
+        it("can create a copy with another 'quantify::*'", [&]() {
           const exec_policy in  = exec_policy::memory::Internal;
-          const exec_policy out = in & exec_policy::quantify::Singleton;
+          const exec_policy out = in & exec_policy::quantify::Singleton
+            & exec_policy::quantify::transposition_growth(4.2f)
+            & exec_policy::quantify::transposition_max(42);
 
           AssertThat(in.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+                     static_cast<float>(in.template get<exec_policy::quantify::transposition_growth>()),
+                     Is().EqualTo(default__transposition_growth));
+          AssertThat(
+                     static_cast<unsigned char>(in.template get<exec_policy::quantify::transposition_max>()),
+                     Is().EqualTo(default__transposition_max));
 
           AssertThat(out.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(
+                     static_cast<float>(out.template get<exec_policy::quantify::transposition_growth>()),
+                     Is().EqualTo(4.2f));
+          AssertThat(
+                     static_cast<unsigned char>(out.template get<exec_policy::quantify::transposition_max>()),
+                     Is().EqualTo(42));
         });
 
         it("can create a copy with another 'nested::fast reduce epsilon'", [&]() {
           const exec_policy in  = exec_policy::memory::Internal;
           const exec_policy out = in & exec_policy::nested::fast_reduce(1.0);
 
-          AssertThat(in.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
           AssertThat(in.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify::algorithm>(),
-                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(in.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(default__fast_reduce));
 
-          AssertThat(out.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
           AssertThat(out.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify::algorithm>(),
-                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(out.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
@@ -395,7 +485,7 @@ go_bandit([]() {
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(4.2f));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(42));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
@@ -418,7 +508,7 @@ go_bandit([]() {
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(default__transposition_growth));
           AssertThat(
-            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            static_cast<unsigned char>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(default__transposition_max));
 
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -7,7 +7,7 @@ go_bandit([]() {
         AssertThat(sizeof(exec_policy),  Is().EqualTo(4u));
       });
 
-      describe("set(const __ &)", []() {
+      describe("exec_policy(const __ &)", []() {
         it("is default constructed with default settings", []() {
           exec_policy ep;
 

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -20,7 +20,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(0.5));
+            Is().EqualTo(1.5));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(1));
@@ -41,7 +41,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(0.5));
+            Is().EqualTo(1.5));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(1));
@@ -62,7 +62,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(0.5));
+            Is().EqualTo(1.5));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(1));
@@ -83,7 +83,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Singleton));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(0.5));
+            Is().EqualTo(1.5));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(1));
@@ -148,13 +148,20 @@ go_bandit([]() {
           exec_policy ep;
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(0.5));
+            Is().EqualTo(1.5));
 
           ep.set(exec_policy::quantify::transposition_growth(4.2));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
             Is().EqualTo(4.2f));
         });
+
+        /* TODO
+        it("throws when setting 'quantify::transposition growth epsilon' to a negative value", []() {
+          exec_policy ep;
+          AssertThrows(invalid_argument, ep.set(exec_policy::quantify::transposition_growth(-42.0)));
+        });
+        */
 
         it("can set 'quantify::transposition max delta'", []() {
           exec_policy ep;
@@ -385,7 +392,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
-            Is().EqualTo(0.5));
+            Is().EqualTo(1.5));
           AssertThat(
             static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
             Is().EqualTo(1));

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -11,80 +11,80 @@ go_bandit([]() {
         it("is default constructed with default settings", []() {
           exec_policy ep;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can be conversion constructed from 'access mode'", []() {
           exec_policy ep = exec_policy::access::Priority_Queue;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can be conversion constructed from 'memory mode'", []() {
           exec_policy ep = exec_policy::memory::Internal;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can be conversion constructed from 'quantify algorithm'", []() {
           exec_policy ep = exec_policy::quantify::Nested;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
         });
       });
 
       describe("set(const __ &)", []() {
         it("can set 'access mode'", []() {
           exec_policy ep;
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
 
           ep.set(exec_policy::access::Random_Access);
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Random_Access));
 
           ep.set(exec_policy::access::Priority_Queue);
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Priority_Queue));
 
           ep.set(exec_policy::access::Auto);
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
         });
 
         it("can set 'memory mode'", []() {
           exec_policy ep;
-          AssertThat(ep.memory_mode(), Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::Auto));
 
           ep.set(exec_policy::memory::Internal);
-          AssertThat(ep.memory_mode(), Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::Internal));
 
           ep.set(exec_policy::memory::External);
-          AssertThat(ep.memory_mode(), Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::External));
 
           ep.set(exec_policy::memory::Auto);
-          AssertThat(ep.memory_mode(), Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::Auto));
         });
 
         it("can set 'quantify algorithm'", []() {
           exec_policy ep;
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
 
           ep.set(exec_policy::quantify::Nested);
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
 
           ep.set(exec_policy::quantify::Partial);
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Partial));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Partial));
 
           ep.set(exec_policy::quantify::Singleton);
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
 
           ep.set(exec_policy::quantify::Auto);
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can set settigs with a builder pattern syntax", []() {
@@ -94,9 +94,9 @@ go_bandit([]() {
             .set(exec_policy::memory::External)
             .set(exec_policy::quantify::Singleton);
 
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(ep.memory_mode(), Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(ep.template get<exec_policy::memory>(), Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
         });
       });
 
@@ -149,87 +149,87 @@ go_bandit([]() {
           exec_policy in = exec_policy::memory::Internal;
           exec_policy out = in & exec_policy::access::Random_Access;
 
-          AssertThat(in.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.access_mode(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(out.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can create a copy with another 'memory mode'", []() {
           exec_policy in = exec_policy::access::Priority_Queue;
           exec_policy out = in & exec_policy::memory::Internal;
 
-          AssertThat(in.access_mode(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(in.memory_mode(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(in.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.access_mode(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(out.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Priority_Queue));
+          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can create a copy with another 'quantify algorithm'", []() {
           exec_policy in = exec_policy::memory::Internal;
           exec_policy out = in & exec_policy::quantify::Partial;
 
-          AssertThat(in.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(in.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(in.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(out.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.quantify_alg(), Is().EqualTo(exec_policy::quantify::Partial));
+          AssertThat(out.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(out.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(out.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Partial));
         });
 
         it("can lift enum values [access & memory]", []() {
           exec_policy ep = exec_policy::access::Random_Access & exec_policy::memory::Internal;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can lift enum values [memory & access]", []() {
           exec_policy ep = exec_policy::memory::Internal & exec_policy::access::Random_Access;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Internal));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can lift enum values [access & quantify]", []() {
           exec_policy ep = exec_policy::access::Random_Access & exec_policy::quantify::Singleton;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
         });
 
         it("can lift enum values [quantify & access]", []() {
           exec_policy ep = exec_policy::quantify::Singleton & exec_policy::access::Random_Access;
 
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Random_Access));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::Auto));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Singleton));
         });
 
         it("can lift enum values [memory & quantify]", []() {
           exec_policy ep = exec_policy::memory::External & exec_policy::quantify::Nested;
 
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(),  Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
         });
 
         it("can lift enum values [quantify & access]", []() {
           exec_policy ep = exec_policy::quantify::Nested & exec_policy::memory::External;
 
-          AssertThat(ep.access_mode(), Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(ep.template get<exec_policy::access>(), Is().EqualTo(exec_policy::access::Auto));
+          AssertThat(ep.template get<exec_policy::memory>(),  Is().EqualTo(exec_policy::memory::External));
+          AssertThat(ep.template get<exec_policy::quantify>(), Is().EqualTo(exec_policy::quantify::Nested));
         });
       });
     });

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -4,7 +4,7 @@ go_bandit([]() {
   describe("adiar/exec_policy.h", []() {
     describe("exec_policy", []() {
       it("uses expected number of bytes",
-         []() { AssertThat(sizeof(exec_policy), Is().EqualTo(4u)); });
+         []() { AssertThat(sizeof(exec_policy), Is().EqualTo(12u)); });
 
       describe("exec_policy(const __ &)", []() {
         it("is default constructed with default settings", []() {
@@ -12,10 +12,19 @@ go_bandit([]() {
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
+
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(0.5));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(1));
+
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -27,8 +36,16 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Priority_Queue));
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(0.5));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(1));
+
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -40,21 +57,37 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Auto));
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(0.5));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(1));
+
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
         it("can be conversion constructed from 'quantify algorithm'", []() {
-          exec_policy ep = exec_policy::quantify::Nested;
+          exec_policy ep = exec_policy::quantify::Singleton;
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Nested));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(0.5));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(1));
+
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
@@ -99,24 +132,40 @@ go_bandit([]() {
 
         it("can set 'quantify algorithm'", []() {
           exec_policy ep;
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
-
-          ep.set(exec_policy::quantify::Nested);
-          AssertThat(ep.template get<exec_policy::quantify>(),
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
 
-          ep.set(exec_policy::quantify::Partial);
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Partial));
-
           ep.set(exec_policy::quantify::Singleton);
-          AssertThat(ep.template get<exec_policy::quantify>(),
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Singleton));
 
-          ep.set(exec_policy::quantify::Auto);
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+          ep.set(exec_policy::quantify::Nested);
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
+        });
+
+        it("can set 'quantify::transposition growth epsilon'", []() {
+          exec_policy ep;
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(0.5));
+
+          ep.set(exec_policy::quantify::transposition_growth(4.2));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(4.2f));
+        });
+
+        it("can set 'quantify::transposition max delta'", []() {
+          exec_policy ep;
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(1));
+
+          ep.set(exec_policy::quantify::transposition_max(42));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(42));
         });
 
         it("can set 'nested::fast reduce epsilon'", []() {
@@ -157,7 +206,7 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Priority_Queue));
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(),
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Singleton));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
@@ -202,7 +251,7 @@ go_bandit([]() {
 
         it("mismatches on 'quantify algorithm'", []() {
           exec_policy ep1 = exec_policy::quantify::Nested;
-          exec_policy ep2 = exec_policy::quantify::Partial;
+          exec_policy ep2 = exec_policy::quantify::Singleton;
 
           AssertThat(ep1, Is().Not().EqualTo(ep2));
         });
@@ -222,55 +271,31 @@ go_bandit([]() {
 
           AssertThat(in.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
 
           AssertThat(out.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(out.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can create a copy with another 'memory mode'", []() {
           const exec_policy in  = exec_policy::access::Priority_Queue;
           const exec_policy out = in & exec_policy::memory::Internal;
 
-          AssertThat(in.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Priority_Queue));
           AssertThat(in.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(in.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
 
-          AssertThat(out.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Priority_Queue));
           AssertThat(out.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
         });
 
         it("can create a copy with another 'quantify algorithm'", []() {
           const exec_policy in  = exec_policy::memory::Internal;
-          const exec_policy out = in & exec_policy::quantify::Partial;
+          const exec_policy out = in & exec_policy::quantify::Singleton;
 
-          AssertThat(in.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(in.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
 
-          AssertThat(out.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(out.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Partial));
+          AssertThat(out.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Singleton));
         });
 
         it("can create a copy with another 'nested::fast reduce epsilon'", []() {
@@ -281,8 +306,8 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Auto));
           AssertThat(in.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(in.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(in.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(in.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
 
@@ -290,170 +315,83 @@ go_bandit([]() {
                      Is().EqualTo(exec_policy::access::Auto));
           AssertThat(out.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(out.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(out.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(out.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(1.0));
         });
 
-        it("can lift enum values [access & memory]", []() {
+        it("can lift enum values [access]", []() {
           const exec_policy ep = exec_policy::access::Random_Access & exec_policy::memory::Internal;
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Random_Access));
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
+                     Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
-        it("can lift enum values [memory & access]", []() {
+        it("can lift enum values [memory]", []() {
           const exec_policy ep = exec_policy::memory::Internal & exec_policy::access::Random_Access;
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Random_Access));
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
-        });
-
-        it("can lift enum values [access & quantify]", []() {
-          const exec_policy ep =
-            exec_policy::access::Random_Access & exec_policy::quantify::Singleton;
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Singleton));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
-        });
-
-        it("can lift enum values [quantify & access]", []() {
-          const exec_policy ep =
-            exec_policy::quantify::Singleton & exec_policy::access::Random_Access;
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Singleton));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(-1.0));
-        });
-
-        it("can lift enum values [memory & quantify]", []() {
-          const exec_policy ep = exec_policy::memory::External & exec_policy::quantify::Nested;
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(),
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
-        it("can lift enum values [quantify & memory]", []() {
-          const exec_policy ep = exec_policy::quantify::Nested & exec_policy::memory::External;
+        it("can lift enum values [quantify::*]", []() {
+          const exec_policy ep = exec_policy::quantify::Nested
+            & exec_policy::quantify::transposition_growth(4.2)
+            & exec_policy::quantify::transposition_max(42);
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
+
           AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(),
+                     Is().EqualTo(exec_policy::memory::Auto));
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(4.2f));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(42));
+
           AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
                      Is().EqualTo(-1.0));
         });
 
-        it("can lift enum values [access & nested::fast reduce epsilon]", []() {
-          const exec_policy ep =
-            exec_policy::access::Random_Access & exec_policy::nested::fast_reduce(1.0);
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(1.0));
-        });
-
-        it("can lift enum values [nested::fast reduce epsilon & access]", []() {
-          const exec_policy ep =
-            exec_policy::nested::fast_reduce(1.0) & exec_policy::access::Random_Access;
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Random_Access));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(1.0));
-        });
-
-        it("can lift enum values [memory & nested::fast reduce epsilon]", []() {
-          const exec_policy ep =
-            exec_policy::memory::Internal & exec_policy::nested::fast_reduce(1.0);
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Internal));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(1.0));
-        });
-
-        it("can lift enum values [nested::fast reduce epsilon & memory]", []() {
-          const exec_policy ep =
-            exec_policy::nested::fast_reduce(1.0) & exec_policy::memory::External;
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Auto));
-          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
-                     Is().EqualTo(1.0));
-        });
-
-        it("can lift enum values [quantify & nested::fast reduce epsilon]", []() {
-          const exec_policy ep =
-            exec_policy::quantify::Singleton & exec_policy::nested::fast_reduce(1.0);
-
-          AssertThat(ep.template get<exec_policy::access>(),
-                     Is().EqualTo(exec_policy::access::Auto));
-          AssertThat(ep.template get<exec_policy::memory>(),
-                     Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
-                     Is().EqualTo(exec_policy::quantify::Singleton));
-        });
-
-        it("can lift enum values [nested::fast reduce epsilon & quantify]", []() {
+        it("can lift enum values [nested::fast reduce epsilon]", []() {
           const exec_policy ep =
             exec_policy::nested::fast_reduce(1.0) & exec_policy::quantify::Nested;
 
           AssertThat(ep.template get<exec_policy::access>(),
                      Is().EqualTo(exec_policy::access::Auto));
+
           AssertThat(ep.template get<exec_policy::memory>(),
                      Is().EqualTo(exec_policy::memory::Auto));
-          AssertThat(ep.template get<exec_policy::quantify>(),
+
+          AssertThat(ep.template get<exec_policy::quantify::algorithm>(),
                      Is().EqualTo(exec_policy::quantify::Nested));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_growth>()),
+            Is().EqualTo(0.5));
+          AssertThat(
+            static_cast<float>(ep.template get<exec_policy::quantify::transposition_max>()),
+            Is().EqualTo(1));
+
+          AssertThat(static_cast<float>(ep.template get<exec_policy::nested::fast_reduce>()),
+                     Is().EqualTo(1.0));
         });
       });
     });

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -87,18 +87,6 @@ go_bandit([]() {
           AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Auto));
         });
 
-        it("can set settigs akin to Adiar v1.0", []() {
-          exec_policy ep;
-
-          ep.set(exec_policy::access::Priority_Queue);
-          ep.set(exec_policy::memory::External);
-          ep.set(exec_policy::quantify::Singleton);
-
-          AssertThat(ep.access_mode(),  Is().EqualTo(exec_policy::access::Priority_Queue));
-          AssertThat(ep.memory_mode(),  Is().EqualTo(exec_policy::memory::External));
-          AssertThat(ep.quantify_alg(), Is().EqualTo(exec_policy::quantify::Singleton));
-        });
-
         it("can set settigs with a builder pattern syntax", []() {
           exec_policy ep;
 

--- a/test/adiar/test_exec_policy.cpp
+++ b/test/adiar/test_exec_policy.cpp
@@ -16,13 +16,24 @@ go_bandit([]() {
           AssertThat(default__transposition_growth, Is().GreaterThanOrEqualTo(0.0f));
         });
 
-        it("'quantify::transposition max' defaults to a non-negative value", [&]() {
-          AssertThat(default__transposition_max, Is().GreaterThanOrEqualTo(0u));
+        it("'quantify::transposition growth' truncates negative values to '0.0f'", [&]() {
+          const exec_policy::quantify::transposition_growth res(-0.5f);
+          AssertThat(static_cast<float>(res), Is().GreaterThanOrEqualTo(0.0f));
         });
 
         it("'nested::fast reduce epsilon' defaults to a value in [-1,1]", [&]() {
           AssertThat(default__fast_reduce, Is().GreaterThanOrEqualTo(-1.0f));
           AssertThat(default__fast_reduce, Is().LessThanOrEqualTo(1.0f));
+        });
+
+        it("'nested::fast reduce epsilon' truncates negative values to '-1.0f'", [&]() {
+          const exec_policy::nested::fast_reduce res(-42.0f);
+          AssertThat(static_cast<float>(res), Is().EqualTo(-1.0f));
+        });
+
+        it("'nested::fast reduce epsilon' truncates positive value to '1.0f'", [&]() {
+          const exec_policy::nested::fast_reduce res(2.0f);
+          AssertThat(static_cast<float>(res), Is().EqualTo(1.0f));
         });
       });
 

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -610,7 +610,7 @@ go_bandit([]() {
 
       describe("algorithm: Nested, max: 1+", [&]() {
         const exec_policy ep = exec_policy::quantify::Nested
-          & exec_policy::quantify::transposition_growth(0.5)
+          & exec_policy::quantify::transposition_growth(1.5)
           & exec_policy::quantify::transposition_max(2);
 
         it("computes with dom = Ø to be { Ø } for non-empty input [zdd_2]", [&](){
@@ -1227,7 +1227,7 @@ go_bandit([]() {
 
         it("switches to Nested Sweeping for exploding ZDD 5", [&]() {
           const exec_policy ep = exec_policy::quantify::Nested
-            & exec_policy::quantify::transposition_growth(0.5)
+            & exec_policy::quantify::transposition_growth(1.5)
             & exec_policy::quantify::transposition_max::max();
 
           std::vector<zdd::label_type> call_history;


### PR DESCRIPTION
Moves heuristic values from Nested Sweeping and Quantification into `exec_policy` (closes #596 ) while also integrating the *fast reduce epsilon* into the Inner Reduce Sweep. We are now almost ready to go searching for a reasonable default value.