### PR TITLE
Preliminary hack to approximate #162 optimisation inside of Quantify

### DIFF
--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -40,13 +40,6 @@ namespace adiar
       return r.uid();
     }
 
-    static inline bdd::pointer_type
-    resolve_terminals(const bdd::pointer_type& a, const bdd::pointer_type& b)
-    {
-      const bool_op& op = ShortcuttingValue ? or_op : and_op;
-      return op(a,b);
-    }
-
   public:
     static inline bool
     keep_terminal(const bdd::pointer_type& p)
@@ -59,6 +52,15 @@ namespace adiar
     {
       return essential(p) == shortcutting_terminal;
     }
+
+    // LCOV_EXCL_START
+    static inline bdd::pointer_type
+    resolve_terminals(const bdd::pointer_type&/*a*/, const bdd::pointer_type&/*b*/)
+    {
+      // Since only a single terminal terminal survives, this piece of code is never executed.
+      adiar_unreachable();
+    }
+    // LCOV_EXCL_STOP
 
   public:
     static inline internal::cut

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -14,13 +14,13 @@
 
 namespace adiar
 {
-  template<bool ShortcuttingValue>
+  template <bool ShortcuttingValue>
   class bdd_quantify_policy : public bdd_policy
   {
   private:
     // Inherit from `bool_op` to hide these compile-time simplifications `bool_op` (see #162)
-    static constexpr bdd::pointer_type shortcutting_terminal = ShortcuttingValue;
-    static constexpr bdd::pointer_type irrelevant_terminal   = !ShortcuttingValue;
+    static constexpr bdd::pointer_type shortcutting_terminal = bdd::pointer_type(ShortcuttingValue);
+    static constexpr bdd::pointer_type irrelevant_terminal = bdd::pointer_type(!ShortcuttingValue);
 
   public:
     static inline bdd::pointer_type
@@ -55,11 +55,12 @@ namespace adiar
 
     // LCOV_EXCL_START
     static inline bdd::pointer_type
-    resolve_terminals(const bdd::pointer_type&/*a*/, const bdd::pointer_type&/*b*/)
+    resolve_terminals(const bdd::pointer_type& /*a*/, const bdd::pointer_type& /*b*/)
     {
       // Since only a single terminal terminal survives, this piece of code is never executed.
       adiar_unreachable();
     }
+
     // LCOV_EXCL_STOP
 
   public:

--- a/src/adiar/internal/algorithms/intercut.h
+++ b/src/adiar/internal/algorithms/intercut.h
@@ -128,8 +128,7 @@ namespace adiar::internal
             const typename intercut_policy::label_type curr_level,
             const typename intercut_policy::label_type next_cut)
     {
-      const typename intercut_policy::label_type target_level =
-        target.is_node() ? target.label() : intercut_policy::max_label + 1;
+      const typename intercut_policy::label_type target_level = target.level();
 
       if (target.is_terminal()
           && !cut_terminal<intercut_policy>(curr_level, next_cut, target.value())) {
@@ -167,7 +166,7 @@ namespace adiar::internal
                   const typename intercut_policy::pointer_type out_target,
                   const typename intercut_policy::label_type l)
   {
-    adiar_assert(out_label <= out_target.label(),
+    adiar_assert(out_label <= out_target.level(),
                  "should forward/output a node on this level or ahead.");
 
     while (pq.can_pull() && pq.top().level() == out_label && pq.top().target() == pq_target) {
@@ -244,7 +243,7 @@ namespace adiar::internal
 
       // Resolve requests that end at the cut for this level
       while (intercut_pq.can_pull()
-             && intercut_pq.peek().target().label() == intercut_pq.peek().level()) {
+             && intercut_pq.peek().target().level() == intercut_pq.peek().level()) {
         while (n.uid() < intercut_pq.top().target()) { n = in_nodes.pull(); }
 
         adiar_assert(n.uid() == intercut_pq.top().target(), "should always find desired node");

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -277,17 +277,20 @@ namespace adiar::internal
     // Set remaining values to nil
     for (size_t i = ts_max_idx + 1; i < ts.size(); ++i) { ts[i] = Policy::pointer_type::nil(); }
 
-    // Is the final element a collapsing terminal?
+    // Is the last surviving element a collapsing terminal?
     const bool max_shortcuts =
       ts[ts_max_idx].is_terminal() && Policy::collapse_to_terminal(ts[ts_max_idx]);
 
     // Are there only terminals left? These should be combined with the operator
-    const bool only_terminals = ts[0].is_terminal() /* sorted => ts[1].is_terminal() */;
+    const bool resolve_terminals =
+      // Are there only terminals left
+      ts[0].is_terminal() /* sorted => ts[1].is_terminal() */
+      // Are there more than one of them?
+      && 0u < ts_max_idx;
 
-    // If there are more than two targets but one of the two apply, then prune it all the way down
-    // to a single target.
-    if (1 <= ts_max_idx && (max_shortcuts || only_terminals)) {
+    if (max_shortcuts || resolve_terminals) {
       ts[0] = max_shortcuts ? ts[ts_max_idx] : Policy::resolve_terminals(ts[0], ts[1]);
+
       for (size_t i = 1u; i <= ts_max_idx; ++i) {
         adiar_assert(!ts[i].is_nil(), "Cannot be nil at i <= ts_max_elem");
         ts[i] = Policy::pointer_type::nil();

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -680,24 +680,21 @@ namespace adiar::internal
 #endif
       using PriorityQueue = PriorityQueueTemplate<0, memory_mode::Internal>;
 
-      return __quantify_ra<NodeRandomAccess, PriorityQueue>(
-        ep, in, policy, pq_memory, max_pq_size);
+      return __quantify_ra<NodeRandomAccess, PriorityQueue>(ep, in, policy, pq_memory, max_pq_size);
     } else if (!external_only && max_pq_size <= pq_memory_fits) {
 #ifdef ADIAR_STATS
       stats_quantify.lpq.internal += 1u;
 #endif
       using PriorityQueue = PriorityQueueTemplate<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>;
 
-      return __quantify_ra<NodeRandomAccess, PriorityQueue>(
-        ep, in, policy, pq_memory, max_pq_size);
+      return __quantify_ra<NodeRandomAccess, PriorityQueue>(ep, in, policy, pq_memory, max_pq_size);
     } else {
 #ifdef ADIAR_STATS
       stats_quantify.lpq.external += 1u;
 #endif
       using PriorityQueue = PriorityQueueTemplate<ADIAR_LPQ_LOOKAHEAD, memory_mode::External>;
 
-      return __quantify_ra<NodeRandomAccess, PriorityQueue>(
-        ep, in, policy, pq_memory, max_pq_size);
+      return __quantify_ra<NodeRandomAccess, PriorityQueue>(ep, in, policy, pq_memory, max_pq_size);
     }
   }
 
@@ -734,8 +731,7 @@ namespace adiar::internal
     // Set up per-level priority queue
     PriorityQueue_2 pq_2(pq_2_memory, max_pq_2_size);
 
-    return __quantify_pq<NodeStream, PriorityQueue_1, PriorityQueue_2>(
-      ep, in, policy, pq_1, pq_2);
+    return __quantify_pq<NodeStream, PriorityQueue_1, PriorityQueue_2>(ep, in, policy, pq_1, pq_2);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -804,13 +800,8 @@ namespace adiar::internal
       using PriorityQueue_1 = PriorityQueue_1_Template<0, memory_mode::Internal>;
       using PriorityQueue_2 = quantify_priority_queue_2_t<memory_mode::Internal>;
 
-      return __quantify_pq<NodeStream, PriorityQueue_1, PriorityQueue_2>(ep,
-                                                                         in,
-                                                                         policy,
-                                                                         pq_1_internal_memory,
-                                                                         max_pq_1_size,
-                                                                         pq_2_internal_memory,
-                                                                         max_pq_2_size);
+      return __quantify_pq<NodeStream, PriorityQueue_1, PriorityQueue_2>(
+        ep, in, policy, pq_1_internal_memory, max_pq_1_size, pq_2_internal_memory, max_pq_2_size);
     } else if (!external_only && max_pq_1_size <= pq_1_memory_fits
                && max_pq_2_size <= pq_2_memory_fits) {
 #ifdef ADIAR_STATS
@@ -819,13 +810,8 @@ namespace adiar::internal
       using PriorityQueue_1 = PriorityQueue_1_Template<ADIAR_LPQ_LOOKAHEAD, memory_mode::Internal>;
       using PriorityQueue_2 = quantify_priority_queue_2_t<memory_mode::Internal>;
 
-      return __quantify_pq<NodeStream, PriorityQueue_1, PriorityQueue_2>(ep,
-                                                                         in,
-                                                                         policy,
-                                                                         pq_1_internal_memory,
-                                                                         max_pq_1_size,
-                                                                         pq_2_internal_memory,
-                                                                         max_pq_2_size);
+      return __quantify_pq<NodeStream, PriorityQueue_1, PriorityQueue_2>(
+        ep, in, policy, pq_1_internal_memory, max_pq_1_size, pq_2_internal_memory, max_pq_2_size);
     } else {
 #ifdef ADIAR_STATS
       stats_quantify.lpq.external += 1u;
@@ -848,9 +834,7 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename Policy>
   typename Policy::__dd_type
-  __quantify(const exec_policy& ep,
-             const typename Policy::dd_type& in,
-             Policy& policy)
+  __quantify(const exec_policy& ep, const typename Policy::dd_type& in, Policy& policy)
   {
     // ---------------------------------------------------------------------------------------------
     // Case: Terminal
@@ -880,8 +864,7 @@ namespace adiar::internal
 #ifdef ADIAR_STATS
       stats_quantify.ra.runs += 1u;
 #endif
-      return __quantify_ra<node_random_access, quantify_priority_queue_1_node_t>(
-        ep, in, policy);
+      return __quantify_ra<node_random_access, quantify_priority_queue_1_node_t>(ep, in, policy);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -899,9 +882,7 @@ namespace adiar::internal
   //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename Policy>
   typename Policy::__dd_type
-  __quantify(const exec_policy& ep,
-             const typename Policy::__dd_type& in,
-             Policy& policy)
+  __quantify(const exec_policy& ep, const typename Policy::__dd_type& in, Policy& policy)
   {
     adiar_assert(in.template has<typename Policy::shared_arc_file_type>(),
                  "__quantify(..., Policy::__dd_type, ...) is only designed for arc-based inputs");
@@ -937,8 +918,7 @@ namespace adiar::internal
 #ifdef ADIAR_STATS
       stats_quantify.ra.runs += 1u;
 #endif
-      return __quantify_ra<node_arc_random_access, quantify_priority_queue_1_arc_t>(
-        ep, in, policy);
+      return __quantify_ra<node_arc_random_access, quantify_priority_queue_1_arc_t>(ep, in, policy);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/src/adiar/internal/data_types/ptr.h
+++ b/src/adiar/internal/data_types/ptr.h
@@ -469,6 +469,7 @@ namespace adiar::internal
     inline label_type
     label() const
     {
+      adiar_assert(is_node());
       return this->level();
     }
 
@@ -480,6 +481,7 @@ namespace adiar::internal
     inline id_type
     id() const
     {
+      adiar_assert(is_node());
       return this->data() >> out_idx_bits;
     }
 
@@ -493,6 +495,7 @@ namespace adiar::internal
     inline out_idx_type
     out_idx() const
     {
+      adiar_assert(is_node());
       return this->data() & static_cast<raw_type>(max_out_idx);
     }
 

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -37,13 +37,7 @@ namespace adiar
       return r.uid();
     }
 
-    static inline zdd::pointer_type
-    resolve_terminals(const zdd::pointer_type &a, const zdd::pointer_type &b)
-    {
-      return or_op(a,b);
-    }
-
-  public:
+    public:
     static inline bool
     keep_terminal(const zdd::pointer_type& p)
     {
@@ -51,9 +45,15 @@ namespace adiar
     }
 
     static constexpr bool
-    collapse_to_terminal(const zdd::pointer_type& /*p*/)
+    collapse_to_terminal(const zdd::pointer_type&/*p*/)
     {
       return false;
+    }
+
+    static inline zdd::pointer_type
+    resolve_terminals(const zdd::pointer_type &a, const zdd::pointer_type &b)
+    {
+      return or_op(a,b);
     }
 
   public:

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -37,7 +37,7 @@ namespace adiar
       return r.uid();
     }
 
-    public:
+  public:
     static inline bool
     keep_terminal(const zdd::pointer_type& p)
     {
@@ -45,15 +45,15 @@ namespace adiar
     }
 
     static constexpr bool
-    collapse_to_terminal(const zdd::pointer_type&/*p*/)
+    collapse_to_terminal(const zdd::pointer_type& /*p*/)
     {
       return false;
     }
 
     static inline zdd::pointer_type
-    resolve_terminals(const zdd::pointer_type &a, const zdd::pointer_type &b)
+    resolve_terminals(const zdd::pointer_type& a, const zdd::pointer_type& b)
     {
-      return or_op(a,b);
+      return or_op(a, b);
     }
 
   public:

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -1,5 +1,6 @@
 #include <utility>
 
+#include <adiar/bool_op.h>
 #include <adiar/zdd.h>
 #include <adiar/zdd/zdd_policy.h>
 
@@ -16,7 +17,7 @@ namespace adiar
   {
   public:
     static inline zdd::pointer_type
-    resolve_root(const zdd::node_type& r, const bool_op& /*op*/)
+    resolve_root(const zdd::node_type& r)
     {
       // TODO: should all but the last case not have a 'suppression taint'?
 
@@ -36,22 +37,28 @@ namespace adiar
       return r.uid();
     }
 
+    static inline zdd::pointer_type
+    resolve_terminals(const zdd::pointer_type &a, const zdd::pointer_type &b)
+    {
+      return or_op(a,b);
+    }
+
   public:
     static inline bool
-    keep_terminal(const bool_op& /*op*/, const zdd::pointer_type& p)
+    keep_terminal(const zdd::pointer_type& p)
     {
       return p.value();
     }
 
     static constexpr bool
-    collapse_to_terminal(const bool_op& /*op*/, const zdd::pointer_type& /*p*/)
+    collapse_to_terminal(const zdd::pointer_type& /*p*/)
     {
       return false;
     }
 
   public:
     static inline internal::cut
-    cut_with_terminals(const bool_op& /*op*/)
+    cut_with_terminals()
     {
       return internal::cut::All;
     }
@@ -64,7 +71,7 @@ namespace adiar
   __zdd
   zdd_project(const exec_policy& ep, const zdd& A, const predicate<zdd::label_type>& dom)
   {
-    return internal::quantify<zdd_project_policy>(ep, A, dom, or_op);
+    return internal::quantify<zdd_project_policy>(ep, A, dom);
   }
 
   __zdd
@@ -76,7 +83,7 @@ namespace adiar
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, const predicate<zdd::label_type>& dom)
   {
-    return internal::quantify<zdd_project_policy>(ep, std::move(A), dom, or_op);
+    return internal::quantify<zdd_project_policy>(ep, std::move(A), dom);
   }
 
   __zdd
@@ -88,7 +95,7 @@ namespace adiar
   __zdd
   zdd_project(const exec_policy& ep, const zdd& A, const generator<zdd::label_type>& dom)
   {
-    return internal::quantify<zdd_project_policy>(ep, A, dom, or_op);
+    return internal::quantify<zdd_project_policy>(ep, A, dom);
   }
 
   __zdd
@@ -100,7 +107,7 @@ namespace adiar
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, const generator<zdd::label_type>& dom)
   {
-    return internal::quantify<zdd_project_policy>(ep, std::move(A), dom, or_op);
+    return internal::quantify<zdd_project_policy>(ep, std::move(A), dom);
   }
 
   __zdd


### PR DESCRIPTION
In the long run, we would want to go back to the previous(ish) code but where the *is-shortcutting* and *is-irrelevant* predicates are specialised at compile-time as described in #162 .