### PR TITLE
Fix 'fast reduce' variable incorrectly is set to 0 as its default

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -109,9 +109,10 @@ jobs:
       matrix:
         include:
           - { category: breakthrough, circuit: 3x4_19_bwnib }
-          - { category: breakthrough, circuit: 3x5_11_bwnib }
-          - { category: domineering,  circuit: 5x5_13_bwnib }
-          - { category: ep,           circuit: 8x8_7_e-8-1_p-3-4_bwnib }
+          - { category: connect4,     circuit: 4x4_9_connect3_bwnib }
+          - { category: domineering,  circuit: 6x6_11_bwnib }
+          - { category: ep,           circuit: 8x8_11_e-8-1_p-2-3_bwnib }
+          - { category: ep_dual,      circuit: 8x8_10_e-8-1_p-3-4_bwnib }
 
     steps:
       - uses: actions/checkout@v2

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -270,7 +270,7 @@ namespace adiar
       public:
         /// \brief Default value construction.
         constexpr fast_reduce()
-          : _value(0.05f)
+          : fast_reduce(0.05f)
         {}
 
         /// \brief Conversion constructor from `float`.

--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -270,7 +270,7 @@ namespace adiar
       public:
         /// \brief Default value construction.
         constexpr fast_reduce()
-          : fast_reduce(0.05f)
+          : fast_reduce(-1.0f)
         {}
 
         /// \brief Conversion constructor from `float`.


### PR DESCRIPTION
The default constructor for `exec_policy::nested::fast_reduce` passes a float `0.05` directly to the *unsigned char* `_value`. This immediately converts it to the value of *0* rather than running it through the `from_float` function as intended.

Based on various experiments, we can also conclude that:
- The epsilon value might need to be different for the inner and the outer Reduce?
- The value for fast reduce seems to better as -1.0 (turned off) or possibly 0.02.