### PR TITLE
Internal/quantify/terminal heuristic  (4)

### DIFF
--- a/src/adiar/exec_policy.h
+++ b/src/adiar/exec_policy.h
@@ -192,7 +192,7 @@ namespace adiar
       public:
         /// \brief Default value construction.
         constexpr transposition_max()
-          : _value(std::numeric_limits<unsigned char>::max())
+          : _value(1)
         {}
 
         /// \brief Wrap an `unsigned char`

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -1329,7 +1329,7 @@ namespace adiar::internal
     const double weighted_terminals = false_weight * false_terminals + true_weight * true_terminals;
 
     const typename Policy::label_type terminal_threshold =
-      (200.0 * weighted_terminals) / total_arcs;
+      (250.0 * weighted_terminals) / total_arcs;
 
     // ---------------------------------------------------------------------------------------------
     // Shallow Variables Heuristic

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -1320,17 +1320,16 @@ namespace adiar::internal
     // Terminal Count Heuristics
 
     const size_t false_weight =
-      1 + Policy::collapse_to_terminal(typename Policy::pointer_type(false));
+      Policy::collapse_to_terminal(typename Policy::pointer_type(false));
 
     const size_t true_weight =
-      1 + Policy::collapse_to_terminal(typename Policy::pointer_type(true));
+      Policy::collapse_to_terminal(typename Policy::pointer_type(true));
 
     const double total_arcs         = 2.0 * size;
     const double weighted_terminals = false_weight * false_terminals + true_weight * true_terminals;
-    const size_t exponent           = 21.0 * (weighted_terminals / total_arcs) + 0.4;
 
     const typename Policy::label_type terminal_threshold =
-      (1u << std::min<size_t>(exponent, log2(2 * Policy::max_label))) - 1u;
+      (200.0 * weighted_terminals) / total_arcs;
 
     // ---------------------------------------------------------------------------------------------
     // Shallow Variables Heuristic


### PR DESCRIPTION
**Changes**
- [x] It now only cares about the shortcutting terminal
- [x] It now also is fully linear such that at least 0.5 percent of all arcs have to be a shortcutting terminal

**TODO**
- [ ] Update unit tests
- [ ] Fix commits are messed up in their content and comments