### PR TITLE
Add terminal pruning for initial transposition sweep

### DIFF
--- a/test/adiar/bdd/test_quantify.cpp
+++ b/test/adiar/bdd/test_quantify.cpp
@@ -134,10 +134,10 @@ go_bandit([]() {
     */
     shared_levelized_file<bdd::node_type> bdd_5;
 
-    const node n5_4 = node(2, node::max_id, ptr_uint64(false), ptr_uint64(true));
-    const node n5_3 = node(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
-    const node n5_2 = node(1, node::max_id, n5_3.uid(), n5_4.uid());
-    const node n5_1 = node(0, node::max_id, ptr_uint64(false), n5_2.uid());
+    const node n5_4(2, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n5_3(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n5_2(1, node::max_id, n5_3.uid(), n5_4.uid());
+    const node n5_1(0, node::max_id, ptr_uint64(false), n5_2.uid());
 
     { // Garbage collect writer to free write-lock
       node_writer nw_5(bdd_5);
@@ -161,26 +161,17 @@ go_bandit([]() {
     shared_levelized_file<bdd::node_type> bdd_6;
 
     { // Garbage collect writer to free write-lock
+      const node n6_8(3, node::max_id, ptr_uint64(false), ptr_uint64(true));
+      const node n6_7(3, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+      const node n6_6(2, node::max_id, n6_8, ptr_uint64(true));
+      const node n6_5(2, node::max_id - 1, n6_7, ptr_uint64(false));
+      const node n6_4(2, node::max_id - 2, ptr_uint64(false), n6_8);
+      const node n6_3(1, node::max_id, n6_4, n6_6);
+      const node n6_2(1, node::max_id - 1, n6_6, n6_5);
+      const node n6_1(0, node::max_id, n6_3, n6_2);
+
       node_writer nw_6(bdd_6);
-      nw_6 << node(3, node::max_id, ptr_uint64(false), ptr_uint64(true))                 // 8
-           << node(3, node::max_id - 1, ptr_uint64(true), ptr_uint64(false))             // 7
-           << node(2, node::max_id, ptr_uint64(3, ptr_uint64::max_id), ptr_uint64(true)) // 6
-           << node(
-                2, node::max_id - 1, ptr_uint64(3, ptr_uint64::max_id - 1), ptr_uint64(false)) // 5
-           << node(2, node::max_id - 2, ptr_uint64(false), ptr_uint64(3, ptr_uint64::max_id))  // 4
-           << node(1,
-                   node::max_id,
-                   ptr_uint64(2, ptr_uint64::max_id - 2),
-                   ptr_uint64(2, ptr_uint64::max_id)) // 3
-           << node(1,
-                   node::max_id - 1,
-                   ptr_uint64(2, ptr_uint64::max_id),
-                   ptr_uint64(2, ptr_uint64::max_id - 1)) // 2
-           << node(0,
-                   node::max_id,
-                   ptr_uint64(1, ptr_uint64::max_id),
-                   ptr_uint64(1, ptr_uint64::max_id - 1)) // 1
-        ;
+      nw_6 << n6_8 << n6_7 << n6_6 << n6_5 << n6_4 << n6_3 << n6_2 << n6_1;
     }
 
     // BDD 6 with an 'x4' instead of T that can collapse to T during the
@@ -188,37 +179,26 @@ go_bandit([]() {
     shared_levelized_file<bdd::node_type> bdd_6_x4T;
 
     { // Garbage collect writer to free write-lock
+      const node n6_9(4, node::max_id, ptr_uint64(false), ptr_uint64(true));
+      const node n6_8(3, node::max_id, ptr_uint64(false), n6_9);
+      const node n6_7(3, node::max_id - 1, n6_9, ptr_uint64(false));
+      const node n6_6(2, node::max_id, n6_8, n6_9);
+      const node n6_5(2, node::max_id - 1, n6_7, ptr_uint64(false));
+      const node n6_4(2, node::max_id - 2, ptr_uint64(false), n6_8);
+      const node n6_3(1, node::max_id, n6_4, n6_6);
+      const node n6_2(1, node::max_id - 1, n6_6, n6_5);
+      const node n6_1(0, node::max_id, n6_3, n6_2);
+
       node_writer nw_6(bdd_6_x4T);
-      nw_6 << node(4, node::max_id, ptr_uint64(false), ptr_uint64(true))                      // T
-           << node(3, node::max_id, ptr_uint64(false), ptr_uint64(4, ptr_uint64::max_id))     // 8
-           << node(3, node::max_id - 1, ptr_uint64(4, ptr_uint64::max_id), ptr_uint64(false)) // 7
-           << node(2,
-                   node::max_id,
-                   ptr_uint64(3, ptr_uint64::max_id),
-                   ptr_uint64(4, ptr_uint64::max_id)) // 6
-           << node(
-                2, node::max_id - 1, ptr_uint64(3, ptr_uint64::max_id - 1), ptr_uint64(false)) // 5
-           << node(2, node::max_id - 2, ptr_uint64(false), ptr_uint64(3, ptr_uint64::max_id))  // 4
-           << node(1,
-                   node::max_id,
-                   ptr_uint64(2, ptr_uint64::max_id - 2),
-                   ptr_uint64(2, ptr_uint64::max_id)) // 3
-           << node(1,
-                   node::max_id - 1,
-                   ptr_uint64(2, ptr_uint64::max_id),
-                   ptr_uint64(2, ptr_uint64::max_id - 1)) // 2
-           << node(0,
-                   node::max_id,
-                   ptr_uint64(1, ptr_uint64::max_id),
-                   ptr_uint64(1, ptr_uint64::max_id - 1)) // 1
-        ;
+      nw_6 << n6_9 << n6_8 << n6_7 << n6_6 << n6_5 << n6_4 << n6_3 << n6_2 << n6_1;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // BDD 7
     /*
-    //          _1_        ---- x0
-    //         /   \
+    //           1         ---- x0
+    //           X
+    //          / \
     //         2   3       ---- x1
     //        / \ / \
     //        \_ | __\
@@ -229,23 +209,15 @@ go_bandit([]() {
     */
     shared_levelized_file<bdd::node_type> bdd_7;
 
+    const node n7_5(2, node::max_id, ptr_uint64(false), ptr_uint64(true));
+    const node n7_4(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false));
+    const node n7_3(1, node::max_id, n7_5, n7_4);
+    const node n7_2(1, node::max_id - 1, n7_4, n7_5);
+    const node n7_1(0, node::max_id, n7_3, n7_2);
+
     { // Garbage collect writer to free write-lock
       node_writer nw_7(bdd_7);
-      nw_7 << node(2, node::max_id, ptr_uint64(false), ptr_uint64(true))     // 5
-           << node(2, node::max_id - 1, ptr_uint64(true), ptr_uint64(false)) // 4
-           << node(1,
-                   node::max_id,
-                   ptr_uint64(2, ptr_uint64::max_id - 1),
-                   ptr_uint64(2, ptr_uint64::max_id)) // 3
-           << node(1,
-                   node::max_id - 1,
-                   ptr_uint64(2, ptr_uint64::max_id),
-                   ptr_uint64(2, ptr_uint64::max_id - 1)) // 2
-           << node(0,
-                   node::max_id,
-                   ptr_uint64(1, ptr_uint64::max_id),
-                   ptr_uint64(1, ptr_uint64::max_id - 1)) // 1
-        ;
+      nw_7 << n7_5 << n7_4 << n7_3 << n7_2 << n7_1;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -2861,7 +2861,11 @@ go_bandit([]() {
           //        / \
           //        T T
           */
-          zdd out = zdd_project(ep, in, [](const zdd::label_type x) { return x == 5; });
+          zdd out = zdd_project(ep, in, [called = false]() mutable -> optional<zdd::label_type> {
+            if (called) { return {}; }
+            called = true;
+            return 5;
+          });
 
           node_test_stream out_nodes(out);
 

--- a/test/adiar/zdd/test_project.cpp
+++ b/test/adiar/zdd/test_project.cpp
@@ -21,8 +21,8 @@ go_bandit([]() {
 
     //////////////////////
     // Non-terminal edge cases
-    ptr_uint64 terminal_F = ptr_uint64(false);
-    ptr_uint64 terminal_T = ptr_uint64(true);
+    const ptr_uint64 terminal_F = ptr_uint64(false);
+    const ptr_uint64 terminal_T = ptr_uint64(true);
 
     // { Ø, {0}, {1}, {1,2}, {1,3}, {1,3,4} }
     /*
@@ -40,13 +40,14 @@ go_bandit([]() {
     */
     shared_levelized_file<zdd::node_type> zdd_1;
     {
+      const node n5(4, node::max_id, terminal_T, terminal_T);
+      const node n4(3, node::max_id, terminal_F, n5.uid());
+      const node n3(2, node::max_id, n4.uid(), terminal_T);
+      const node n2(1, node::max_id, n3.uid(), n3.uid());
+      const node n1(0, node::max_id, n2.uid(), terminal_T);
+
       node_writer nw(zdd_1);
-      nw << node(4, node::max_id, terminal_T, terminal_T)
-         << node(3, node::max_id, terminal_F, ptr_uint64(4, ptr_uint64::max_id))
-         << node(2, node::max_id, ptr_uint64(3, ptr_uint64::max_id), terminal_T)
-         << node(
-              1, node::max_id, ptr_uint64(2, ptr_uint64::max_id), ptr_uint64(2, ptr_uint64::max_id))
-         << node(0, node::max_id, ptr_uint64(1, ptr_uint64::max_id), terminal_T);
+      nw << n5 << n4 << n3 << n2 << n1;
     }
 
     // { {0}, {2}, {0,3}, {2,4} }
@@ -65,14 +66,13 @@ go_bandit([]() {
     */
     shared_levelized_file<zdd::node_type> zdd_2;
     {
+      const node n4(4, node::max_id, terminal_T, terminal_T);
+      const node n3(3, node::max_id, terminal_T, terminal_T);
+      const node n2(2, node::max_id, terminal_F, n4.uid());
+      const node n1(0, node::max_id, n2.uid(), n3.uid());
+
       node_writer nw(zdd_2);
-      nw << node(4, node::max_id, terminal_T, terminal_T)
-         << node(3, node::max_id, terminal_T, terminal_T)
-         << node(2, node::max_id, terminal_F, ptr_uint64(4, ptr_uint64::max_id))
-         << node(0,
-                 node::max_id,
-                 ptr_uint64(2, ptr_uint64::max_id),
-                 ptr_uint64(3, ptr_uint64::max_id));
+      nw << n4 << n3 << n2 << n1;
     }
 
     // { {0}, {2}, {1,2}, {0,2} }
@@ -87,17 +87,13 @@ go_bandit([]() {
     */
     shared_levelized_file<zdd::node_type> zdd_3;
     {
+      const node n4(2, node::max_id, terminal_T, terminal_T);
+      const node n3(2, node::max_id - 1, terminal_F, terminal_T);
+      const node n2(1, node::max_id, n3.uid(), n4.uid());
+      const node n1(0, node::max_id, n2.uid(), n4.uid());
+
       node_writer nw(zdd_3);
-      nw << node(2, node::max_id, terminal_T, terminal_T)
-         << node(2, node::max_id - 1, terminal_F, terminal_T)
-         << node(1,
-                 node::max_id,
-                 ptr_uint64(2, ptr_uint64::max_id - 1),
-                 ptr_uint64(2, ptr_uint64::max_id))
-         << node(0,
-                 node::max_id,
-                 ptr_uint64(1, ptr_uint64::max_id),
-                 ptr_uint64(2, ptr_uint64::max_id));
+      nw << n4 << n3 << n2 << n1;
     }
 
     // { {4}, {0,2}, {0,4}, {2,4}, {0,2,4} }
@@ -112,21 +108,14 @@ go_bandit([]() {
     */
     shared_levelized_file<zdd::node_type> zdd_4;
     {
+      const node n5(4, node::max_id, terminal_T, terminal_T);
+      const node n4(4, node::max_id - 1, terminal_F, terminal_T);
+      const node n3(2, node::max_id, n4.uid(), n5.uid());
+      const node n2(2, node::max_id - 1, n4.uid(), n4.uid());
+      const node n1(0, node::max_id, n2.uid(), n3.uid());
+
       node_writer nw(zdd_4);
-      nw << node(4, node::max_id, terminal_T, terminal_T)
-         << node(4, node::max_id - 1, terminal_F, terminal_T)
-         << node(2,
-                 node::max_id,
-                 ptr_uint64(4, ptr_uint64::max_id - 1),
-                 ptr_uint64(4, ptr_uint64::max_id))
-         << node(2,
-                 node::max_id - 1,
-                 ptr_uint64(4, ptr_uint64::max_id - 1),
-                 ptr_uint64(4, ptr_uint64::max_id - 1))
-         << node(0,
-                 node::max_id,
-                 ptr_uint64(2, ptr_uint64::max_id - 1),
-                 ptr_uint64(2, ptr_uint64::max_id));
+      nw << n5 << n4 << n3 << n2 << n1;
     }
 
     // { ... }


### PR DESCRIPTION
Closes #652 ; the code is feels slightly hacky/ugly. But, it seems more a sign of a deeper problem that ought to be fixed.