### PR TITLE
BDD/RelProd/Apply Transpose

### DIFF
--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -1591,9 +1591,6 @@ namespace adiar
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief Replace variables in *f* according to the mapping in *m*.
-  ///
-  /// \details Unlike the `bdd_replace(const bdd& f, ...)` variants, this saves *2N/B* I/Os by
-  ///          incorporating the renaming into the Reduce algorithm.
   //////////////////////////////////////////////////////////////////////////////////////////////////
   bdd
   bdd_replace(const exec_policy& ep,
@@ -1603,17 +1600,6 @@ namespace adiar
   //////////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief Replace variables in *f* according to the mapping in *m*.
   ///
-  /// \details Unlike the `bdd_replace(const bdd& f, ...)` variants, this saves *2N/B* I/Os by
-  ///          incorporating the renaming into the Reduce algorithm.
-  //////////////////////////////////////////////////////////////////////////////////////////////////
-  bdd
-  bdd_replace(__bdd&& f, const function<bdd::label_type(bdd::label_type)>& m, replace_type m_type);
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////
-  /// \brief Replace variables in *f* according to the mapping in *m*.
-  ///
-  /// \details Unlike the `bdd_replace(const bdd& f, ...)` variants, this saves *2N/B* I/Os by
-  ///          incorporating the renaming into the Reduce algorithm.
   ///
   /// \param f
   ///    Possibly unreduced BDD to replace variables within
@@ -1625,6 +1611,12 @@ namespace adiar
   ///    Guarantees on the class of variable relabelling, e.g. whether it is monotonic.
   ///
   /// \throws invalid_argument if `m_type` classifies `m` as not monotonic.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  bdd
+  bdd_replace(__bdd&& f, const function<bdd::label_type(bdd::label_type)>& m, replace_type m_type);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Replace variables in *f* according to the mapping in *m*.
   //////////////////////////////////////////////////////////////////////////////////////////////////
   bdd
   bdd_replace(const exec_policy& ep,

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -840,7 +840,6 @@ namespace adiar
   {
     return bdd_exists(f, var);
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -855,7 +854,6 @@ namespace adiar
   {
     return bdd_exists(ep, f, var);
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -875,8 +873,13 @@ namespace adiar
   bdd_exists(const bdd& f, const predicate<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_exists(bdd&& f, const predicate<bdd::label_type>& vars);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -886,8 +889,13 @@ namespace adiar
   bdd_exists(const exec_policy& ep, const bdd& f, const predicate<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_exists(const exec_policy& ep, bdd&& f, const predicate<bdd::label_type>& vars);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -906,8 +914,13 @@ namespace adiar
   bdd_exists(const bdd& f, const generator<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_exists(const bdd& f, const generator<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_exists(bdd&& f, const generator<bdd::label_type>& vars);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -917,6 +930,10 @@ namespace adiar
   bdd_exists(const exec_policy& ep, const bdd& f, const generator<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_exists(const exec_policy& ep, bdd&& f, const generator<bdd::label_type>& vars);
 
@@ -951,7 +968,6 @@ namespace adiar
   {
     return bdd_exists(std::move(f), make_generator(begin, end));
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -971,7 +987,6 @@ namespace adiar
   {
     return bdd_exists(ep, std::move(f), make_generator(begin, end));
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -997,7 +1012,6 @@ namespace adiar
   {
     return bdd_forall(f, var);
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1012,7 +1026,6 @@ namespace adiar
   {
     return bdd_forall(ep, f, var);
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1032,8 +1045,13 @@ namespace adiar
   bdd_forall(const bdd& f, const predicate<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_forall(bdd&& f, const predicate<bdd::label_type>& vars);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1043,8 +1061,13 @@ namespace adiar
   bdd_forall(const exec_policy& ep, const bdd& f, const predicate<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_forall(const exec_policy& ep, bdd&& f, const predicate<bdd::label_type>& vars);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1063,8 +1086,13 @@ namespace adiar
   bdd_forall(const bdd& f, const generator<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_forall(bdd&& f, const generator<bdd::label_type>& vars);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1074,6 +1102,10 @@ namespace adiar
   bdd_forall(const exec_policy& ep, const bdd& f, const generator<bdd::label_type>& vars);
 
   /// \cond
+
+  /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
   __bdd
   bdd_forall(const exec_policy& ep, bdd&& f, const generator<bdd::label_type>& vars);
 
@@ -1108,7 +1140,6 @@ namespace adiar
   {
     return bdd_forall(std::move(f), make_generator(begin, end));
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1128,7 +1159,6 @@ namespace adiar
   {
     return bdd_forall(ep, std::move(f), make_generator(begin, end));
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd.h
+++ b/src/adiar/bdd.h
@@ -835,11 +835,16 @@ namespace adiar
   bdd_exists(const bdd& f, bdd::label_type var);
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of a single variable.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   inline __bdd
   bdd_exists(bdd&& f, bdd::label_type var)
   {
     return bdd_exists(f, var);
   }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -849,11 +854,16 @@ namespace adiar
   bdd_exists(const exec_policy& ep, const bdd& f, bdd::label_type var);
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of a single variable.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   inline __bdd
   bdd_exists(const exec_policy& ep, bdd&& f, bdd::label_type var)
   {
     return bdd_exists(ep, f, var);
   }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -874,11 +884,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_exists(bdd&& f, const predicate<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_exists(__bdd&& f, const predicate<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -890,11 +913,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_exists(const exec_policy& ep, bdd&& f, const predicate<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_exists(const exec_policy& ep, __bdd&& f, const predicate<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -915,11 +951,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief     Existential quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_exists(const bdd& f, const generator<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_exists(bdd&& f, const generator<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief     Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, const generator<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_exists(__bdd&& f, const generator<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -931,11 +980,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_exists(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_exists(const exec_policy& ep, bdd&& f, const generator<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, const generator<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_exists(const exec_policy& ep, __bdd&& f, const generator<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -962,12 +1024,34 @@ namespace adiar
   }
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, ForwardIt, ForwardIt)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename ForwardIt>
   __bdd
   bdd_exists(bdd&& f, ForwardIt begin, ForwardIt end)
   {
     return bdd_exists(std::move(f), make_generator(begin, end));
   }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief     Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, ForwardIt, ForwardIt)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template <typename ForwardIt>
+  __bdd
+  bdd_exists(__bdd&& f, ForwardIt begin, ForwardIt end)
+  {
+    return bdd_exists(std::move(f), make_generator(begin, end));
+  }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -981,12 +1065,34 @@ namespace adiar
   }
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, ForwardIt, ForwardIt)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename ForwardIt>
   __bdd
   bdd_exists(const exec_policy& ep, bdd&& f, ForwardIt begin, ForwardIt end)
   {
     return bdd_exists(ep, std::move(f), make_generator(begin, end));
   }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief     Existential quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_exists(const bdd& f, ForwardIt, ForwardIt)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template <typename ForwardIt>
+  __bdd
+  bdd_exists(const exec_policy& ep, __bdd&& f, ForwardIt begin, ForwardIt end)
+  {
+    return bdd_exists(ep, std::move(f), make_generator(begin, end));
+  }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1007,11 +1113,16 @@ namespace adiar
   bdd_forall(const bdd& f, bdd::label_type var);
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of a single variable.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   inline __bdd
   bdd_forall(bdd&& f, bdd::label_type var)
   {
     return bdd_forall(f, var);
   }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1021,11 +1132,16 @@ namespace adiar
   bdd_forall(const exec_policy& ep, const bdd& f, bdd::label_type var);
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of a single variable.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   inline __bdd
   bdd_forall(const exec_policy& ep, bdd&& f, bdd::label_type var)
   {
     return bdd_forall(ep, f, var);
   }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1046,11 +1162,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_forall(bdd&& f, const predicate<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_forall(__bdd&& f, const predicate<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -1062,11 +1191,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_forall(const exec_policy& ep, bdd&& f, const predicate<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_forall(const exec_policy& ep, __bdd&& f, const predicate<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -1087,9 +1229,22 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_forall(bdd&& f, const generator<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, const generator<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_forall(bdd&& f, const generator<bdd::label_type>& vars);
 
@@ -1103,11 +1258,24 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
   /// \remark Unlike `bdd_forall(const bdd& f, const predicate<...>& vars)`, this function moves the
   ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
   ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __bdd
   bdd_forall(const exec_policy& ep, bdd&& f, const generator<bdd::label_type>& vars);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, const generator<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __bdd
+  bdd_forall(const exec_policy& ep, __bdd&& f, const generator<bdd::label_type>& vars);
 
   /// \endcond
 
@@ -1134,12 +1302,34 @@ namespace adiar
   }
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, ForwardIt, ForwardIt)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename ForwardIt>
   __bdd
   bdd_forall(bdd&& f, ForwardIt begin, ForwardIt end)
   {
     return bdd_forall(std::move(f), make_generator(begin, end));
   }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, const generator<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template <typename ForwardIt>
+  __bdd
+  bdd_forall(__bdd&& f, ForwardIt begin, ForwardIt end)
+  {
+    return bdd_forall(std::move(f), make_generator(begin, end));
+  }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1153,12 +1343,34 @@ namespace adiar
   }
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, ForwardIt, ForwardIt)`, this function moves the
+  ///         ownership of `f` into the quantification algorithm. This allows it to garbage collect
+  ///         `f` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename ForwardIt>
   __bdd
   bdd_forall(const exec_policy& ep, bdd&& f, ForwardIt begin, ForwardIt end)
   {
     return bdd_forall(ep, std::move(f), make_generator(begin, end));
   }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Forall quantification of multiple variables.
+  ///
+  /// \remark Unlike `bdd_forall(const bdd& f, const generator<...>& vars)`, this function skips the
+  ///         initial transposition of `f` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template <typename ForwardIt>
+  __bdd
+  bdd_forall(const exec_policy& ep, __bdd&& f, ForwardIt begin, ForwardIt end)
+  {
+    return bdd_forall(ep, std::move(f), make_generator(begin, end));
+  }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adiar/bdd/quantify.cpp
+++ b/src/adiar/bdd/quantify.cpp
@@ -91,6 +91,10 @@ namespace adiar
     return bdd_exists(exec_policy(), f, var);
   }
 
+  // TODO bdd_exists(__bdd&& f, bdd::label_type var)
+  //
+  // Use nested sweeping to skip some of the Reduce step!
+
   __bdd
   bdd_exists(const exec_policy& ep, const bdd& f, const predicate<bdd::label_type>& vars)
   {
@@ -111,6 +115,18 @@ namespace adiar
 
   __bdd
   bdd_exists(bdd&& f, const predicate<bdd::label_type>& vars)
+  {
+    return bdd_exists(exec_policy(), std::move(f), vars);
+  }
+
+  __bdd
+  bdd_exists(const exec_policy& ep, __bdd&& f, const predicate<bdd::label_type>& vars)
+  {
+    return internal::quantify<bdd_quantify_policy<true>>(ep, std::move(f), vars);
+  }
+
+  __bdd
+  bdd_exists(__bdd&& f, const predicate<bdd::label_type>& vars)
   {
     return bdd_exists(exec_policy(), std::move(f), vars);
   }
@@ -139,6 +155,18 @@ namespace adiar
     return bdd_exists(exec_policy(), std::move(f), vars);
   }
 
+  __bdd
+  bdd_exists(const exec_policy& ep, __bdd&& f, const generator<bdd::label_type>& vars)
+  {
+    return internal::quantify<bdd_quantify_policy<true>>(ep, std::move(f), vars);
+  }
+
+  __bdd
+  bdd_exists(__bdd&& f, const generator<bdd::label_type>& vars)
+  {
+    return bdd_exists(exec_policy(), std::move(f), vars);
+  }
+
   //////////////////////////////////////////////////////////////////////////////
 
   __bdd
@@ -152,6 +180,10 @@ namespace adiar
   {
     return bdd_forall(exec_policy(), f, var);
   }
+
+  // TODO bdd_forall(__bdd&& f, bdd::label_type var)
+  //
+  // Use nested sweeping to skip some of the Reduce step!
 
   __bdd
   bdd_forall(const exec_policy& ep, const bdd& f, const predicate<bdd::label_type>& vars)
@@ -178,6 +210,18 @@ namespace adiar
   }
 
   __bdd
+  bdd_forall(const exec_policy& ep, __bdd&& f, const predicate<bdd::label_type>& vars)
+  {
+    return internal::quantify<bdd_quantify_policy<false>>(ep, std::move(f), vars);
+  }
+
+  __bdd
+  bdd_forall(__bdd&& f, const predicate<bdd::label_type>& vars)
+  {
+    return bdd_forall(exec_policy(), std::move(f), vars);
+  }
+
+  __bdd
   bdd_forall(const exec_policy& ep, const bdd& f, const generator<bdd::label_type>& vars)
   {
     return internal::quantify<bdd_quantify_policy<false>>(ep, f, vars);
@@ -197,6 +241,18 @@ namespace adiar
 
   __bdd
   bdd_forall(bdd&& f, const generator<bdd::label_type>& vars)
+  {
+    return bdd_forall(exec_policy(), std::move(f), vars);
+  }
+
+  __bdd
+  bdd_forall(const exec_policy& ep, __bdd&& f, const generator<bdd::label_type>& vars)
+  {
+    return internal::quantify<bdd_quantify_policy<false>>(ep, std::move(f), vars);
+  }
+
+  __bdd
+  bdd_forall(__bdd&& f, const generator<bdd::label_type>& vars)
   {
     return bdd_forall(exec_policy(), std::move(f), vars);
   }

--- a/src/adiar/bdd/relprod.cpp
+++ b/src/adiar/bdd/relprod.cpp
@@ -28,13 +28,13 @@ namespace adiar
               const function<optional<bdd::label_type>(bdd::label_type)>& m,
               replace_type m_type)
   {
-    const bdd tmp_1 = bdd_and(ep, states, relation);
+    __bdd tmp_1 = bdd_and(ep, states, relation);
 
     const bdd tmp_2 =
       bdd_exists(ep, std::move(tmp_1), [&m](bdd::label_type x) { return !m(x).has_value(); });
 
-    const bdd tmp_3 =
-      bdd_replace(ep, std::move(tmp_2), [&m](bdd::label_type x) { return m(x).value(); }, m_type);
+    const bdd tmp_3 = bdd_replace(
+      ep, std::move(tmp_2), [&m](bdd::label_type x) { return m(x).value(); }, m_type);
 
     return tmp_3;
   }
@@ -77,10 +77,10 @@ namespace adiar
               const function<optional<bdd::label_type>(bdd::label_type)>& m,
               replace_type m_type)
   {
-    const bdd tmp_1 =
-      bdd_replace(ep, states, [&m](bdd::label_type x) { return m(x).value(); }, m_type);
+    const bdd tmp_1 = bdd_replace(
+      ep, states, [&m](bdd::label_type x) { return m(x).value(); }, m_type);
 
-    const bdd tmp_2 = bdd_and(ep, std::move(tmp_1), relation);
+    __bdd tmp_2 = bdd_and(ep, std::move(tmp_1), relation);
 
     const bdd tmp_3 =
       bdd_exists(ep, std::move(tmp_2), [&m](bdd::label_type x) { return !m(x).has_value(); });

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -985,11 +985,26 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
   /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function moves the
   ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
   ///         `A` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __zdd
   zdd_project(zdd&& A, const predicate<zdd::label_type>& dom);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function skips the
+  ///         initial transposition of `A` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __zdd
+  zdd_project(__zdd&& A, const predicate<zdd::label_type>& dom);
 
   /// \endcond
 
@@ -1002,11 +1017,26 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
   /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function moves the
   ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
   ///         `A` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, const predicate<zdd::label_type>& dom);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function skips the
+  ///         initial transposition of `A` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __zdd
+  zdd_project(const exec_policy& ep, __zdd&& A, const predicate<zdd::label_type>& dom);
 
   /// \endcond
 
@@ -1030,11 +1060,26 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
   /// \remark Unlike `zdd_project(const zdd& A, const generator<...>& dom)`, this function moves the
   ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
   ///         `A` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __zdd
   zdd_project(zdd&& A, const generator<zdd::label_type>& dom);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, const generator<...>& dom)`, this function skips the
+  ///         initial transposition of `A` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __zdd
+  zdd_project(__zdd&& A, const generator<zdd::label_type>& dom);
 
   /// \endcond
 
@@ -1047,11 +1092,26 @@ namespace adiar
 
   /// \cond
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
   /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function moves the
   ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
   ///         `A` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, const generator<zdd::label_type>& dom);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, const generator<...>& dom)`, this function skips the
+  ///         initial transposition of `A` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  __zdd
+  zdd_project(const exec_policy& ep, __zdd&& A, const generator<zdd::label_type>& dom);
 
   /// \endcond
 
@@ -1081,12 +1141,36 @@ namespace adiar
   }
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, ForwardIt, ForwardIt)`, this function moves the
+  ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
+  ///         `A` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename ForwardIt>
   __zdd
   zdd_project(zdd&& A, ForwardIt begin, ForwardIt end)
   {
     return zdd_project(std::move(A), make_generator(begin, end));
   }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, ForwardIt, ForwardIt)`, this function skips the
+  ///         initial transposition of `A` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template <typename ForwardIt>
+  __zdd
+  zdd_project(__zdd&& A, ForwardIt begin, ForwardIt end)
+  {
+    return zdd_project(std::move(A), make_generator(begin, end));
+  }
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1101,12 +1185,36 @@ namespace adiar
   }
 
   /// \cond
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, ForwardIt, ForwardIt)`, this function moves the
+  ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
+  ///         `A` early.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename ForwardIt>
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, ForwardIt begin, ForwardIt end)
   {
     return zdd_project(ep, std::move(A), make_generator(begin, end));
   }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /// \brief Project family of sets onto a domain, i.e. remove from every set all variables not
+  ///        within the domain.
+  ///
+  /// \remark Unlike `zdd_project(const zdd& A, ForwardIt, ForwardIt)`, this function skips the
+  ///         initial transposition of `A` if possible.
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template <typename ForwardIt>
+  __zdd
+  zdd_project(const exec_policy& ep, __zdd&& A, ForwardIt begin, ForwardIt end)
+  {
+    return zdd_project(ep, std::move(A), make_generator(begin, end));
+  }
+
   /// \endcond
 
   /// \}

--- a/src/adiar/zdd.h
+++ b/src/adiar/zdd.h
@@ -984,8 +984,13 @@ namespace adiar
   zdd_project(const zdd& A, const predicate<zdd::label_type>& dom);
 
   /// \cond
+
+  /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function moves the
+  ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
+  ///         `A` early.
   __zdd
   zdd_project(zdd&& A, const predicate<zdd::label_type>& dom);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -996,8 +1001,13 @@ namespace adiar
   zdd_project(const exec_policy& ep, const zdd& A, const predicate<zdd::label_type>& dom);
 
   /// \cond
+
+  /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function moves the
+  ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
+  ///         `A` early.
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, const predicate<zdd::label_type>& dom);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1019,8 +1029,13 @@ namespace adiar
   zdd_project(const zdd& A, const generator<zdd::label_type>& dom);
 
   /// \cond
+
+  /// \remark Unlike `zdd_project(const zdd& A, const generator<...>& dom)`, this function moves the
+  ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
+  ///         `A` early.
   __zdd
   zdd_project(zdd&& A, const generator<zdd::label_type>& dom);
+
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1031,6 +1046,10 @@ namespace adiar
   zdd_project(const exec_policy& ep, const zdd& A, const generator<zdd::label_type>& dom);
 
   /// \cond
+
+  /// \remark Unlike `zdd_project(const zdd& A, const predicate<...>& dom)`, this function moves the
+  ///         ownership of `A` into the quantification algorithm. This allows it to garbage collect
+  ///         `A` early.
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, const generator<zdd::label_type>& dom);
 
@@ -1066,9 +1085,8 @@ namespace adiar
   __zdd
   zdd_project(zdd&& A, ForwardIt begin, ForwardIt end)
   {
-    return zdd_project(std::forward<zdd>(A), make_generator(begin, end));
+    return zdd_project(std::move(A), make_generator(begin, end));
   }
-
   /// \endcond
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1087,9 +1105,8 @@ namespace adiar
   __zdd
   zdd_project(const exec_policy& ep, zdd&& A, ForwardIt begin, ForwardIt end)
   {
-    return zdd_project(ep, std::forward<zdd>(A), make_generator(begin, end));
+    return zdd_project(ep, std::move(A), make_generator(begin, end));
   }
-
   /// \endcond
 
   /// \}

--- a/src/adiar/zdd/project.cpp
+++ b/src/adiar/zdd/project.cpp
@@ -92,6 +92,18 @@ namespace adiar
   }
 
   __zdd
+  zdd_project(const exec_policy& ep, __zdd&& A, const predicate<zdd::label_type>& dom)
+  {
+    return internal::quantify<zdd_project_policy>(ep, std::move(A), dom);
+  }
+
+  __zdd
+  zdd_project(__zdd&& A, const predicate<zdd::label_type>& dom)
+  {
+    return zdd_project(exec_policy(), std::move(A), dom);
+  }
+
+  __zdd
   zdd_project(const exec_policy& ep, const zdd& A, const generator<zdd::label_type>& dom)
   {
     return internal::quantify<zdd_project_policy>(ep, A, dom);
@@ -111,6 +123,18 @@ namespace adiar
 
   __zdd
   zdd_project(zdd&& A, const generator<zdd::label_type>& dom)
+  {
+    return zdd_project(exec_policy(), std::move(A), dom);
+  }
+
+  __zdd
+  zdd_project(const exec_policy& ep, __zdd&& A, const generator<zdd::label_type>& dom)
+  {
+    return internal::quantify<zdd_project_policy>(ep, std::move(A), dom);
+  }
+
+  __zdd
+  zdd_project(__zdd&& A, const generator<zdd::label_type>& dom)
   {
     return zdd_project(exec_policy(), std::move(A), dom);
   }

--- a/test/adiar/bdd/test_relprod.cpp
+++ b/test/adiar/bdd/test_relprod.cpp
@@ -1139,12 +1139,14 @@ go_bandit([]() {
         AssertThat(out->width, Is().EqualTo(1u));
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
@@ -1197,12 +1199,14 @@ go_bandit([]() {
         AssertThat(out->width, Is().EqualTo(1u));
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
@@ -2325,12 +2329,14 @@ go_bandit([]() {
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
@@ -2388,12 +2394,14 @@ go_bandit([]() {
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
@@ -4359,12 +4367,14 @@ go_bandit([]() {
         AssertThat(out->width, Is().EqualTo(1u));
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
@@ -4401,12 +4411,14 @@ go_bandit([]() {
         AssertThat(out->width, Is().EqualTo(1u));
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
@@ -4847,12 +4859,14 @@ go_bandit([]() {
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
@@ -4889,12 +4903,14 @@ go_bandit([]() {
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));
@@ -5274,12 +5290,14 @@ go_bandit([]() {
         AssertThat(out->width, Is().EqualTo(1u));
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_False], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
@@ -5598,12 +5616,14 @@ go_bandit([]() {
 
         AssertThat(out->max_1level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_1level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_1level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_1level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_1level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->max_2level_cut[cut::Internal], Is().EqualTo(1u));
         AssertThat(out->max_2level_cut[cut::Internal_False], Is().EqualTo(1u));
-        AssertThat(out->max_2level_cut[cut::Internal_True], Is().EqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().GreaterThanOrEqualTo(2u));
+        AssertThat(out->max_2level_cut[cut::Internal_True], Is().LessThanOrEqualTo(3u));
         AssertThat(out->max_2level_cut[cut::All], Is().EqualTo(3u));
 
         AssertThat(out->number_of_terminals[false], Is().EqualTo(1u));

--- a/test/adiar/zdd/test_change.cpp
+++ b/test/adiar/zdd/test_change.cpp
@@ -1392,71 +1392,71 @@ go_bandit([]() {
                    Is().EqualTo(2u));
       });
 
-      it("correctly connects pre-root chain with skipped root for { { 1 }, { 1,2 } } on (0,1)",
-         [&]() {
-           shared_levelized_file<zdd::node_type> in;
-           /*
-           //          1     ---- x1
-           //         / \
-           //         F 2    ---- x2
-           //          / \
-           //          T T
-           */
+      it(
+        "correctly connects pre-root chain with skipped root for { { 1 }, { 1,2 } } on (0,1)",
+        [&]() {
+          shared_levelized_file<zdd::node_type> in;
+          /*
+          //          1     ---- x1
+          //         / \
+          //         F 2    ---- x2
+          //          / \
+          //          T T
+          */
 
-           const node n2 = node(2, node::max_id, terminal_T, terminal_T);
-           const node n1 = node(1, node::max_id, terminal_F, n2.uid());
+          const node n2 = node(2, node::max_id, terminal_T, terminal_T);
+          const node n1 = node(1, node::max_id, terminal_F, n2.uid());
 
-           {
-             node_writer nw(in);
-             nw << n2 << n1;
-           }
+          {
+            node_writer nw(in);
+            nw << n2 << n1;
+          }
 
-           const std::vector<int> vars = { 0, 1 };
+          const std::vector<int> vars = { 0, 1 };
 
-           __zdd out = zdd_change(in, vars.begin(), vars.end());
+          __zdd out = zdd_change(in, vars.begin(), vars.end());
 
-           arc_test_stream arcs(out);
+          arc_test_stream arcs(out);
 
-           AssertThat(arcs.can_pull_internal(), Is().True());
-           AssertThat(arcs.pull_internal(),
-                      Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 0) }));
+          AssertThat(arcs.can_pull_internal(), Is().True());
+          AssertThat(arcs.pull_internal(),
+                     Is().EqualTo(arc{ ptr_uint64(0, 0), true, ptr_uint64(2, 0) }));
 
-           AssertThat(arcs.can_pull_internal(), Is().False());
+          AssertThat(arcs.can_pull_internal(), Is().False());
 
-           AssertThat(arcs.can_pull_terminal(), Is().True());
-           AssertThat(arcs.pull_terminal(),
-                      Is().EqualTo(arc{ ptr_uint64(0, 0), false, terminal_F }));
+          AssertThat(arcs.can_pull_terminal(), Is().True());
+          AssertThat(arcs.pull_terminal(),
+                     Is().EqualTo(arc{ ptr_uint64(0, 0), false, terminal_F }));
 
-           AssertThat(arcs.can_pull_terminal(), Is().True());
-           AssertThat(arcs.pull_terminal(),
-                      Is().EqualTo(arc{ ptr_uint64(2, 0), false, terminal_T }));
+          AssertThat(arcs.can_pull_terminal(), Is().True());
+          AssertThat(arcs.pull_terminal(),
+                     Is().EqualTo(arc{ ptr_uint64(2, 0), false, terminal_T }));
 
-           AssertThat(arcs.can_pull_terminal(), Is().True());
-           AssertThat(arcs.pull_terminal(),
-                      Is().EqualTo(arc{ ptr_uint64(2, 0), true, terminal_T }));
+          AssertThat(arcs.can_pull_terminal(), Is().True());
+          AssertThat(arcs.pull_terminal(), Is().EqualTo(arc{ ptr_uint64(2, 0), true, terminal_T }));
 
-           AssertThat(arcs.can_pull_terminal(), Is().False());
+          AssertThat(arcs.can_pull_terminal(), Is().False());
 
-           level_info_test_stream levels(out);
+          level_info_test_stream levels(out);
 
-           AssertThat(levels.can_pull(), Is().True());
-           AssertThat(levels.pull(), Is().EqualTo(level_info(0, 1u)));
+          AssertThat(levels.can_pull(), Is().True());
+          AssertThat(levels.pull(), Is().EqualTo(level_info(0, 1u)));
 
-           AssertThat(levels.can_pull(), Is().True());
-           AssertThat(levels.pull(), Is().EqualTo(level_info(2, 1u)));
+          AssertThat(levels.can_pull(), Is().True());
+          AssertThat(levels.pull(), Is().EqualTo(level_info(2, 1u)));
 
-           AssertThat(levels.can_pull(), Is().False());
+          AssertThat(levels.can_pull(), Is().False());
 
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->width, Is().EqualTo(1u));
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->width, Is().EqualTo(1u));
 
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->max_1level_cut,
-                      Is().GreaterThanOrEqualTo(1u));
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->max_1level_cut,
+                     Is().GreaterThanOrEqualTo(1u));
 
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[false],
-                      Is().EqualTo(1u));
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[true],
-                      Is().EqualTo(2u));
-         });
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[false],
+                     Is().EqualTo(1u));
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[true],
+                     Is().EqualTo(2u));
+        });
 
       it("cuts collapse of root to a terminal for { { 0 } } on (0,1)", [&]() {
         shared_levelized_file<zdd::node_type> in;
@@ -1549,54 +1549,54 @@ go_bandit([]() {
                    Is().EqualTo(1u));
       });
 
-      it("keeps pre-root chain despite collapse to a terminal of the root for { { 1 } } on (0,1)",
-         [&]() {
-           shared_levelized_file<zdd::node_type> in;
-           /*
-           //          1     ---- x1
-           //         / \
-           //         F T
-           */
-           { // Garbage collect writer to free write-lock
-             node_writer nw(in);
-             nw << node(1, node::max_id, terminal_F, terminal_T);
-           }
+      it(
+        "keeps pre-root chain despite collapse to a terminal of the root for { { 1 } } on (0,1)",
+        [&]() {
+          shared_levelized_file<zdd::node_type> in;
+          /*
+          //          1     ---- x1
+          //         / \
+          //         F T
+          */
+          { // Garbage collect writer to free write-lock
+            node_writer nw(in);
+            nw << node(1, node::max_id, terminal_F, terminal_T);
+          }
 
-           const std::vector<int> vars = { 0, 1 };
+          const std::vector<int> vars = { 0, 1 };
 
-           __zdd out = zdd_change(in, vars.begin(), vars.end());
+          __zdd out = zdd_change(in, vars.begin(), vars.end());
 
-           arc_test_stream arcs(out);
+          arc_test_stream arcs(out);
 
-           AssertThat(arcs.can_pull_internal(), Is().False());
+          AssertThat(arcs.can_pull_internal(), Is().False());
 
-           AssertThat(arcs.can_pull_terminal(), Is().True());
-           AssertThat(arcs.pull_terminal(),
-                      Is().EqualTo(arc{ ptr_uint64(0, 0), false, terminal_F }));
+          AssertThat(arcs.can_pull_terminal(), Is().True());
+          AssertThat(arcs.pull_terminal(),
+                     Is().EqualTo(arc{ ptr_uint64(0, 0), false, terminal_F }));
 
-           AssertThat(arcs.can_pull_terminal(), Is().True());
-           AssertThat(arcs.pull_terminal(),
-                      Is().EqualTo(arc{ ptr_uint64(0, 0), true, terminal_T }));
+          AssertThat(arcs.can_pull_terminal(), Is().True());
+          AssertThat(arcs.pull_terminal(), Is().EqualTo(arc{ ptr_uint64(0, 0), true, terminal_T }));
 
-           AssertThat(arcs.can_pull_terminal(), Is().False());
+          AssertThat(arcs.can_pull_terminal(), Is().False());
 
-           level_info_test_stream levels(out);
+          level_info_test_stream levels(out);
 
-           AssertThat(levels.can_pull(), Is().True());
-           AssertThat(levels.pull(), Is().EqualTo(level_info(0, 1u)));
+          AssertThat(levels.can_pull(), Is().True());
+          AssertThat(levels.pull(), Is().EqualTo(level_info(0, 1u)));
 
-           AssertThat(levels.can_pull(), Is().False());
+          AssertThat(levels.can_pull(), Is().False());
 
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->width, Is().EqualTo(1u));
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->width, Is().EqualTo(1u));
 
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->max_1level_cut,
-                      Is().GreaterThanOrEqualTo(0u));
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->max_1level_cut,
+                     Is().GreaterThanOrEqualTo(0u));
 
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[false],
-                      Is().EqualTo(1u));
-           AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[true],
-                      Is().EqualTo(1u));
-         });
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[false],
+                     Is().EqualTo(1u));
+          AssertThat(out.get<__zdd::shared_arc_file_type>()->number_of_terminals[true],
+                     Is().EqualTo(1u));
+        });
     });
   });
 });


### PR DESCRIPTION
Optimisation from #502 : Skips the *transposition step* of the `bdd_exists` by using the unreduced (and already transposed) output of `bdd_and`.