### PR TITLE
BDD/RelNext/Renaming

### DIFF
--- a/src/adiar/internal/algorithms/nested_sweeping.h
+++ b/src/adiar/internal/algorithms/nested_sweeping.h
@@ -1721,6 +1721,8 @@ namespace adiar::internal
       adiar_assert(next_inner == inner_iter_t::end || next_inner <= outer_level.level(),
                    "next_inner level should (if it exists) be above current level (inclusive).");
 
+      const level_type out_level = policy_impl.map_level(outer_level.level());
+
       // -------------------------------------------------------------------------------------------
       // CASE: Unnested Level with no nested sweep above:
       //   Reduce this level (without decorators).
@@ -1736,6 +1738,7 @@ namespace adiar::internal
 
           nested_sweeping::__reduce_level__fast<nesting_policy>(outer_arcs,
                                                                 outer_level.level(),
+                                                                out_level,
                                                                 outer_pq,
                                                                 outer_writer,
                                                                 nested_sweeping::stats.outer_up);
@@ -1745,6 +1748,7 @@ namespace adiar::internal
           if (unreduced_width <= outer_internal_sorter_can_fit) {
             __reduce_level<nesting_policy, internal_sorter>(outer_arcs,
                                                             outer_level.level(),
+                                                            out_level,
                                                             outer_pq,
                                                             outer_writer,
                                                             outer_sorters_memory,
@@ -1753,6 +1757,7 @@ namespace adiar::internal
           } else {
             __reduce_level<nesting_policy, external_sorter>(outer_arcs,
                                                             outer_level.level(),
+                                                            out_level,
                                                             outer_pq,
                                                             outer_writer,
                                                             outer_sorters_memory,
@@ -1781,6 +1786,7 @@ namespace adiar::internal
 
           nested_sweeping::__reduce_level__fast<nesting_policy>(outer_arcs,
                                                                 outer_level.level(),
+                                                                out_level,
                                                                 outer_pq_decorator,
                                                                 outer_writer,
                                                                 nested_sweeping::stats.outer_up);
@@ -1790,6 +1796,7 @@ namespace adiar::internal
           if (unreduced_width <= outer_internal_sorter_can_fit) {
             __reduce_level<nesting_policy, internal_sorter>(outer_arcs,
                                                             outer_level.level(),
+                                                            out_level,
                                                             outer_pq_decorator,
                                                             outer_writer,
                                                             outer_sorters_memory,
@@ -1798,6 +1805,7 @@ namespace adiar::internal
           } else {
             __reduce_level<nesting_policy, external_sorter>(outer_arcs,
                                                             outer_level.level(),
+                                                            out_level,
                                                             outer_pq_decorator,
                                                             outer_writer,
                                                             outer_sorters_memory,

--- a/src/adiar/internal/algorithms/quantify.h
+++ b/src/adiar/internal/algorithms/quantify.h
@@ -1066,7 +1066,7 @@ namespace adiar::internal
     ////////////////////////////////////////////////////////////////////////////////////////////////
     static constexpr bool partial_quantification = false;
 
-    // bool has_sweep(typename Policy::label_type) const;
+    // bool has_sweep(const typename Policy::label_type x) const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     /// \brief What the labels should be mapped to (themselves).
@@ -1348,12 +1348,12 @@ namespace adiar::internal
 
   public:
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    /// \brief Whether the generator wants to sweep on the given level.
+    /// \brief Whether the predicate wants to sweep on the given level.
     ////////////////////////////////////////////////////////////////////////////////////////////////
     bool
-    has_sweep(node::pointer_type::label_type l)
+    has_sweep(const typename Policy::label_type x)
     {
-      return _pred(l) == Policy::quantify_onset;
+      return _pred(x) == Policy::quantify_onset;
     }
   };
 
@@ -1694,9 +1694,9 @@ namespace adiar::internal
     /// \brief Whether the generator wants to do a Nested Sweep on the given level.
     ////////////////////////////////////////////////////////////////////////////////////////////////
     bool
-    has_sweep(const typename Policy::label_type l)
+    has_sweep(const typename Policy::label_type x)
     {
-      return l == next_level(l) ? Policy::quantify_onset : !Policy::quantify_onset;
+      return x == next_level(x) ? Policy::quantify_onset : !Policy::quantify_onset;
     }
 
   private:

--- a/src/adiar/internal/algorithms/replace.h
+++ b/src/adiar/internal/algorithms/replace.h
@@ -213,7 +213,7 @@ namespace adiar::internal
 #endif
       return dd;
     }
-    adiar_unreachable();
+    adiar_unreachable(); // LCOV_EXCL_LINE
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Optimisation from #502 : Integrates the *relabelling* directly within the `bdd_exists` nested sweep.