### PR TITLE
Set `tpie::tempname` before calling `tpie_init()`

### DIFF
--- a/src/adiar/adiar.cpp
+++ b/src/adiar/adiar.cpp
@@ -70,6 +70,17 @@ namespace adiar
     }
 
     try {
+      // Set the temporary directory for TPIE before calling
+      // `tpie::tpie_init()`. This avoids a directory named `TPIE_<date>_<...>`
+      // at the default tmp path.
+
+      // - file names
+      tpie::tempname::set_default_base_name("ADIAR");
+      tpie::tempname::set_default_extension("adiar");
+
+      // - tmp directory
+      if (temp_dir != "") { tpie::tempname::set_default_path(temp_dir); }
+
       // Initialise TPIE
       tpie::tpie_init(_tpie_subsystems);
 
@@ -78,13 +89,6 @@ namespace adiar
       //   everything to 'std::cerr'.
       tpie::add_log_target(&_devnull);
 #endif
-
-      // - file names
-      tpie::tempname::set_default_base_name("ADIAR");
-      tpie::tempname::set_default_extension("adiar");
-
-      // - tmp directory
-      if (temp_dir != "") { tpie::tempname::set_default_path(temp_dir); }
 
       // - memory limit and block size
       tpie::get_memory_manager().set_limit(memory_limit_bytes);


### PR DESCRIPTION
This avoids an additional directory named `TPIE_<date>_<…>` at the default tmp path.

About a year ago, when executing benchmarks in a scripted way, I ran into the problem that the BDDs produced by Adiar filled up the entire disk. Because of that, the benchmarking process crashed and left the files there, so my benchmark runner script was not even able to create new log files for the upcoming benchmarks. That was when I started to use the `-T` option in BDD benchmark to make Adiar write to a location I previously created using Python’s `tempfile.TemporaryDirectory()`, so I could be sure that would be cleaned even upon timeouts and crashes.

However, that fix seemed to be ineffective, Adiar still created directories named `TPIE_<date>_<…>` in my `/tmp` folder. So I added two additional lines to my benchmark running script to remove `/tmp/TPIE_*` after every benchmark item. Recently, I’ve switched to parallel execution of benchmarks, and it just came to my mind that removing all `/tmp/TPIE_*` might also remove the folders of another Adiar process, which could lead to crashes. Fortunately, there were no such crashes, but it made me think I should fix that issue in my script.

Seeking for solutions, I noticed that Adiar sets the temporary directory of TPIE only after initializing TPIE. So the `/tmp/TPIE_*` directories were probably created during the initialization, and afterwards TPIE switched to the other location. I just moved the initialization after setting TPIE’s temporary directory, and it worked as expected.

For sure, you know a lot more than me about TPIE, so please re-check that this change does not introduce any unwanted side-effects.

(EDIT: This is not urgent at all, it seems like the `/tmp/TPIE_*` directories stay below 1 MiB in size each, so I could just drop the removal of these directories from my script.)