### PR TITLE
Fix Continuous Integration

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,12 +63,18 @@ jobs:
           submodules: 'recursive'
           fetch-depth: '0'
 
-      - name: 'apt install'
+      - name: 'apt install boost'
         run: |
           sudo apt update
           sudo apt install libboost-all-dev
 
-      - name: 'pip install'
+      - name: 'apt install cargo (+ cbindgen)'
+        run: |
+          sudo apt update
+          sudo apt install cargo
+          cargo install --force cbindgen
+
+      - name: 'pip install wget'
         run: |
           sudo pip install wget
 
@@ -123,12 +129,18 @@ jobs:
           submodules: 'recursive'
           fetch-depth: '0'
 
-      - name: 'apt install'
+      - name: 'apt install boost'
         run: |
           sudo apt update
           sudo apt install libboost-all-dev
 
-      - name: 'pip install'
+      - name: 'apt install cargo (+ cbindgen)'
+        run: |
+          sudo apt update
+          sudo apt install cargo
+          cargo install --force cbindgen
+
+      - name: 'pip install wget'
         run: |
           sudo pip install wget
 
@@ -178,12 +190,18 @@ jobs:
           submodules: 'recursive'
           fetch-depth: '0'
 
-      - name: 'apt install'
+      - name: 'apt install boost'
         run: |
           sudo apt update
           sudo apt install libboost-all-dev
 
-      - name: 'pip install'
+      - name: 'apt install cargo (+ cbindgen)'
+        run: |
+          sudo apt update
+          sudo apt install cargo
+          cargo install --force cbindgen
+
+      - name: 'pip install wget'
         run: |
           sudo pip install wget
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,7 +61,7 @@ jobs:
       if: always()
       run: |
         lcov -c -d build/ -o ./coverage.info
-        lcov --remove coverage.info --output-file coverage.info "/usr/*" "*/external/*" "./test/*"
+        lcov --remove coverage.info --output-file coverage.info --ignore-errors unused "/usr/*" "*/external/*" "./test/*"
 
     - name: Upload report to Codecov.io
       working-directory: ${{runner.workspace}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,15 +36,16 @@ jobs:
         os: [ubuntu-latest]
         cc:
           # GNU Compiler
-          - { cc: gcc,   v: 10, cxx: g++ } # oldest possible
-          - { cc: gcc,   v: 11, cxx: g++ } # default
-          - { cc: gcc,   v: 12, cxx: g++ } # newest
+          - { cc: gcc,   v: 12, cxx: g++ }
+          - { cc: gcc,   v: 13, cxx: g++ }
+          - { cc: gcc,   v: 14, cxx: g++ }
 
           # Clang Compiler
           # - { cc: clang, v: 11, cxx: clang++ } # oldest possible
-          - { cc: clang, v: 12, cxx: clang++ } # oldest supported
-          - { cc: clang, v: 14, cxx: clang++ } # default
-          - { cc: clang, v: 15, cxx: clang++ } # newst possible
+          - { cc: clang, v: 14, cxx: clang++ }
+          - { cc: clang, v: 15, cxx: clang++ }
+          - { cc: clang, v: 16, cxx: clang++ }
+          - { cc: clang, v: 17, cxx: clang++ }
 
     env:
       cc: ${{matrix.cc.cc}}-${{matrix.cc.v}}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -41,8 +41,9 @@ jobs:
         # - { cc: gcc,   v: 13, cxx: g++, xcode: latest }
 
           # Clang Compiler
-          - { cc: clang, cxx: clang++, xcode: 14.3 } # oldest supported
           - { cc: clang, cxx: clang++, xcode: 15.0 }
+          - { cc: clang, cxx: clang++, xcode: 15.4 }
+          - { cc: clang, cxx: clang++, xcode: 16.1 }
           - { cc: clang, cxx: clang++, xcode: latest }
 
     steps:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -61,7 +61,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: RafikFarhad/clang-format-github-action@v4
+      - name: 'src/*'
+        uses: RafikFarhad/clang-format-github-action@v4
         with:
           style: "file"
-          sources: "src/**/*.h,src/**/*.cpp,test/**/*.h,test/**/*.cpp"
+          sources: "src/*.h,src/*.cpp,src/*/*.h,src/*/*.cpp,src/*/*/*.h,src/*/*/*.cpp"
+
+      - name: 'test/*'
+        uses: RafikFarhad/clang-format-github-action@v4
+        with:
+          style: "file"
+          sources: "test/*.h,test/*.cpp,test/*/*.h,test/*/*.cpp,test/*/*/*.h,test/*/*/*.cpp"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -54,21 +54,3 @@ jobs:
         with:
           message-path: ./cppcheck_report.txt
           message-id: 'cppcheck'
-
-  clang-format-checking:
-    name: 'Clang Format'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: 'src/*'
-        uses: RafikFarhad/clang-format-github-action@v4
-        with:
-          style: "file"
-          sources: "src/*.h,src/*.cpp,src/*/*.h,src/*/*.cpp,src/*/*/*.h,src/*/*/*.cpp"
-
-      - name: 'test/*'
-        uses: RafikFarhad/clang-format-github-action@v4
-        with:
-          style: "file"
-          sources: "test/*.h,test/*.cpp,test/*/*.h,test/*/*.cpp,test/*/*/*.h,test/*/*/*.cpp"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -83,6 +83,12 @@ jobs:
         sudo apt update
         sudo apt install libboost-all-dev
 
+    - name: Apt | install cargo + cbindgen
+      run: |
+        sudo apt update
+        sudo apt install cargo
+        cargo install --force cbindgen
+
     - name: CMake | build
       run: |
         cmake -E make_directory build
@@ -136,6 +142,12 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libboost-all-dev
+
+    - name: Apt | install cargo + cbindgen
+      run: |
+        sudo apt update
+        sudo apt install cargo
+        cargo install --force cbindgen
 
     - name: CMake | build
       run: |


### PR DESCRIPTION
Continuous Integration is broken due to it not being up to date.

- [x] Fix the matrix for `linux.yml` to not request GCC and Clang versions that are too old.
- [x] Fix the matrix for `mac.yml` to not request Clang versions that are too old.
- [x] Fix Coverage breaks...
- [x] Fix System Tests do not install *cargo* and *cbindgen*
- [x] Fix Regression Tests do not install *cargo* and *cbindgen*
- [x] "Fix" `clang-format` checking...